### PR TITLE
feat: Add WebSocket real-time job progress

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -62,3 +62,27 @@ async def get_current_user_or_api_key(
 
     # JWT fallback
     return await get_current_user(authorization=authorization, db=db)
+
+
+async def validate_api_key(token: str, db: AsyncSession) -> UserDB | None:
+    """WebSocket용 토큰 검증 (API Key 또는 JWT)"""
+    # Try API Key
+    if token.startswith("vnt_"):
+        key_hash = hash_api_key(token)
+        result = await db.execute(
+            select(APIKeyDB).where(APIKeyDB.key_hash == key_hash, APIKeyDB.is_active == True)
+        )
+        api_key = result.scalar_one_or_none()
+        if api_key is None:
+            return None
+        user_result = await db.execute(select(UserDB).where(UserDB.id == api_key.user_id))
+        return user_result.scalar_one_or_none()
+
+    # Try JWT
+    payload = verify_jwt(token)
+    if payload and "sub" in payload:
+        result = await db.execute(select(UserDB).where(UserDB.id == payload["sub"]))
+        user = result.scalar_one_or_none()
+        if user and user.is_active:
+            return user
+    return None

--- a/backend/app/api/routes/ws.py
+++ b/backend/app/api/routes/ws.py
@@ -1,0 +1,97 @@
+"""
+backend/app/api/routes/ws.py
+WebSocket 실시간 Job 진행률 스트리밍
+"""
+import asyncio
+import json
+import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
+
+router = APIRouter(tags=["websocket"])
+logger = logging.getLogger(__name__)
+
+
+@router.websocket("/api/v1/jobs/{job_id}/ws")
+async def job_progress_ws(
+    websocket: WebSocket,
+    job_id: str,
+    token: str = Query(default=""),
+):
+    """Job 진행률을 WebSocket으로 실시간 스트리밍.
+
+    인증: ws://host/api/v1/jobs/{job_id}/ws?token=<api_key>
+    Temporal workflow query를 2초 간격으로 폴링하여 전송.
+    """
+    # Authenticate
+    if not token:
+        await websocket.close(code=4001, reason="Missing token")
+        return
+
+    try:
+        from app.api.deps import validate_api_key
+        from app.core.database import async_session
+
+        async with async_session() as db:
+            user = await validate_api_key(token, db)
+            if not user:
+                await websocket.close(code=4003, reason="Invalid token")
+                return
+    except Exception:
+        await websocket.close(code=4003, reason="Authentication failed")
+        return
+
+    await websocket.accept()
+
+    try:
+        # Look up job and get workflow handle
+        from app.core.database import async_session
+        from app.models.database import JobDB
+        from sqlalchemy import select
+        import uuid
+
+        async with async_session() as db:
+            result = await db.execute(
+                select(JobDB).where(JobDB.id == uuid.UUID(job_id))
+            )
+            job = result.scalar_one_or_none()
+
+        if not job or not job.temporal_workflow_id:
+            await websocket.send_json({"error": "Job not found or no workflow"})
+            await websocket.close(code=4004)
+            return
+
+        # Poll Temporal for progress
+        from app.core.temporal import get_temporal_client
+        client = await get_temporal_client()
+        handle = client.get_workflow_handle(job.temporal_workflow_id)
+
+        last_progress = None
+        while True:
+            try:
+                progress = await handle.query("get_progress")
+                # Only send if changed
+                if progress != last_progress:
+                    await websocket.send_json(progress)
+                    last_progress = progress
+
+                # Stop if terminal state
+                if progress.get("status") in ("completed", "failed"):
+                    await websocket.send_json({"event": "done", **progress})
+                    break
+
+            except Exception as e:
+                logger.debug(f"Workflow query failed: {e}")
+                await websocket.send_json({"event": "query_error", "message": str(e)})
+                break
+
+            await asyncio.sleep(2)
+
+    except WebSocketDisconnect:
+        logger.debug(f"WebSocket disconnected for job {job_id}")
+    except Exception as e:
+        logger.error(f"WebSocket error: {e}")
+        try:
+            await websocket.close(code=1011)
+        except Exception:
+            pass

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.exceptions import VantictBaseError
 from app.api.health import router as health_router
 from app.api.routes.auth import router as auth_router
 from app.api.routes.jobs import router as jobs_router
+from app.api.routes.ws import router as ws_router
 
 logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL))
 logger = logging.getLogger(__name__)
@@ -106,6 +107,7 @@ async def vantict_error_handler(request: Request, exc: VantictBaseError):
 app.include_router(health_router)
 app.include_router(auth_router)
 app.include_router(jobs_router)
+app.include_router(ws_router)
 
 
 @app.get("/")

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -1,0 +1,30 @@
+"""WebSocket progress endpoint tests."""
+import pytest
+
+
+class TestWebSocketRoute:
+    def test_ws_route_exists(self):
+        from app.api.routes.ws import job_progress_ws
+        assert callable(job_progress_ws)
+
+    def test_ws_router_registered(self):
+        from app.main import app
+        ws_routes = [
+            r.path for r in app.routes
+            if hasattr(r, "path") and "/ws" in r.path
+        ]
+        assert "/api/v1/jobs/{job_id}/ws" in ws_routes
+
+
+class TestValidateApiKey:
+    def test_validate_api_key_exists(self):
+        from app.api.deps import validate_api_key
+        assert callable(validate_api_key)
+
+    def test_validate_api_key_signature(self):
+        import inspect
+        from app.api.deps import validate_api_key
+        sig = inspect.signature(validate_api_key)
+        params = list(sig.parameters.keys())
+        assert "token" in params
+        assert "db" in params


### PR DESCRIPTION
## Summary
- `WS /api/v1/jobs/{job_id}/ws?token=<api_key>` — real-time progress streaming
- Polls Temporal workflow query every 2s, sends only on change
- Token authentication via query parameter (API key `vnt_*` or JWT)
- `validate_api_key()` helper in deps.py for WebSocket auth
- Auto-closes connection on terminal states (completed/failed)
- 4 new tests

## Test plan
- [x] 99 tests passing (95 existing + 4 new)
- [x] Docker build succeeds
- [ ] Manual: `wscat -c ws://localhost:8000/api/v1/jobs/{id}/ws?token=vnt_xxx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)