### PR TITLE
feat: Add 6 multi-agent enhancement activities (3c-3h)

### DIFF
--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -29,3 +29,109 @@ prompts:
       6. terminology: technical terms with plain_language_explanation
       7. interviewer_note: guidance for the interviewer
       8. time_allocation_minutes: suggested time
+
+  enhance_terminology:
+    description: "질문 내 전문용어에 비개발자용 설명 추가"
+    template: |
+      Review the following interview questions and enhance all technical terminology
+      with plain-language explanations suitable for non-technical interviewers.
+
+      Language: {output_language}
+      Questions:
+      {questions_json}
+
+      For each question, return a list of terminology entries:
+      - term: the technical term
+      - plain_language_explanation: everyday analogy or simple description
+      - business_relevance: why this matters for the business
+
+      Return JSON: {{"question_id": [...terminology entries]}}
+
+  craft_evaluation_scenarios:
+    description: "3단계 평가 시나리오 텍스트 생성"
+    template: |
+      For each interview question below, create detailed evaluation scenarios
+      at three levels: Expert, Mid-level, Low-level.
+
+      Language: {output_language}
+      Experience Level: {experience_level}
+      Questions:
+      {questions_json}
+
+      For each question return:
+      - expert: {{description, trigger_keywords, behavioral_indicators}}
+      - mid_level: {{description, trigger_keywords, behavioral_indicators}}
+      - low_level: {{description, trigger_keywords, behavioral_indicators}}
+
+      Return JSON: {{"question_id": {{expert, mid_level, low_level}}}}
+
+  design_follow_ups:
+    description: "후속질문 분기 설계 (Expert/Mid/Low 트리거별)"
+    template: |
+      Design follow-up question branches for each interview question.
+      Each follow-up should probe deeper based on the candidate's response level.
+
+      Language: {output_language}
+      Experience Level: {experience_level}
+      Questions:
+      {questions_json}
+
+      For each question, create follow-ups triggered by response quality:
+      - expert_trigger: follow-up for strong answers (probe deeper expertise)
+      - mid_trigger: follow-up for adequate answers (clarify understanding)
+      - low_trigger: follow-up for weak answers (provide scaffolding)
+
+      Return JSON: {{"question_id": [{{trigger, question_text, purpose}}]}}
+
+  generate_interviewer_notes:
+    description: "면접관 참고 노트 생성 (비즈니스 해석, 일상 비유)"
+    template: |
+      Generate interviewer guidance notes for each question.
+      Target audience: non-technical interviewers (HR, hiring managers).
+
+      Language: {output_language}
+      Questions:
+      {questions_json}
+
+      For each question provide:
+      - business_interpretation: what this question reveals about the candidate in business terms
+      - daily_analogy: everyday analogy to understand the technical concept
+      - red_flags: warning signs in candidate's answer
+      - green_flags: positive indicators in candidate's answer
+
+      Return JSON: {{"question_id": {{business_interpretation, daily_analogy, red_flags, green_flags}}}}
+
+  generate_decision_guide:
+    description: "채용 의사결정 가이드 생성"
+    template: |
+      Based on the candidate analysis and interview questions, generate a decision guide
+      for the hiring committee.
+
+      Language: {output_language}
+      Experience Level: {experience_level}
+      Analysis Summary:
+      {analysis_summary}
+      Question Categories:
+      {category_summary}
+
+      Generate:
+      - scoring_weights: category weights by experience level
+      - decision_thresholds: {{strong_hire: 90, hire: 60, no_hire: 35}}
+      - category_insights: key evaluation focus per category
+      - risk_assessment: identified risks and mitigation questions
+
+      Return JSON with the above structure.
+
+  revise_questions:
+    description: "품질 검토 후 질문 수정"
+    template: |
+      Revise the following interview questions based on quality review feedback.
+
+      Language: {output_language}
+      Questions:
+      {questions_json}
+      Review Feedback:
+      {review_feedback}
+
+      Apply the feedback to improve each flagged question. Preserve question IDs.
+      Return the revised questions as a JSON list.

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -20,7 +20,12 @@ from app.workflows.activities.planning import create_execution_plan
 from app.workflows.activities.document_analysis import analyze_documents
 from app.workflows.activities.code_analysis import analyze_code
 from app.workflows.activities.jd_analysis import analyze_jd
-from app.workflows.activities.question_generation import select_topics, craft_question
+from app.workflows.activities.question_generation import (
+    select_topics, craft_question,
+    enhance_terminology, craft_evaluation_scenarios,
+    design_follow_ups, generate_interviewer_notes,
+    generate_decision_guide, revise_questions,
+)
 from app.workflows.activities.quality_review import review_questions
 from app.workflows.activities.finalization import finalize_output
 from app.workflows.activities.persist_result import persist_result
@@ -34,6 +39,12 @@ ACTIVITIES = [
     analyze_jd,
     select_topics,
     craft_question,
+    enhance_terminology,
+    craft_evaluation_scenarios,
+    design_follow_ups,
+    generate_interviewer_notes,
+    generate_decision_guide,
+    revise_questions,
     review_questions,
     finalize_output,
     persist_result,

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -134,6 +134,143 @@ async def craft_question(
     return question
 
 
+@activity.defn
+async def enhance_terminology(questions: list[dict], enriched_input: dict) -> dict:
+    """3c. Terminology Agent — 전문용어에 비개발자용 설명 추가"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt
+    import json
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+
+    prompt = get_prompt(
+        "question_generation.yaml", "enhance_terminology",
+        output_language=output_language,
+        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
+    )
+    result = await llm.run(prompt)
+    return result if isinstance(result, dict) else {}
+
+
+@activity.defn
+async def craft_evaluation_scenarios(questions: list[dict], enriched_input: dict) -> dict:
+    """3d. Scenario Writer Agent — 3단계 평가 시나리오 생성"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt
+    import json
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+    experience_level = raw_input.get("experience_level", "미들")
+
+    prompt = get_prompt(
+        "question_generation.yaml", "craft_evaluation_scenarios",
+        output_language=output_language,
+        experience_level=experience_level,
+        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
+    )
+    result = await llm.run(prompt)
+    return result if isinstance(result, dict) else {}
+
+
+@activity.defn
+async def design_follow_ups(questions: list[dict], enriched_input: dict) -> dict:
+    """3e. Follow-up Designer Agent — 후속질문 분기 설계"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt
+    import json
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+    experience_level = raw_input.get("experience_level", "미들")
+
+    prompt = get_prompt(
+        "question_generation.yaml", "design_follow_ups",
+        output_language=output_language,
+        experience_level=experience_level,
+        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
+    )
+    result = await llm.run(prompt)
+    return result if isinstance(result, dict) else {}
+
+
+@activity.defn
+async def generate_interviewer_notes(questions: list[dict], enriched_input: dict) -> dict:
+    """3f. Interviewer Note Agent — 면접관 참고 노트"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt
+    import json
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+
+    prompt = get_prompt(
+        "question_generation.yaml", "generate_interviewer_notes",
+        output_language=output_language,
+        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
+    )
+    result = await llm.run(prompt)
+    return result if isinstance(result, dict) else {}
+
+
+@activity.defn
+async def generate_decision_guide(analysis: dict, enriched_input: dict) -> dict:
+    """3g. Decision Guide Agent — 채용 의사결정 가이드"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt
+    import json
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+    experience_level = raw_input.get("experience_level", "미들")
+
+    # Summarize analysis for the prompt
+    analysis_summary = json.dumps({
+        k: v.get("summary", str(v)[:500]) if isinstance(v, dict) else str(v)[:500]
+        for k, v in analysis.items()
+    }, ensure_ascii=False, default=str)
+
+    categories = ["role_fit", "technical_depth", "execution_ownership", "communication", "risk_flags"]
+    category_summary = json.dumps(categories, ensure_ascii=False)
+
+    prompt = get_prompt(
+        "question_generation.yaml", "generate_decision_guide",
+        output_language=output_language,
+        experience_level=experience_level,
+        analysis_summary=analysis_summary,
+        category_summary=category_summary,
+    )
+    result = await llm.run(prompt)
+    return result if isinstance(result, dict) else {}
+
+
+@activity.defn
+async def revise_questions(questions: list[dict], review_feedback: dict, enriched_input: dict) -> list[dict]:
+    """3h. Quality Review revision — 피드백 기반 질문 수정"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt
+    import json
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+
+    prompt = get_prompt(
+        "question_generation.yaml", "revise_questions",
+        output_language=output_language,
+        questions_json=json.dumps(questions, ensure_ascii=False, default=str),
+        review_feedback=json.dumps(review_feedback, ensure_ascii=False, default=str),
+    )
+    result = await llm.run(prompt)
+    return result if isinstance(result, list) else questions
+
+
 def _format_candidates(candidates: list[dict]) -> str:
     lines = []
     for i, c in enumerate(candidates[:30]):

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -15,7 +15,12 @@ with workflow.unsafe.imports_passed_through():
     from app.workflows.activities.document_analysis import analyze_documents
     from app.workflows.activities.code_analysis import analyze_code
     from app.workflows.activities.jd_analysis import analyze_jd
-    from app.workflows.activities.question_generation import select_topics, craft_question
+    from app.workflows.activities.question_generation import (
+        select_topics, craft_question,
+        enhance_terminology, craft_evaluation_scenarios,
+        design_follow_ups, generate_interviewer_notes,
+        generate_decision_guide, revise_questions,
+    )
     from app.workflows.activities.quality_review import review_questions
     from app.workflows.activities.finalization import finalize_output
     from app.workflows.activities.persist_result import persist_result
@@ -133,6 +138,67 @@ class InterviewGenerationWorkflow:
             questions = await asyncio.gather(*question_tasks)
             questions = list(questions)
 
+            # Phase 3c-3g: Enhancement Agents (병렬)
+            self._update_status(JobStatus.GENERATING, "Phase 3: Enhancement", 70)
+
+            enhancement_tasks = [
+                # 3c. Terminology Agent
+                workflow.execute_activity(
+                    enhance_terminology,
+                    args=[questions, enriched],
+                    start_to_close_timeout=timedelta(minutes=3),
+                ),
+                # 3d. Scenario Writer Agent
+                workflow.execute_activity(
+                    craft_evaluation_scenarios,
+                    args=[questions, enriched],
+                    start_to_close_timeout=timedelta(minutes=3),
+                ),
+                # 3e. Follow-up Designer Agent
+                workflow.execute_activity(
+                    design_follow_ups,
+                    args=[questions, enriched],
+                    start_to_close_timeout=timedelta(minutes=3),
+                ),
+            ]
+
+            guide_tasks = [
+                # 3f. Interviewer Note Agent
+                workflow.execute_activity(
+                    generate_interviewer_notes,
+                    args=[questions, enriched],
+                    start_to_close_timeout=timedelta(minutes=3),
+                ),
+                # 3g. Decision Guide Agent
+                workflow.execute_activity(
+                    generate_decision_guide,
+                    args=[analysis, enriched],
+                    start_to_close_timeout=timedelta(minutes=3),
+                ),
+            ]
+
+            # Run all enhancement agents in parallel
+            all_enhancements = await asyncio.gather(
+                *enhancement_tasks, *guide_tasks
+            )
+            terminology = all_enhancements[0]
+            scenarios = all_enhancements[1]
+            follow_ups = all_enhancements[2]
+            interviewer_notes = all_enhancements[3]
+            decision_guide = all_enhancements[4]
+
+            # Merge enhancements into questions
+            for q in questions:
+                q_id = q.get("question_id") or q.get("topic", "")
+                if q_id in terminology:
+                    q["terminology"] = terminology[q_id]
+                if q_id in scenarios:
+                    q["evaluation_scenarios"] = scenarios[q_id]
+                if q_id in follow_ups:
+                    q["follow_up_questions"] = follow_ups[q_id]
+                if q_id in interviewer_notes:
+                    q["interviewer_note"] = interviewer_notes[q_id]
+
             # Phase 4: Quality Review + Finalization
             self._update_status(JobStatus.REVIEWING, "Phase 4: Review", 85)
 
@@ -143,6 +209,31 @@ class InterviewGenerationWorkflow:
                 start_to_close_timeout=timedelta(minutes=3),
             )
 
+            # 4a-1. Revision loop (최대 3회)
+            revision_count = 0
+            max_revisions = 3
+            while (
+                isinstance(review, dict)
+                and review.get("needs_revision")
+                and revision_count < max_revisions
+            ):
+                revision_count += 1
+                self._update_status(
+                    JobStatus.REVIEWING,
+                    f"Phase 4: Revision {revision_count}/{max_revisions}",
+                    85 + revision_count,
+                )
+                questions = await workflow.execute_activity(
+                    revise_questions,
+                    args=[questions, review, enriched],
+                    start_to_close_timeout=timedelta(minutes=3),
+                )
+                review = await workflow.execute_activity(
+                    review_questions,
+                    questions,
+                    start_to_close_timeout=timedelta(minutes=3),
+                )
+
             # 4b. 최종화
             self._update_status(JobStatus.REVIEWING, "Phase 4: Finalization", 90)
             final_script = await workflow.execute_activity(
@@ -151,6 +242,9 @@ class InterviewGenerationWorkflow:
                 start_to_close_timeout=timedelta(minutes=5),
                 heartbeat_timeout=timedelta(seconds=60),
             )
+            # Attach decision guide to final output
+            if isinstance(final_script, dict) and decision_guide:
+                final_script["decision_guide"] = decision_guide
 
             # DB에 결과 저장
             job_id = input_data.get("job_id")

--- a/backend/tests/test_workflow.py
+++ b/backend/tests/test_workflow.py
@@ -16,6 +16,12 @@ class TestActivityRegistration:
             "analyze_jd",
             "select_topics",
             "craft_question",
+            "enhance_terminology",
+            "craft_evaluation_scenarios",
+            "design_follow_ups",
+            "generate_interviewer_notes",
+            "generate_decision_guide",
+            "revise_questions",
             "review_questions",
             "finalize_output",
             "persist_result",
@@ -24,7 +30,7 @@ class TestActivityRegistration:
         assert names == expected
 
     def test_activity_count(self):
-        assert len(ACTIVITIES) == 11
+        assert len(ACTIVITIES) == 17
 
 
 class TestWorkflow:


### PR DESCRIPTION
## Summary
- Implement 6 missing enhancement activities completing the 8-agent question generation pipeline
- **3c** `enhance_terminology`: plain-language term explanations for non-tech interviewers
- **3d** `craft_evaluation_scenarios`: 3-level (Expert/Mid/Low) scoring scenarios
- **3e** `design_follow_ups`: branching follow-up questions by response quality
- **3f** `generate_interviewer_notes`: business interpretation + daily analogies
- **3g** `generate_decision_guide`: category weights + hiring decision thresholds
- **3h** `revise_questions`: quality review revision loop (max 3 iterations)
- All 5 enhancement agents (3c-3g) run in parallel after question crafting
- Decision guide attached to final interview script output
- Worker now registers **17 activities** (was 11)
- 6 new YAML prompt templates added

## Test plan
- [x] 87 tests passing
- [x] Docker build succeeds
- [ ] E2E: trigger workflow → verify enhancement fields in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)