### PR TITLE
feat: Alembic database migration infrastructure

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,42 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+
+# sqlalchemy.url is set dynamically in env.py from app settings
+# sqlalchemy.url = driver://user:pass@localhost/dbname
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,77 @@
+"""
+Alembic async migration environment for Vantict Sniper.
+Uses the same DATABASE_URL from app settings.
+"""
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from app.models.database import Base
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def get_url() -> str:
+    """Get database URL from app settings, converting async to sync driver for Alembic."""
+    from app.core.config import settings
+    url = settings.DATABASE_URL
+    # Alembic offline mode needs sync driver
+    return url.replace("postgresql+asyncpg", "postgresql+psycopg2")
+
+
+def get_async_url() -> str:
+    """Get async database URL for online migrations."""
+    from app.core.config import settings
+    return settings.DATABASE_URL
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode (generates SQL without DB connection)."""
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """Run migrations in 'online' mode using async engine."""
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = get_async_url()
+    connectable = async_engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/001_initial_schema.py
+++ b/backend/alembic/versions/001_initial_schema.py
@@ -1,0 +1,103 @@
+"""Initial schema baseline - matches existing init-db.sql tables.
+
+Revision ID: 001_initial
+Revises:
+Create Date: 2026-02-02
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "001_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Users
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("email", sa.String(255), unique=True, nullable=False),
+        sa.Column("name", sa.String(255)),
+        sa.Column("image", sa.String(2048)),
+        sa.Column("plan", sa.String(50), nullable=False, server_default="free"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    # OAuth Accounts
+    op.create_table(
+        "oauth_accounts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("provider", sa.String(50), nullable=False),
+        sa.Column("provider_account_id", sa.String(255), nullable=False),
+        sa.Column("access_token", sa.Text()),
+        sa.Column("refresh_token", sa.Text()),
+        sa.Column("expires_at", sa.BigInteger()),
+        sa.Column("token_type", sa.String(50)),
+        sa.Column("scope", sa.Text()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("idx_oauth_provider", "oauth_accounts", ["provider", "provider_account_id"])
+    op.create_index("idx_oauth_user", "oauth_accounts", ["user_id"])
+
+    # API Keys
+    op.create_table(
+        "api_keys",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("key_hash", sa.String(255), unique=True, nullable=False),
+        sa.Column("key_prefix", sa.String(10), nullable=False),
+        sa.Column("name", sa.String(255)),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("last_used_at", sa.DateTime(timezone=True)),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("idx_api_keys_user", "api_keys", ["user_id"])
+    op.create_index("idx_api_keys_hash", "api_keys", ["key_hash"])
+
+    # Jobs
+    op.create_table(
+        "jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("temporal_workflow_id", sa.String(255), unique=True),
+        sa.Column("status", sa.String(50), nullable=False, server_default="pending"),
+        sa.Column("input_data", postgresql.JSONB(), nullable=False),
+        sa.Column("final_output", postgresql.JSONB()),
+        sa.Column("callback_url", sa.String(2048)),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("completed_at", sa.DateTime(timezone=True)),
+    )
+    op.create_index("idx_jobs_user", "jobs", ["user_id"])
+    op.create_index("idx_jobs_status", "jobs", ["status"])
+    op.create_index("idx_jobs_temporal", "jobs", ["temporal_workflow_id"])
+
+    # Checkpoints
+    op.create_table(
+        "checkpoints",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("job_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("phase", sa.String(50), nullable=False),
+        sa.Column("data", postgresql.JSONB(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("job_id", "phase", name="uq_checkpoints_job_phase"),
+    )
+    op.create_index("idx_checkpoints_job", "checkpoints", ["job_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("checkpoints")
+    op.drop_table("jobs")
+    op.drop_table("api_keys")
+    op.drop_table("oauth_accounts")
+    op.drop_table("users")

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from sqlalchemy import (
     Boolean, Column, DateTime, ForeignKey, Index, String, Text, BigInteger,
-    func,
+    UniqueConstraint, func,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, relationship
@@ -94,3 +94,20 @@ class JobDB(Base):
     completed_at = Column(DateTime(timezone=True))
 
     user = relationship("UserDB", back_populates="jobs")
+    checkpoints = relationship("CheckpointDB", back_populates="job", cascade="all, delete-orphan")
+
+
+class CheckpointDB(Base):
+    __tablename__ = "checkpoints"
+    __table_args__ = (
+        Index("idx_checkpoints_job", "job_id"),
+        UniqueConstraint("job_id", "phase", name="uq_checkpoints_job_phase"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    job_id = Column(UUID(as_uuid=True), ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False)
+    phase = Column(String(50), nullable=False)
+    data = Column(JSONB, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    job = relationship("JobDB", back_populates="checkpoints")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ PyYAML>=6.0
 sqlalchemy[asyncio]>=2.0.30
 asyncpg>=0.29.0
 pgvector>=0.3.0
+alembic>=1.13.0
 
 # Cache
 redis>=5.0.0


### PR DESCRIPTION
## Summary
- Set up async Alembic with `asyncpg` driver for PostgreSQL schema versioning
- Created baseline migration (`001_initial`) covering all 5 tables (users, oauth_accounts, api_keys, jobs, checkpoints)
- Added `CheckpointDB` ORM model to map previously unmapped checkpoints table from init-db.sql
- Existing DB stamped at baseline — future migrations use `alembic revision --autogenerate`

## Test plan
- [x] Docker rebuild successful
- [x] `alembic stamp 001_initial` on existing DB
- [x] `alembic current` shows `001_initial (head)`
- [x] Autogenerate diff confirms no real schema mismatch
- [x] 46 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)