### PR TITLE
feat: 문서 파서 고도화 및 벡터 스토어 연동

### DIFF
--- a/backend/app/services/document_parser.py
+++ b/backend/app/services/document_parser.py
@@ -4,36 +4,74 @@ PDF/DOCX 텍스트 추출 (Docling primary, pymupdf4llm fallback)
 """
 import logging
 import os
+from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
+
+SUPPORTED_EXTENSIONS = {".pdf", ".docx", ".doc", ".txt", ".md", ".html"}
+
+
+@dataclass
+class ParseResult:
+    """문서 파싱 결과"""
+    text: str
+    metadata: dict = field(default_factory=dict)
+    sections: list[dict] = field(default_factory=list)
+    parser_used: str = "unknown"
 
 
 async def extract_text(file_path: str) -> str:
     """파일에서 텍스트 추출 (PDF/DOCX 지원)"""
+    result = await parse_document(file_path)
+    return result.text
+
+
+async def parse_document(file_path: str) -> ParseResult:
+    """파일에서 구조화된 파싱 결과 반환"""
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"File not found: {file_path}")
 
     ext = os.path.splitext(file_path)[1].lower()
+    if ext not in SUPPORTED_EXTENSIONS:
+        raise ValueError(f"Unsupported file format: {ext}")
 
     # Docling 시도
     try:
-        return await _extract_with_docling(file_path)
+        text = await _extract_with_docling(file_path)
+        sections = _extract_sections(text)
+        return ParseResult(
+            text=text,
+            metadata={"source": file_path, "format": ext},
+            sections=sections,
+            parser_used="docling",
+        )
     except Exception as e:
         logger.warning(f"Docling failed for {file_path}: {e}")
 
     # Fallback: pymupdf4llm (PDF only)
     if ext == ".pdf":
         try:
-            return await _extract_with_pymupdf(file_path)
+            text = await _extract_with_pymupdf(file_path)
+            return ParseResult(
+                text=text,
+                metadata={"source": file_path, "format": ext},
+                sections=_extract_sections(text),
+                parser_used="pymupdf4llm",
+            )
         except Exception as e:
             logger.warning(f"pymupdf4llm failed for {file_path}: {e}")
 
     # Fallback: plain text read
-    if ext in (".txt", ".md"):
+    if ext in (".txt", ".md", ".html"):
         with open(file_path, "r", encoding="utf-8") as f:
-            return f.read()
+            text = f.read()
+        return ParseResult(
+            text=text,
+            metadata={"source": file_path, "format": ext},
+            parser_used="plaintext",
+        )
 
-    raise ValueError(f"Unsupported file format: {ext}")
+    raise ValueError(f"All parsers failed for: {file_path}")
 
 
 async def _extract_with_docling(file_path: str) -> str:
@@ -48,3 +86,30 @@ async def _extract_with_pymupdf(file_path: str) -> str:
     """pymupdf4llm으로 PDF 텍스트 추출 (fallback)"""
     import pymupdf4llm
     return pymupdf4llm.to_markdown(file_path)
+
+
+def _extract_sections(text: str) -> list[dict]:
+    """마크다운 텍스트에서 섹션 구분"""
+    sections = []
+    current_title = "Introduction"
+    current_lines = []
+
+    for line in text.split("\n"):
+        if line.startswith("# ") or line.startswith("## "):
+            if current_lines:
+                sections.append({
+                    "title": current_title,
+                    "content": "\n".join(current_lines).strip(),
+                })
+            current_title = line.lstrip("# ").strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_lines:
+        sections.append({
+            "title": current_title,
+            "content": "\n".join(current_lines).strip(),
+        })
+
+    return sections

--- a/backend/app/workflows/activities/document_analysis.py
+++ b/backend/app/workflows/activities/document_analysis.py
@@ -14,28 +14,36 @@ async def analyze_documents(input_data: dict) -> dict:
     """
     이력서/포트폴리오 분석
 
-    1. 문서 텍스트 추출 (Docling)
+    1. 문서 텍스트 추출 (Docling primary, pymupdf4llm fallback)
     2. LLM으로 프로필 구조화 추출
-    3. 벡터 스토어에 저장
+    3. 벡터 스토어에 프로필 임베딩 저장
     """
-    from app.services.document_parser import extract_text
+    from app.services.document_parser import parse_document
     from app.services.cached_llm import CachedLLMService
 
     llm = CachedLLMService()
     documents = []
+    parse_results = []
 
     for doc_key in ("resume_path", "portfolio_path", "cover_letter_path"):
         path = input_data.get(doc_key)
         if path:
             activity.heartbeat(f"Parsing {doc_key}...")
             try:
-                text = await extract_text(path)
-                documents.append(f"## {doc_key}\n{text}")
+                result = await parse_document(path)
+                documents.append(f"## {doc_key}\n{result.text}")
+                parse_results.append({
+                    "key": doc_key,
+                    "parser": result.parser_used,
+                    "sections": len(result.sections),
+                    "chars": len(result.text),
+                })
+                logger.info(f"Parsed {doc_key} with {result.parser_used}: {len(result.text)} chars")
             except Exception as e:
                 logger.warning(f"Failed to parse {doc_key}: {e}")
 
     if not documents:
-        return {"profile": {}, "raw_texts": []}
+        return {"profile": {}, "raw_texts": [], "parse_info": []}
 
     # LLM으로 프로필 추출
     activity.heartbeat("Extracting candidate profile with LLM...")
@@ -43,7 +51,20 @@ async def analyze_documents(input_data: dict) -> dict:
     prompt = get_prompt("document_analysis.yaml", "extract_profile", documents="\n---\n".join(documents))
     profile = await llm.run(prompt)
 
+    # 벡터 스토어에 프로필 저장 (job_id가 있을 경우)
+    job_id = input_data.get("job_id")
+    if job_id and isinstance(profile, dict):
+        activity.heartbeat("Storing profile embeddings...")
+        try:
+            from app.services.vector_store import get_vector_store
+            vs = get_vector_store(job_id)
+            await vs.store_profile(profile)
+            logger.info(f"Stored profile embeddings for job {job_id}")
+        except Exception as e:
+            logger.warning(f"Vector store failed (non-fatal): {e}")
+
     return {
         "profile": profile if isinstance(profile, dict) else {},
         "raw_texts": documents,
+        "parse_info": parse_results,
     }

--- a/backend/tests/test_document_parser.py
+++ b/backend/tests/test_document_parser.py
@@ -1,0 +1,88 @@
+"""Document parser and document analysis activity tests."""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from dataclasses import fields
+
+
+class TestParseResult:
+    def test_parse_result_dataclass(self):
+        from app.services.document_parser import ParseResult
+        r = ParseResult(text="hello", parser_used="docling")
+        assert r.text == "hello"
+        assert r.metadata == {}
+        assert r.sections == []
+        assert r.parser_used == "docling"
+
+    def test_parse_result_fields(self):
+        from app.services.document_parser import ParseResult
+        names = {f.name for f in fields(ParseResult)}
+        assert names == {"text", "metadata", "sections", "parser_used"}
+
+
+class TestSupportedExtensions:
+    def test_pdf_supported(self):
+        from app.services.document_parser import SUPPORTED_EXTENSIONS
+        assert ".pdf" in SUPPORTED_EXTENSIONS
+
+    def test_docx_supported(self):
+        from app.services.document_parser import SUPPORTED_EXTENSIONS
+        assert ".docx" in SUPPORTED_EXTENSIONS
+
+    def test_unsupported_extension(self):
+        from app.services.document_parser import SUPPORTED_EXTENSIONS
+        assert ".xyz" not in SUPPORTED_EXTENSIONS
+
+
+class TestExtractSections:
+    def test_extract_sections_basic(self):
+        from app.services.document_parser import _extract_sections
+        text = "# Title\nContent here\n## Sub\nMore content"
+        sections = _extract_sections(text)
+        assert len(sections) >= 2
+        assert sections[0]["title"] == "Title"
+
+    def test_extract_sections_empty(self):
+        from app.services.document_parser import _extract_sections
+        sections = _extract_sections("")
+        assert isinstance(sections, list)
+
+    def test_extract_sections_no_headers(self):
+        from app.services.document_parser import _extract_sections
+        sections = _extract_sections("Just plain text\nAnother line")
+        assert len(sections) == 1
+        assert sections[0]["title"] == "Introduction"
+
+
+class TestParseDocumentValidation:
+    @pytest.mark.asyncio
+    async def test_file_not_found(self):
+        from app.services.document_parser import parse_document
+        with pytest.raises(FileNotFoundError):
+            await parse_document("/nonexistent/file.pdf")
+
+    @pytest.mark.asyncio
+    async def test_unsupported_format(self, tmp_path):
+        f = tmp_path / "test.xyz"
+        f.write_text("data")
+        from app.services.document_parser import parse_document
+        with pytest.raises(ValueError, match="Unsupported"):
+            await parse_document(str(f))
+
+    @pytest.mark.asyncio
+    async def test_plaintext_fallback(self, tmp_path):
+        f = tmp_path / "test.txt"
+        f.write_text("Hello world")
+        from app.services.document_parser import parse_document
+        result = await parse_document(str(f))
+        assert result.text == "Hello world"
+        assert result.parser_used == "plaintext"
+
+
+class TestDocumentAnalysisActivity:
+    def test_activity_exists(self):
+        from app.workflows.activities.document_analysis import analyze_documents
+        assert callable(analyze_documents)
+
+    def test_activity_is_defn(self):
+        from app.workflows.activities.document_analysis import analyze_documents
+        assert hasattr(analyze_documents, "__temporal_activity_definition")


### PR DESCRIPTION
## 요약
- `ParseResult` 데이터클래스 도입으로 파싱 결과 구조화 (텍스트, 메타데이터, 섹션, 사용된 파서)
- Docling → pymupdf4llm → plaintext 3단계 폴백 체인 구현
- `document_analysis` Activity에서 벡터 스토어에 프로필 임베딩 자동 저장

## 변경사항
- `document_parser.py`: `ParseResult`, `parse_document()`, `_extract_sections()`, `SUPPORTED_EXTENSIONS` 추가
- `document_analysis.py`: `parse_document()` 사용, `parse_info` 반환, 벡터 스토어 연동
- `test_document_parser.py`: 13개 테스트 추가 (99→112 tests)

## 테스트 계획
- [x] ParseResult 데이터클래스 필드 검증
- [x] 지원 확장자 확인 (.pdf, .docx, .txt 등)
- [x] 섹션 추출 로직 테스트 (헤더 있음/없음/빈 텍스트)
- [x] 파일 미존재/미지원 포맷 에러 처리
- [x] plaintext 폴백 동작 확인
- [x] Activity 데코레이터 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)