### PR TITLE
feat: Connect Jobs API to Temporal workflow pipeline

### DIFF
--- a/backend/app/api/routes/jobs.py
+++ b/backend/app/api/routes/jobs.py
@@ -2,6 +2,8 @@
 backend/app/api/routes/jobs.py
 Job CRUD API 엔드포인트
 """
+import logging
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,6 +13,7 @@ from app.models.database import UserDB
 from app.models.input import CreateJobRequest, CreateJobResponse
 from app.services import job_service
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/jobs", tags=["jobs"])
 
 
@@ -38,7 +41,6 @@ async def create_job(
         db=db,
     )
 
-    # TODO: Step 7에서 Temporal workflow 시작 연동
     return CreateJobResponse(
         job_id=str(job.id),
         status=job.status,
@@ -65,11 +67,28 @@ async def get_job(
     user: UserDB = Depends(get_current_user_or_api_key),
     db: AsyncSession = Depends(get_db),
 ):
-    """Job 상세 조회"""
+    """Job 상세 조회 (Temporal에서 실시간 진행률 포함)"""
     job = await job_service.get_job(job_id, user.id, db)
     result = _job_to_dict(job)
     if job.final_output:
         result["output"] = job.final_output
+
+    # Temporal에서 실시간 진행률 조회
+    if job.temporal_workflow_id and job.status not in ("completed", "failed"):
+        try:
+            from app.core.temporal import get_temporal_client
+            client = await get_temporal_client()
+            handle = client.get_workflow_handle(job.temporal_workflow_id)
+            progress = await handle.query("get_progress")
+            result["progress"] = progress
+
+            # Temporal 상태가 DB와 다르면 DB 동기화
+            if progress.get("status") and progress["status"] != job.status:
+                job.status = progress["status"]
+                result["status"] = progress["status"]
+        except Exception as e:
+            logger.debug(f"Could not query workflow progress: {e}")
+
     return result
 
 

--- a/backend/app/services/job_service.py
+++ b/backend/app/services/job_service.py
@@ -34,13 +34,15 @@ async def create_job(
     try:
         from app.core.temporal import get_temporal_client
         from app.workflows.interview_workflow import InterviewGenerationWorkflow
+        from app.core.config import settings
         client = await get_temporal_client()
         workflow_id = f"interview-{job.id}"
+        workflow_input = {**input_data, "job_id": str(job.id)}
         await client.start_workflow(
             InterviewGenerationWorkflow.run,
-            input_data,
+            workflow_input,
             id=workflow_id,
-            task_queue="interview-generation",
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
         )
         job.temporal_workflow_id = workflow_id
     except Exception:

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -23,6 +23,7 @@ from app.workflows.activities.jd_analysis import analyze_jd
 from app.workflows.activities.question_generation import select_topics, craft_question
 from app.workflows.activities.quality_review import review_questions
 from app.workflows.activities.finalization import finalize_output
+from app.workflows.activities.persist_result import persist_result
 
 ACTIVITIES = [
     enrich_input,
@@ -34,6 +35,7 @@ ACTIVITIES = [
     craft_question,
     review_questions,
     finalize_output,
+    persist_result,
 ]
 
 

--- a/backend/app/workflows/activities/persist_result.py
+++ b/backend/app/workflows/activities/persist_result.py
@@ -1,0 +1,39 @@
+"""
+backend/app/workflows/activities/persist_result.py
+워크플로우 결과를 DB에 저장하는 Activity
+"""
+import logging
+from datetime import datetime, timezone
+
+from temporalio import activity
+
+logger = logging.getLogger(__name__)
+
+
+@activity.defn
+async def persist_result(job_id: str, final_script: dict) -> dict:
+    """워크플로우 완료 결과를 DB에 저장"""
+    from app.core.database import async_session
+    from app.models.database import JobDB
+    from sqlalchemy import select
+    import uuid
+
+    async with async_session() as session:
+        result = await session.execute(
+            select(JobDB).where(JobDB.id == uuid.UUID(job_id))
+        )
+        job = result.scalar_one_or_none()
+        if job is None:
+            logger.error(f"Job {job_id} not found for result persistence")
+            return {"persisted": False}
+
+        is_error = "error" in final_script and len(final_script) == 1
+        job.status = "failed" if is_error else "completed"
+        job.final_output = final_script
+        job.updated_at = datetime.now(timezone.utc)
+        if not is_error:
+            job.completed_at = datetime.now(timezone.utc)
+        await session.commit()
+
+    logger.info(f"Job {job_id} result persisted to DB")
+    return {"persisted": True}

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -18,6 +18,7 @@ with workflow.unsafe.imports_passed_through():
     from app.workflows.activities.question_generation import select_topics, craft_question
     from app.workflows.activities.quality_review import review_questions
     from app.workflows.activities.finalization import finalize_output
+    from app.workflows.activities.persist_result import persist_result
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +151,16 @@ class InterviewGenerationWorkflow:
                 heartbeat_timeout=timedelta(seconds=60),
             )
 
+            # DB에 결과 저장
+            job_id = input_data.get("job_id")
+            if job_id:
+                self._update_status(JobStatus.REVIEWING, "Persisting result", 95)
+                await workflow.execute_activity(
+                    persist_result,
+                    args=[job_id, final_script],
+                    start_to_close_timeout=timedelta(minutes=1),
+                )
+
             self._update_status(JobStatus.COMPLETED, "completed", 100)
             return {"status": "completed", "script": final_script}
 
@@ -157,6 +168,18 @@ class InterviewGenerationWorkflow:
             self._status = JobStatus.FAILED.value
             self._current_phase = "failed"
             logger.error(f"Workflow failed: {e}")
+
+            # DB에 실패 상태 저장
+            job_id = input_data.get("job_id")
+            if job_id:
+                try:
+                    await workflow.execute_activity(
+                        persist_result,
+                        args=[job_id, {"error": str(e)}],
+                        start_to_close_timeout=timedelta(minutes=1),
+                    )
+                except Exception:
+                    logger.error("Failed to persist error status to DB")
             raise
 
     @workflow.query

--- a/backend/tests/test_workflow.py
+++ b/backend/tests/test_workflow.py
@@ -18,11 +18,12 @@ class TestActivityRegistration:
             "craft_question",
             "review_questions",
             "finalize_output",
+            "persist_result",
         ]
         assert names == expected
 
     def test_activity_count(self):
-        assert len(ACTIVITIES) == 9
+        assert len(ACTIVITIES) == 10
 
 
 class TestWorkflow:


### PR DESCRIPTION
## Summary
- `POST /jobs` → Temporal `start_workflow` 연결 완료 (job_id를 workflow input에 포함)
- `GET /jobs/{id}` → Temporal workflow query로 실시간 진행률 조회 추가
- 신규 `persist_result` Activity: 워크플로우 완료/실패 시 DB에 결과 저장
- Worker에 10번째 Activity 등록

## Test plan
- [x] Docker rebuild 후 health check 통과 (DB/Redis/Temporal ok)
- [x] JWT 인증 → Job 생성 → `temporal_workflow_id` DB 저장 확인
- [x] Job CRUD 전체 (생성/조회/목록/삭제) E2E 검증
- [x] 미완료 Job result 조회 시 422 에러 정상 반환
- [x] 미인증 접근 시 401 정상 반환
- [x] Unit 테스트 14개 전부 통과
- [x] Frontend 빌드 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)