### PR TITLE
feat: Add Langfuse LLM observability

### DIFF
--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -1,0 +1,45 @@
+"""
+backend/app/core/observability.py
+Langfuse LLM observability — LiteLLM callback 방식
+"""
+import logging
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_initialized = False
+
+
+def setup_langfuse() -> bool:
+    """Langfuse를 LiteLLM success/failure callback으로 등록.
+
+    LANGFUSE_PUBLIC_KEY가 설정되지 않으면 skip.
+    Returns True if enabled.
+    """
+    global _initialized
+    if _initialized:
+        return True
+
+    if not settings.LANGFUSE_PUBLIC_KEY or not settings.LANGFUSE_SECRET_KEY:
+        logger.info("Langfuse disabled (LANGFUSE_PUBLIC_KEY not set)")
+        return False
+
+    try:
+        import litellm
+
+        litellm.success_callback = ["langfuse"]
+        litellm.failure_callback = ["langfuse"]
+
+        # LiteLLM reads these env vars automatically, but set explicitly
+        import os
+        os.environ.setdefault("LANGFUSE_PUBLIC_KEY", settings.LANGFUSE_PUBLIC_KEY)
+        os.environ.setdefault("LANGFUSE_SECRET_KEY", settings.LANGFUSE_SECRET_KEY)
+        os.environ.setdefault("LANGFUSE_HOST", settings.LANGFUSE_HOST)
+
+        _initialized = True
+        logger.info(f"Langfuse enabled → {settings.LANGFUSE_HOST}")
+        return True
+    except Exception as e:
+        logger.warning(f"Langfuse setup failed: {e}")
+        return False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,6 +57,10 @@ async def vantict_error_handler(request: Request, exc: VantictBaseError):
         content={"code": exc.code, "message": exc.message},
     )
 
+# --- Observability ---
+from app.core.observability import setup_langfuse
+setup_langfuse()
+
 # --- Routers ---
 
 app.include_router(health_router)

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,63 @@
+"""Langfuse observability integration tests."""
+import os
+import pytest
+
+
+class TestObservabilityModule:
+    def test_importable(self):
+        from app.core.observability import setup_langfuse
+        assert callable(setup_langfuse)
+
+    def test_disabled_without_keys(self):
+        """Without LANGFUSE keys, setup returns False."""
+        from app.core import observability
+        observability._initialized = False
+        result = observability.setup_langfuse()
+        assert result is False
+
+    def test_enabled_with_keys(self, monkeypatch):
+        """With keys set, setup registers litellm callbacks."""
+        from app.core import observability
+        observability._initialized = False
+
+        # Patch settings
+        monkeypatch.setattr("app.core.observability.settings.LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setattr("app.core.observability.settings.LANGFUSE_SECRET_KEY", "sk-test")
+        monkeypatch.setattr("app.core.observability.settings.LANGFUSE_HOST", "http://localhost:3100")
+
+        result = observability.setup_langfuse()
+        assert result is True
+        assert observability._initialized is True
+
+        import litellm
+        assert "langfuse" in litellm.success_callback
+        assert "langfuse" in litellm.failure_callback
+
+        # Cleanup
+        observability._initialized = False
+        litellm.success_callback = []
+        litellm.failure_callback = []
+
+    def test_idempotent(self, monkeypatch):
+        """Calling setup twice doesn't fail."""
+        from app.core import observability
+        observability._initialized = False
+        monkeypatch.setattr("app.core.observability.settings.LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setattr("app.core.observability.settings.LANGFUSE_SECRET_KEY", "sk-test")
+
+        observability.setup_langfuse()
+        result = observability.setup_langfuse()
+        assert result is True
+
+        # Cleanup
+        observability._initialized = False
+        import litellm
+        litellm.success_callback = []
+        litellm.failure_callback = []
+
+    def test_main_calls_setup(self):
+        """main.py imports and calls setup_langfuse."""
+        import ast
+        with open("app/main.py") as f:
+            source = f.read()
+        assert "setup_langfuse" in source


### PR DESCRIPTION
## Summary
- Register Langfuse as LiteLLM success/failure callback at app startup
- Disabled by default — enabled when `LANGFUSE_PUBLIC_KEY` env var is set
- All LLM calls via LiteLLM automatically traced (no per-call instrumentation needed)
- 5 new tests validating setup, idempotency, and integration

## Test plan
- [x] 81 tests passing (76 existing + 5 new)
- [x] Docker build succeeds
- [ ] Set LANGFUSE keys in docker-compose → verify traces in Langfuse UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)