### PR TITLE
feat: Webhook callback on workflow completion

### DIFF
--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -24,6 +24,7 @@ from app.workflows.activities.question_generation import select_topics, craft_qu
 from app.workflows.activities.quality_review import review_questions
 from app.workflows.activities.finalization import finalize_output
 from app.workflows.activities.persist_result import persist_result
+from app.workflows.activities.send_webhook import send_webhook
 
 ACTIVITIES = [
     enrich_input,
@@ -36,6 +37,7 @@ ACTIVITIES = [
     review_questions,
     finalize_output,
     persist_result,
+    send_webhook,
 ]
 
 

--- a/backend/app/workflows/activities/send_webhook.py
+++ b/backend/app/workflows/activities/send_webhook.py
@@ -1,0 +1,44 @@
+"""
+backend/app/workflows/activities/send_webhook.py
+Job 완료 시 callback_url로 결과를 POST하는 Activity
+"""
+import logging
+
+from temporalio import activity
+
+logger = logging.getLogger(__name__)
+
+
+@activity.defn
+async def send_webhook(job_id: str, callback_url: str, status: str, final_output: dict | None) -> dict:
+    """callback_url로 job 결과를 POST 전송.
+
+    Args:
+        job_id: Job UUID
+        callback_url: 외부 시스템의 webhook URL
+        status: completed | failed
+        final_output: 워크플로우 최종 결과 (또는 에러)
+
+    Returns:
+        {"sent": bool, "status_code": int | None}
+    """
+    import httpx
+
+    payload = {
+        "job_id": job_id,
+        "status": status,
+        "output": final_output,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                callback_url,
+                json=payload,
+                headers={"Content-Type": "application/json", "User-Agent": "Vantict-Sniper/4.0"},
+            )
+            logger.info(f"Webhook sent for job {job_id}: {response.status_code}")
+            return {"sent": True, "status_code": response.status_code}
+    except Exception as e:
+        logger.warning(f"Webhook failed for job {job_id} → {callback_url}: {e}")
+        return {"sent": False, "status_code": None}

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -19,6 +19,7 @@ with workflow.unsafe.imports_passed_through():
     from app.workflows.activities.quality_review import review_questions
     from app.workflows.activities.finalization import finalize_output
     from app.workflows.activities.persist_result import persist_result
+    from app.workflows.activities.send_webhook import send_webhook
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +162,18 @@ class InterviewGenerationWorkflow:
                     start_to_close_timeout=timedelta(minutes=1),
                 )
 
+            # Webhook callback (fire-and-forget, 실패해도 워크플로우 성공)
+            callback_url = input_data.get("callback_url")
+            if callback_url and job_id:
+                try:
+                    await workflow.execute_activity(
+                        send_webhook,
+                        args=[job_id, callback_url, "completed", final_script],
+                        start_to_close_timeout=timedelta(seconds=30),
+                    )
+                except Exception as we:
+                    logger.warning(f"Webhook delivery failed (non-fatal): {we}")
+
             self._update_status(JobStatus.COMPLETED, "completed", 100)
             return {"status": "completed", "script": final_script}
 
@@ -180,6 +193,18 @@ class InterviewGenerationWorkflow:
                     )
                 except Exception:
                     logger.error("Failed to persist error status to DB")
+
+            # Webhook callback for failure
+            callback_url = input_data.get("callback_url")
+            if callback_url and job_id:
+                try:
+                    await workflow.execute_activity(
+                        send_webhook,
+                        args=[job_id, callback_url, "failed", {"error": str(e)}],
+                        start_to_close_timeout=timedelta(seconds=30),
+                    )
+                except Exception:
+                    logger.warning("Webhook delivery for failure failed (non-fatal)")
             raise
 
     @workflow.query

--- a/backend/tests/test_webhook.py
+++ b/backend/tests/test_webhook.py
@@ -1,0 +1,25 @@
+"""Unit tests for webhook callback activity."""
+import pytest
+
+
+class TestSendWebhookImport:
+    def test_importable(self):
+        from app.workflows.activities.send_webhook import send_webhook
+        assert callable(send_webhook)
+
+    def test_is_activity(self):
+        from app.workflows.activities.send_webhook import send_webhook
+        assert hasattr(send_webhook, "__temporal_activity_definition")
+
+    def test_registered_in_worker(self):
+        from app.worker import ACTIVITIES
+        names = [a.__name__ for a in ACTIVITIES]
+        assert "send_webhook" in names
+
+    def test_workflow_imports_webhook(self):
+        """Verify workflow file imports send_webhook."""
+        import inspect
+        from app.workflows import interview_workflow
+        source = inspect.getsource(interview_workflow)
+        assert "send_webhook" in source
+        assert "callback_url" in source

--- a/backend/tests/test_workflow.py
+++ b/backend/tests/test_workflow.py
@@ -19,11 +19,12 @@ class TestActivityRegistration:
             "review_questions",
             "finalize_output",
             "persist_result",
+            "send_webhook",
         ]
         assert names == expected
 
     def test_activity_count(self):
-        assert len(ACTIVITIES) == 10
+        assert len(ACTIVITIES) == 11
 
 
 class TestWorkflow:


### PR DESCRIPTION
## Summary
- New `send_webhook` activity: POSTs job result to `callback_url` via httpx (30s timeout)
- Integrated in workflow: fires after `persist_result` on both success and failure paths
- Non-blocking: webhook failure is logged but does not fail the workflow
- Worker registers 11 activities (was 10)
- 4 new tests (total: 57)

## Test plan
- [x] Docker rebuild + health check OK
- [x] 57 unit tests passing
- [x] `send_webhook` registered as Temporal activity
- [x] Workflow source confirms callback_url handling on both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)