### PR TITLE
feat: Add retry and checkpoint API endpoints

### DIFF
--- a/backend/app/api/routes/jobs.py
+++ b/backend/app/api/routes/jobs.py
@@ -11,7 +11,11 @@ from app.core.database import get_db
 from app.core.rate_limit import limiter
 from app.api.deps import get_current_user_or_api_key
 from app.models.database import UserDB
+from pydantic import BaseModel
+from sqlalchemy import select
+
 from app.models.input import CreateJobRequest, CreateJobResponse
+from app.models.database import CheckpointDB
 from app.services import job_service
 
 logger = logging.getLogger(__name__)
@@ -107,6 +111,129 @@ async def get_job_result(
         from app.exceptions import ValidationError
         raise ValidationError("Job is not completed yet")
     return job.final_output
+
+
+WORKFLOW_STEPS = [
+    "enrich_input", "plan", "document_analysis", "code_analysis",
+    "jd_analysis", "aggregate_analysis", "select_topics",
+    "craft_questions", "enhance_questions", "review_quality", "finalize",
+]
+
+
+class RetryRequest(BaseModel):
+    from_step: str | None = None
+    force_rerun: bool = False
+
+
+@router.post("/{job_id}/retry")
+async def retry_job(
+    job_id: str,
+    body: RetryRequest = RetryRequest(),
+    user: UserDB = Depends(get_current_user_or_api_key),
+    db: AsyncSession = Depends(get_db),
+):
+    """실패한 Job을 체크포인트부터 재시작"""
+    import uuid as _uuid
+    job = await job_service.get_job(job_id, user.id, db)
+
+    if job.status not in ("failed", "completed"):
+        from app.exceptions import ValidationError
+        raise ValidationError("Only failed or completed jobs can be retried")
+
+    # Determine resume point
+    result = await db.execute(
+        select(CheckpointDB)
+        .where(CheckpointDB.job_id == _uuid.UUID(job_id))
+        .order_by(CheckpointDB.created_at.desc())
+    )
+    checkpoints = list(result.scalars().all())
+    completed_phases = {cp.phase for cp in checkpoints}
+
+    if body.from_step:
+        resume_from = body.from_step
+    else:
+        # Auto-detect: first step without checkpoint
+        resume_from = WORKFLOW_STEPS[-1]
+        for step in WORKFLOW_STEPS:
+            if step not in completed_phases:
+                resume_from = step
+                break
+
+    # Determine skipped/cached steps
+    resume_idx = WORKFLOW_STEPS.index(resume_from) if resume_from in WORKFLOW_STEPS else 0
+    skipped = WORKFLOW_STEPS[:resume_idx]
+    cached = [s for s in skipped if s in completed_phases]
+
+    # Start new Temporal workflow
+    try:
+        from app.core.temporal import get_temporal_client
+        from app.workflows.interview_workflow import InterviewGenerationWorkflow
+        from app.core.config import settings
+
+        client = await get_temporal_client()
+        workflow_id = f"interview-{job.id}-retry"
+        workflow_input = {
+            **(job.input_data or {}),
+            "job_id": str(job.id),
+            "resume_from": resume_from,
+            "force_rerun": body.force_rerun,
+        }
+        await client.start_workflow(
+            InterviewGenerationWorkflow.run,
+            workflow_input,
+            id=workflow_id,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+        )
+        job.temporal_workflow_id = workflow_id
+        job.status = "retrying"
+    except Exception as e:
+        logger.error(f"Failed to start retry workflow: {e}")
+        from app.exceptions import ValidationError
+        raise ValidationError(f"Could not start retry: {e}")
+
+    return {
+        "job_id": str(job.id),
+        "status": "retrying",
+        "resume_from": resume_from,
+        "skipped_steps": skipped,
+        "cached_steps": cached,
+    }
+
+
+@router.get("/{job_id}/checkpoints")
+async def get_checkpoints(
+    job_id: str,
+    user: UserDB = Depends(get_current_user_or_api_key),
+    db: AsyncSession = Depends(get_db),
+):
+    """Job의 체크포인트 상태 조회"""
+    import uuid as _uuid
+    # Verify ownership
+    await job_service.get_job(job_id, user.id, db)
+
+    result = await db.execute(
+        select(CheckpointDB)
+        .where(CheckpointDB.job_id == _uuid.UUID(job_id))
+        .order_by(CheckpointDB.created_at)
+    )
+    checkpoints = list(result.scalars().all())
+    completed_phases = {cp.phase for cp in checkpoints}
+
+    steps = []
+    resume_point = None
+    for step in WORKFLOW_STEPS:
+        status = "completed" if step in completed_phases else "pending"
+        steps.append({"name": step, "status": status})
+        if status == "pending" and resume_point is None:
+            resume_point = step
+
+    return {
+        "job_id": job_id,
+        "steps": steps,
+        "resume_point": resume_point,
+        "total_steps": len(WORKFLOW_STEPS),
+        "completed_count": len(completed_phases & set(WORKFLOW_STEPS)),
+    }
 
 
 @router.delete("/{job_id}", status_code=204)

--- a/backend/tests/test_retry_checkpoint.py
+++ b/backend/tests/test_retry_checkpoint.py
@@ -1,0 +1,53 @@
+"""Retry and checkpoint API endpoint tests."""
+import pytest
+
+
+class TestRetryEndpoint:
+    def test_retry_route_exists(self):
+        from app.api.routes.jobs import retry_job
+        assert callable(retry_job)
+
+    def test_retry_request_model(self):
+        from app.api.routes.jobs import RetryRequest
+        req = RetryRequest()
+        assert req.from_step is None
+        assert req.force_rerun is False
+
+    def test_retry_request_with_step(self):
+        from app.api.routes.jobs import RetryRequest
+        req = RetryRequest(from_step="craft_questions", force_rerun=True)
+        assert req.from_step == "craft_questions"
+        assert req.force_rerun is True
+
+
+class TestCheckpointEndpoint:
+    def test_checkpoint_route_exists(self):
+        from app.api.routes.jobs import get_checkpoints
+        assert callable(get_checkpoints)
+
+    def test_workflow_steps_defined(self):
+        from app.api.routes.jobs import WORKFLOW_STEPS
+        assert len(WORKFLOW_STEPS) == 11
+        assert "enrich_input" == WORKFLOW_STEPS[0]
+        assert "finalize" == WORKFLOW_STEPS[-1]
+
+    def test_workflow_steps_contains_all_phases(self):
+        from app.api.routes.jobs import WORKFLOW_STEPS
+        required = [
+            "enrich_input", "plan", "document_analysis",
+            "code_analysis", "jd_analysis", "select_topics",
+            "craft_questions", "review_quality", "finalize",
+        ]
+        for step in required:
+            assert step in WORKFLOW_STEPS, f"Missing step: {step}"
+
+
+class TestCheckpointDB:
+    def test_checkpoint_model_importable(self):
+        from app.models.database import CheckpointDB
+        assert CheckpointDB.__tablename__ == "checkpoints"
+
+    def test_checkpoint_has_required_columns(self):
+        from app.models.database import CheckpointDB
+        columns = {c.name for c in CheckpointDB.__table__.columns}
+        assert {"id", "job_id", "phase", "data", "created_at"} <= columns


### PR DESCRIPTION
## Summary
- `POST /api/v1/jobs/{job_id}/retry` — resume failed jobs from last checkpoint or specified step
- `GET /api/v1/jobs/{job_id}/checkpoints` — view 11-step workflow completion status
- RetryRequest model with `from_step` and `force_rerun` options
- Auto-detects resume point from CheckpointDB records
- 8 new tests for endpoints, models, and workflow steps

## Test plan
- [x] 95 tests passing (87 existing + 8 new)
- [x] Docker build succeeds
- [ ] E2E: fail a job → POST /retry → verify workflow restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)