### PR TITLE
feat: LinkedIn 서비스 고도화 (재시도, URL 검증, 추가 필드)

### DIFF
--- a/backend/app/services/linkedin_service.py
+++ b/backend/app/services/linkedin_service.py
@@ -2,7 +2,9 @@
 backend/app/services/linkedin_service.py
 Proxycurl API를 통한 LinkedIn 프로필 수집
 """
+import asyncio
 import logging
+import re
 
 import httpx
 
@@ -10,6 +12,12 @@ from app.core.config import settings
 from app.exceptions import LinkedInFetchError
 
 logger = logging.getLogger(__name__)
+
+LINKEDIN_URL_PATTERN = re.compile(
+    r"^https?://(?:www\.)?linkedin\.com/in/[\w\-]+/?$"
+)
+MAX_RETRIES = 2
+RETRY_BACKOFF = 1.0  # seconds
 
 
 class ProxycurlService:
@@ -24,7 +32,7 @@ class ProxycurlService:
         """LinkedIn 프로필 조회
 
         Returns:
-            프로필 dict or None (API 키 미설정 시)
+            프로필 dict or None (API 키 미설정 시 또는 404)
 
         Raises:
             LinkedInFetchError: API 호출 실패 시
@@ -33,34 +41,54 @@ class ProxycurlService:
             logger.warning("PROXYCURL_API_KEY not set, skipping LinkedIn fetch")
             return None
 
-        try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                resp = await client.get(
-                    self.BASE_URL,
-                    params={"linkedin_profile_url": linkedin_url, "use_cache": "if-present"},
-                    headers={"Authorization": f"Bearer {self.api_key}"},
-                )
+        if not self.validate_url(linkedin_url):
+            raise LinkedInFetchError(f"Invalid LinkedIn URL: {linkedin_url}")
 
-            if resp.status_code == 200:
-                data = resp.json()
-                return self._normalize_profile(data, linkedin_url)
-            elif resp.status_code == 404:
-                logger.warning(f"LinkedIn profile not found: {linkedin_url}")
-                return None
-            else:
-                raise LinkedInFetchError(
-                    f"Proxycurl API error {resp.status_code}: {resp.text}"
-                )
+        last_error: Exception | None = None
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                return await self._fetch_profile(linkedin_url)
+            except LinkedInFetchError:
+                raise
+            except httpx.HTTPError as e:
+                last_error = e
+                if attempt < MAX_RETRIES:
+                    wait = RETRY_BACKOFF * (2 ** attempt)
+                    logger.info(f"Retry {attempt + 1}/{MAX_RETRIES} for {linkedin_url} in {wait}s")
+                    await asyncio.sleep(wait)
 
-        except httpx.HTTPError as e:
-            raise LinkedInFetchError(f"Proxycurl request failed: {e}") from e
+        raise LinkedInFetchError(f"Proxycurl request failed after retries: {last_error}") from last_error
+
+    async def _fetch_profile(self, linkedin_url: str) -> dict | None:
+        """단일 API 호출"""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                self.BASE_URL,
+                params={"linkedin_profile_url": linkedin_url, "use_cache": "if-present"},
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            )
+
+        if resp.status_code == 200:
+            data = resp.json()
+            return self._normalize_profile(data, linkedin_url)
+        elif resp.status_code == 404:
+            logger.warning(f"LinkedIn profile not found: {linkedin_url}")
+            return None
+        elif resp.status_code == 429:
+            raise httpx.HTTPError("Rate limited by Proxycurl")
+        else:
+            raise LinkedInFetchError(
+                f"Proxycurl API error {resp.status_code}: {resp.text}"
+            )
+
+    @staticmethod
+    def validate_url(url: str) -> bool:
+        """LinkedIn 프로필 URL 유효성 검증"""
+        return bool(LINKEDIN_URL_PATTERN.match(url))
 
     def _normalize_profile(self, data: dict, url: str) -> dict:
         """Proxycurl 응답을 내부 형식으로 정규화"""
         github_url = None
-        for site in data.get("personal_emails", []):
-            pass  # emails not useful for github
-        # Check websites for GitHub
         for site in data.get("personal_urls", []) or []:
             if "github.com" in (site.get("url") or ""):
                 github_url = site["url"]
@@ -80,6 +108,7 @@ class ProxycurlService:
                     "description": exp.get("description"),
                     "starts_at": exp.get("starts_at"),
                     "ends_at": exp.get("ends_at"),
+                    "location": exp.get("location"),
                 }
                 for exp in (data.get("experiences") or [])[:10]
             ],
@@ -88,6 +117,8 @@ class ProxycurlService:
                     "school": edu.get("school"),
                     "degree": edu.get("degree_name"),
                     "field": edu.get("field_of_study"),
+                    "starts_at": edu.get("starts_at"),
+                    "ends_at": edu.get("ends_at"),
                 }
                 for edu in (data.get("education") or [])[:5]
             ],
@@ -95,5 +126,14 @@ class ProxycurlService:
             "languages": [
                 lang.get("name") for lang in (data.get("languages") or [])
             ],
+            "certifications": [
+                {
+                    "name": cert.get("name"),
+                    "authority": cert.get("authority"),
+                }
+                for cert in (data.get("certifications") or [])[:10]
+            ],
+            "recommendations_count": len(data.get("recommendations", []) or []),
+            "connections": data.get("connections"),
             "github_url": github_url,
         }

--- a/backend/tests/test_linkedin_service.py
+++ b/backend/tests/test_linkedin_service.py
@@ -1,0 +1,142 @@
+"""LinkedIn service (Proxycurl) tests."""
+import pytest
+
+
+class TestProxycurlServiceInit:
+    def test_importable(self):
+        from app.services.linkedin_service import ProxycurlService
+        assert ProxycurlService is not None
+
+    def test_base_url(self):
+        from app.services.linkedin_service import ProxycurlService
+        assert "proxycurl" in ProxycurlService.BASE_URL
+
+    def test_default_no_api_key(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key=None)
+        # settings.PROXYCURL_API_KEY is likely empty in test env
+        assert isinstance(svc.api_key, (str, type(None)))
+
+
+class TestValidateUrl:
+    def test_valid_url(self):
+        from app.services.linkedin_service import ProxycurlService
+        assert ProxycurlService.validate_url("https://www.linkedin.com/in/john-doe")
+
+    def test_valid_url_no_www(self):
+        from app.services.linkedin_service import ProxycurlService
+        assert ProxycurlService.validate_url("https://linkedin.com/in/john-doe")
+
+    def test_valid_url_trailing_slash(self):
+        from app.services.linkedin_service import ProxycurlService
+        assert ProxycurlService.validate_url("https://linkedin.com/in/john-doe/")
+
+    def test_invalid_url_company(self):
+        from app.services.linkedin_service import ProxycurlService
+        assert not ProxycurlService.validate_url("https://linkedin.com/company/acme")
+
+    def test_invalid_url_random(self):
+        from app.services.linkedin_service import ProxycurlService
+        assert not ProxycurlService.validate_url("https://example.com/in/john")
+
+    def test_invalid_url_empty(self):
+        from app.services.linkedin_service import ProxycurlService
+        assert not ProxycurlService.validate_url("")
+
+
+class TestNormalizeProfile:
+    def test_basic_fields(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key="test")
+        data = {
+            "full_name": "John Doe",
+            "headline": "Engineer",
+            "summary": "Experienced",
+            "country_full_name": "Korea",
+            "city": "Seoul",
+        }
+        result = svc._normalize_profile(data, "https://linkedin.com/in/john")
+        assert result["full_name"] == "John Doe"
+        assert result["country"] == "Korea"
+        assert result["url"] == "https://linkedin.com/in/john"
+
+    def test_github_extraction(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key="test")
+        data = {
+            "personal_urls": [
+                {"url": "https://github.com/johndoe"},
+                {"url": "https://blog.example.com"},
+            ],
+        }
+        result = svc._normalize_profile(data, "https://linkedin.com/in/john")
+        assert result["github_url"] == "https://github.com/johndoe"
+
+    def test_no_github(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key="test")
+        result = svc._normalize_profile({}, "https://linkedin.com/in/john")
+        assert result["github_url"] is None
+
+    def test_experiences_limit(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key="test")
+        data = {"experiences": [{"title": f"Job {i}"} for i in range(20)]}
+        result = svc._normalize_profile(data, "https://linkedin.com/in/john")
+        assert len(result["experiences"]) == 10
+
+    def test_certifications_included(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key="test")
+        data = {"certifications": [{"name": "AWS", "authority": "Amazon"}]}
+        result = svc._normalize_profile(data, "https://linkedin.com/in/john")
+        assert len(result["certifications"]) == 1
+        assert result["certifications"][0]["name"] == "AWS"
+
+    def test_recommendations_count(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key="test")
+        data = {"recommendations": ["rec1", "rec2"]}
+        result = svc._normalize_profile(data, "https://linkedin.com/in/john")
+        assert result["recommendations_count"] == 2
+
+    def test_empty_data(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key="test")
+        result = svc._normalize_profile({}, "https://linkedin.com/in/john")
+        assert result["experiences"] == []
+        assert result["skills"] == []
+        assert result["certifications"] == []
+
+
+class TestGetProfileNoKey:
+    @pytest.mark.asyncio
+    async def test_returns_none_without_key(self):
+        from app.services.linkedin_service import ProxycurlService
+        svc = ProxycurlService(api_key="")
+        result = await svc.get_profile("https://linkedin.com/in/john")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_raises(self):
+        from app.services.linkedin_service import ProxycurlService
+        from app.exceptions import LinkedInFetchError
+        svc = ProxycurlService(api_key="test-key")
+        with pytest.raises(LinkedInFetchError, match="Invalid"):
+            await svc.get_profile("not-a-url")
+
+
+class TestRetryConstants:
+    def test_max_retries(self):
+        from app.services.linkedin_service import MAX_RETRIES
+        assert MAX_RETRIES == 2
+
+    def test_retry_backoff(self):
+        from app.services.linkedin_service import RETRY_BACKOFF
+        assert RETRY_BACKOFF > 0
+
+
+class TestLinkedInUrlPattern:
+    def test_pattern_exists(self):
+        from app.services.linkedin_service import LINKEDIN_URL_PATTERN
+        assert LINKEDIN_URL_PATTERN is not None


### PR DESCRIPTION
## 요약
- Proxycurl LinkedIn 서비스에 URL 유효성 검증, 지수 백오프 재시도, 추가 프로필 필드 보강
- 21개 테스트 추가로 서비스 신뢰성 확보

## 변경사항
- `linkedin_service.py`: URL 검증 정규식, 재시도 로직 (MAX_RETRIES=2, 지수 백오프), 429 처리, certifications/recommendations_count/connections 필드 추가
- `test_linkedin_service.py`: 21개 테스트 (URL 검증, normalize, API 키 없는 경우, 상수 검증)

## 테스트 계획
- [x] URL 유효성 검증 (정상/비정상 6가지 케이스)
- [x] 프로필 정규화 (기본 필드, GitHub 추출, 경력 제한, 인증서, 추천 수)
- [x] API 키 미설정 시 None 반환
- [x] 잘못된 URL 시 LinkedInFetchError 발생
- [x] 재시도 상수 검증
- [x] 전체 133 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)