### PR TITLE
refactor: Externalize LLM prompts into YAML templates

### DIFF
--- a/backend/app/prompts/__init__.py
+++ b/backend/app/prompts/__init__.py
@@ -1,0 +1,30 @@
+"""
+backend/app/prompts/__init__.py
+YAML 프롬프트 템플릿 로더
+"""
+import os
+from functools import lru_cache
+
+import yaml
+
+PROMPTS_DIR = os.path.dirname(__file__)
+
+
+@lru_cache(maxsize=32)
+def _load_yaml(filename: str) -> dict:
+    path = os.path.join(PROMPTS_DIR, filename)
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def get_prompt(filename: str, key: str, **kwargs) -> str:
+    """YAML에서 프롬프트 템플릿을 로드하고 변수를 치환합니다.
+
+    Args:
+        filename: YAML 파일명 (예: "jd_analysis.yaml")
+        key: 프롬프트 키 (예: "analyze")
+        **kwargs: 템플릿 변수
+    """
+    data = _load_yaml(filename)
+    template = data["prompts"][key]["template"]
+    return template.format(**kwargs)

--- a/backend/app/prompts/document_analysis.yaml
+++ b/backend/app/prompts/document_analysis.yaml
@@ -1,0 +1,7 @@
+prompts:
+  extract_profile:
+    description: "이력서/포트폴리오에서 후보자 프로필 추출"
+    template: |
+      Extract a structured candidate profile from the following documents. Include: name, contact, education, work experience, skills, projects, certifications.
+
+      {documents}

--- a/backend/app/prompts/finalization.yaml
+++ b/backend/app/prompts/finalization.yaml
@@ -1,0 +1,14 @@
+prompts:
+  candidate_summary:
+    description: "후보자 요약 생성"
+    template: |
+      Generate a brief candidate summary based on:
+      Document analysis: {document_analysis}
+      Code analysis: {code_analysis}
+
+  interviewer_guide:
+    description: "면접관 가이드 생성"
+    template: |
+      Generate interviewer guide for {experience_level} level candidate.
+      Total questions: {total_questions}
+      Categories: {categories}

--- a/backend/app/prompts/jd_analysis.yaml
+++ b/backend/app/prompts/jd_analysis.yaml
@@ -1,0 +1,14 @@
+prompts:
+  analyze:
+    description: "Job Description 분석 및 구조화 추출"
+    template: |
+      Analyze the following job description and extract:
+      1. job_title
+      2. company_name
+      3. requirements (list of {{skill, category: '필수'|'우대', level}})
+      4. responsibilities (list of strings)
+      5. company_culture (list of strings)
+      6. tech_stack (list of technology names)
+
+      Job Description:
+      {jd_text}

--- a/backend/app/prompts/quality_review.yaml
+++ b/backend/app/prompts/quality_review.yaml
@@ -1,0 +1,10 @@
+prompts:
+  review:
+    description: "생성된 면접 질문 품질 검토"
+    template: |
+      Review these interview questions for quality:
+      1. Identify any duplicate or very similar questions (list indices)
+      2. Rate overall quality 1-10
+      3. Suggest any improvements
+
+      {questions}

--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -1,0 +1,31 @@
+prompts:
+  select_topics:
+    description: "면접 질문 토픽 25개 선정 (5카테고리 × 5개)"
+    template: |
+      Select {max_questions} interview question topics for a {experience_level} level candidate.
+      Distribute across 5 categories (5 each): role_fit, technical_depth, execution_ownership, communication, risk_flags.
+      For each topic, assign difficulty (Easy/Medium/Medium/Hard) with distribution: 2 Easy, 2 Medium, 1 Hard per category.
+
+      Available candidates:
+      {candidates}
+
+      Return a JSON list of objects with: category, topic, difficulty, source, evidence_summary.
+
+  craft_question:
+    description: "개별 면접 질문 생성 (후속질문, 평가 시나리오 포함)"
+    template: |
+      Generate a detailed interview question in {output_language} for a {experience_level} level candidate.
+
+      Topic: {topic}
+      Category: {category}
+      Difficulty: {difficulty}
+
+      Include:
+      1. question_text: Main question
+      2. alternative_phrasings: 2 alternative ways to ask
+      3. expected_answer: {{expert, mid_level, low_level}} responses
+      4. evaluation_scenarios: 3 levels with trigger keywords
+      5. follow_up_questions: 2-3 follow-ups
+      6. terminology: technical terms with plain_language_explanation
+      7. interviewer_note: guidance for the interviewer
+      8. time_allocation_minutes: suggested time

--- a/backend/app/workflows/activities/document_analysis.py
+++ b/backend/app/workflows/activities/document_analysis.py
@@ -39,11 +39,8 @@ async def analyze_documents(input_data: dict) -> dict:
 
     # LLM으로 프로필 추출
     activity.heartbeat("Extracting candidate profile with LLM...")
-    prompt = (
-        "Extract a structured candidate profile from the following documents. "
-        "Include: name, contact, education, work experience, skills, projects, certifications.\n\n"
-        + "\n---\n".join(documents)
-    )
+    from app.prompts import get_prompt
+    prompt = get_prompt("document_analysis.yaml", "extract_profile", documents="\n---\n".join(documents))
     profile = await llm.run(prompt)
 
     return {

--- a/backend/app/workflows/activities/finalization.py
+++ b/backend/app/workflows/activities/finalization.py
@@ -46,19 +46,21 @@ async def finalize_output(
                 seen_terms.add(term_name)
 
     # 2. 후보자 요약
-    summary_prompt = (
-        "Generate a brief candidate summary based on:\n"
-        f"Document analysis: {json.dumps(analysis.get('document_analysis', {}), default=str)[:2000]}\n"
-        f"Code analysis: {json.dumps(analysis.get('code_analysis', {}), default=str)[:2000]}\n"
+    from app.prompts import get_prompt
+    summary_prompt = get_prompt(
+        "finalization.yaml", "candidate_summary",
+        document_analysis=json.dumps(analysis.get("document_analysis", {}), default=str)[:2000],
+        code_analysis=json.dumps(analysis.get("code_analysis", {}), default=str)[:2000],
     )
     candidate_summary = await llm.run(summary_prompt)
 
     # 3. 면접관 가이드
     activity.heartbeat("Generating interviewer guide...")
-    guide_prompt = (
-        f"Generate interviewer guide for {raw_input.get('experience_level', '미들')} level candidate.\n"
-        f"Total questions: {len(questions)}\n"
-        f"Categories: {list(set(q.get('category', '') for q in questions))}\n"
+    guide_prompt = get_prompt(
+        "finalization.yaml", "interviewer_guide",
+        experience_level=raw_input.get("experience_level", "미들"),
+        total_questions=len(questions),
+        categories=list(set(q.get("category", "") for q in questions)),
     )
     interviewer_guide = await llm.run(guide_prompt)
 

--- a/backend/app/workflows/activities/jd_analysis.py
+++ b/backend/app/workflows/activities/jd_analysis.py
@@ -22,16 +22,8 @@ async def analyze_jd(jd_text: str) -> dict:
 
     llm = CachedLLMService()
 
-    prompt = (
-        "Analyze the following job description and extract:\n"
-        "1. job_title\n"
-        "2. company_name\n"
-        "3. requirements (list of {skill, category: '필수'|'우대', level})\n"
-        "4. responsibilities (list of strings)\n"
-        "5. company_culture (list of strings)\n"
-        "6. tech_stack (list of technology names)\n\n"
-        f"Job Description:\n{jd_text}"
-    )
+    from app.prompts import get_prompt
+    prompt = get_prompt("jd_analysis.yaml", "analyze", jd_text=jd_text)
 
     result = await llm.run(prompt)
 

--- a/backend/app/workflows/activities/quality_review.py
+++ b/backend/app/workflows/activities/quality_review.py
@@ -61,13 +61,9 @@ async def review_questions(questions: list[dict]) -> dict:
     # 3. LLM 기반 중복/품질 검토
     if len(questions) > 0:
         question_texts = [q.get("question_text", "") for q in questions[:25]]
-        prompt = (
-            "Review these interview questions for quality:\n"
-            "1. Identify any duplicate or very similar questions (list indices)\n"
-            "2. Rate overall quality 1-10\n"
-            "3. Suggest any improvements\n\n"
-            + "\n".join(f"{i+1}. {t}" for i, t in enumerate(question_texts))
-        )
+        from app.prompts import get_prompt
+        formatted_questions = "\n".join(f"{i+1}. {t}" for i, t in enumerate(question_texts))
+        prompt = get_prompt("quality_review.yaml", "review", questions=formatted_questions)
         review_result = await llm.run(prompt)
         if isinstance(review_result, dict):
             if review_result.get("duplicates"):

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -53,12 +53,12 @@ async def select_topics(analysis: dict, enriched_input: dict) -> list[dict]:
 
     activity.heartbeat(f"Selecting {max_questions} topics from {len(candidates)} candidates...")
 
-    prompt = (
-        f"Select {max_questions} interview question topics for a {experience_level} level candidate.\n"
-        f"Distribute across 5 categories (5 each): role_fit, technical_depth, execution_ownership, communication, risk_flags.\n"
-        f"For each topic, assign difficulty (Easy/Medium/Hard) with distribution: 2 Easy, 2 Medium, 1 Hard per category.\n\n"
-        f"Available candidates:\n{_format_candidates(candidates)}\n\n"
-        f"Return a JSON list of objects with: category, topic, difficulty, source, evidence_summary."
+    from app.prompts import get_prompt
+    prompt = get_prompt(
+        "question_generation.yaml", "select_topics",
+        max_questions=max_questions,
+        experience_level=experience_level,
+        candidates=_format_candidates(candidates),
     )
 
     result = await llm.run(prompt)
@@ -112,20 +112,14 @@ async def craft_question(
     output_language = language_config.get("output_language", "ko")
     experience_level = raw_input.get("experience_level", "미들")
 
-    prompt = (
-        f"Generate a detailed interview question in {output_language} for a {experience_level} level candidate.\n\n"
-        f"Topic: {topic.get('topic')}\n"
-        f"Category: {topic.get('category')}\n"
-        f"Difficulty: {topic.get('difficulty')}\n\n"
-        f"Include:\n"
-        f"1. question_text: Main question\n"
-        f"2. alternative_phrasings: 2 alternative ways to ask\n"
-        f"3. expected_answer: {{expert, mid_level, low_level}} responses\n"
-        f"4. evaluation_scenarios: 3 levels with trigger keywords\n"
-        f"5. follow_up_questions: 2-3 follow-ups\n"
-        f"6. terminology: technical terms with plain_language_explanation\n"
-        f"7. interviewer_note: guidance for the interviewer\n"
-        f"8. time_allocation_minutes: suggested time\n"
+    from app.prompts import get_prompt
+    prompt = get_prompt(
+        "question_generation.yaml", "craft_question",
+        output_language=output_language,
+        experience_level=experience_level,
+        topic=topic.get("topic"),
+        category=topic.get("category"),
+        difficulty=topic.get("difficulty"),
     )
 
     result = await llm.run(prompt)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 python-multipart>=0.0.9
+PyYAML>=6.0
 
 # Database
 sqlalchemy[asyncio]>=2.0.30


### PR DESCRIPTION
## Summary
- 5개 Activity 파일에 하드코딩된 7개 LLM 프롬프트를 YAML 템플릿으로 외부화
- `backend/app/prompts/` 디렉토리에 프롬프트 로더 + 5개 YAML 파일 생성
- Activity 코드에서 `get_prompt(file, key, **vars)` 호출로 교체
- PyYAML 의존성 추가

## Test plan
- [x] Docker rebuild 후 health check 통과
- [x] 프롬프트 로더 직접 테스트 (jd_analysis, select_topics, candidate_summary)
- [x] Unit 테스트 14개 전부 통과
- [x] 변수 치환 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)