### PR TITLE
test: Expand test coverage from 14 to 46 tests

### DIFF
--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,64 @@
+"""Unit tests for auth service (JWT, API Key, Fernet)."""
+import pytest
+from app.services.auth_service import (
+    create_jwt, verify_jwt,
+    create_api_key, verify_api_key, hash_api_key,
+    encrypt_token, decrypt_token,
+    API_KEY_PREFIX,
+)
+
+
+class TestJWT:
+    def test_create_and_verify(self):
+        payload = {"sub": "user-123", "email": "test@test.com"}
+        token = create_jwt(payload)
+        assert isinstance(token, str)
+        decoded = verify_jwt(token)
+        assert decoded is not None
+        assert decoded["sub"] == "user-123"
+        assert decoded["email"] == "test@test.com"
+        assert "exp" in decoded
+        assert "iat" in decoded
+
+    def test_invalid_token(self):
+        result = verify_jwt("invalid.token.string")
+        assert result is None
+
+    def test_empty_token(self):
+        result = verify_jwt("")
+        assert result is None
+
+
+class TestAPIKey:
+    def test_create_api_key_format(self):
+        raw, hashed = create_api_key()
+        assert raw.startswith(API_KEY_PREFIX)
+        assert len(hashed) == 64  # SHA-256 hex digest
+
+    def test_verify_api_key(self):
+        raw, hashed = create_api_key()
+        assert verify_api_key(raw, hashed) is True
+        assert verify_api_key("wrong_key", hashed) is False
+
+    def test_hash_api_key_consistent(self):
+        raw, hashed = create_api_key()
+        assert hash_api_key(raw) == hashed
+
+    def test_unique_keys(self):
+        key1, _ = create_api_key()
+        key2, _ = create_api_key()
+        assert key1 != key2
+
+
+class TestFernet:
+    def test_encrypt_produces_output(self):
+        encrypted = encrypt_token("test-token")
+        assert isinstance(encrypted, str)
+        assert len(encrypted) > 0
+        assert encrypted != "test-token"
+
+    def test_get_fernet_returns_instance(self):
+        from app.services.auth_service import get_fernet
+        from cryptography.fernet import Fernet
+        f = get_fernet()
+        assert isinstance(f, Fernet)

--- a/backend/tests/test_exceptions.py
+++ b/backend/tests/test_exceptions.py
@@ -1,0 +1,65 @@
+"""Unit tests for custom exception hierarchy."""
+import pytest
+from app.exceptions import (
+    VantictBaseError, JobNotFoundError, JobAlreadyExistsError,
+    AuthenticationError, AuthorizationError, ValidationError,
+    RateLimitError, TemporalError, DocumentParseError, LinkedInFetchError,
+)
+
+
+class TestExceptionHierarchy:
+    def test_job_not_found(self):
+        err = JobNotFoundError("abc-123")
+        assert err.status_code == 404
+        assert err.code == "JOB_NOT_FOUND"
+        assert "abc-123" in err.message
+
+    def test_job_already_exists(self):
+        err = JobAlreadyExistsError("abc-123")
+        assert err.status_code == 409
+
+    def test_authentication_error(self):
+        err = AuthenticationError()
+        assert err.status_code == 401
+        assert err.code == "UNAUTHORIZED"
+
+    def test_authorization_error(self):
+        err = AuthorizationError()
+        assert err.status_code == 403
+        assert err.code == "FORBIDDEN"
+
+    def test_validation_error(self):
+        err = ValidationError("bad input")
+        assert err.status_code == 422
+        assert "bad input" in err.message
+
+    def test_rate_limit_error(self):
+        err = RateLimitError()
+        assert err.status_code == 429
+
+    def test_temporal_error(self):
+        err = TemporalError("workflow crashed")
+        assert err.status_code == 500
+        assert "workflow crashed" in err.message
+
+    def test_document_parse_error(self):
+        err = DocumentParseError("corrupt PDF", source="resume.pdf")
+        assert err.status_code == 422
+        assert err.source == "resume.pdf"
+
+    def test_linkedin_fetch_error(self):
+        err = LinkedInFetchError()
+        assert err.status_code == 502
+
+    def test_all_inherit_from_base(self):
+        errors = [
+            JobNotFoundError("x"), AuthenticationError(),
+            AuthorizationError(), ValidationError("x"),
+            RateLimitError(), TemporalError(), LinkedInFetchError(),
+        ]
+        for err in errors:
+            assert isinstance(err, VantictBaseError)
+
+    def test_detail_structure(self):
+        err = JobNotFoundError("test-id")
+        assert err.detail == {"code": "JOB_NOT_FOUND", "message": "Job not found: test-id"}

--- a/backend/tests/test_prompts.py
+++ b/backend/tests/test_prompts.py
@@ -1,0 +1,89 @@
+"""Unit tests for prompt template loader."""
+import pytest
+from app.prompts import get_prompt, _load_yaml
+
+
+class TestPromptLoader:
+    def test_load_jd_analysis(self):
+        prompt = get_prompt("jd_analysis.yaml", "analyze", jd_text="Test JD text")
+        assert "job_title" in prompt
+        assert "Test JD text" in prompt
+
+    def test_load_document_analysis(self):
+        prompt = get_prompt("document_analysis.yaml", "extract_profile", documents="Resume content here")
+        assert "Resume content here" in prompt
+        assert "candidate profile" in prompt
+
+    def test_load_select_topics(self):
+        prompt = get_prompt(
+            "question_generation.yaml", "select_topics",
+            max_questions=25, experience_level="시니어", candidates="1. React",
+        )
+        assert "25" in prompt
+        assert "시니어" in prompt
+
+    def test_load_craft_question(self):
+        prompt = get_prompt(
+            "question_generation.yaml", "craft_question",
+            output_language="ko", experience_level="주니어",
+            topic="React hooks", category="technical_depth", difficulty="Medium",
+        )
+        assert "React hooks" in prompt
+        assert "ko" in prompt
+
+    def test_load_quality_review(self):
+        prompt = get_prompt("quality_review.yaml", "review", questions="1. What is X?")
+        assert "quality" in prompt
+        assert "What is X?" in prompt
+
+    def test_load_candidate_summary(self):
+        prompt = get_prompt(
+            "finalization.yaml", "candidate_summary",
+            document_analysis="{}", code_analysis="{}",
+        )
+        assert "candidate summary" in prompt
+
+    def test_load_interviewer_guide(self):
+        prompt = get_prompt(
+            "finalization.yaml", "interviewer_guide",
+            experience_level="시니어", total_questions=25,
+            categories=["role_fit", "technical_depth"],
+        )
+        assert "시니어" in prompt
+        assert "25" in prompt
+
+    def test_missing_key_raises(self):
+        with pytest.raises(KeyError):
+            get_prompt("jd_analysis.yaml", "nonexistent_key", jd_text="test")
+
+    def test_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            get_prompt("nonexistent.yaml", "key")
+
+    def test_missing_variable_raises(self):
+        with pytest.raises(KeyError):
+            get_prompt("jd_analysis.yaml", "analyze")  # missing jd_text
+
+
+class TestYamlStructure:
+    """Verify all YAML files have correct structure."""
+
+    YAML_FILES = [
+        "jd_analysis.yaml",
+        "document_analysis.yaml",
+        "question_generation.yaml",
+        "quality_review.yaml",
+        "finalization.yaml",
+    ]
+
+    def test_all_yamls_loadable(self):
+        for f in self.YAML_FILES:
+            data = _load_yaml(f)
+            assert "prompts" in data, f"{f} missing 'prompts' key"
+
+    def test_all_prompts_have_template(self):
+        for f in self.YAML_FILES:
+            data = _load_yaml(f)
+            for key, value in data["prompts"].items():
+                assert "template" in value, f"{f}:{key} missing 'template'"
+                assert len(value["template"]) > 10, f"{f}:{key} template too short"


### PR DESCRIPTION
## Summary
- 테스트 14개 → 46개 (3.3배 증가)
- Auth 서비스: JWT 생성/검증, API Key CRUD, Fernet 암호화 (9개)
- 프롬프트 로더: 7개 프롬프트 로딩, 변수 치환, 에러 케이스, YAML 구조 검증 (12개)
- 예외 계층: 9개 커스텀 예외 타입, 상속, HTTP 상태코드, detail 구조 (11개)

## Test plan
- [x] Docker 환경에서 46개 테스트 전부 통과
- [x] 기존 14개 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)