### PR TITLE
feat: Workflow 재시도 정책 및 문서 크기 제한 추가

### DIFF
--- a/backend/app/services/document_parser.py
+++ b/backend/app/services/document_parser.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 logger = logging.getLogger(__name__)
 
 SUPPORTED_EXTENSIONS = {".pdf", ".docx", ".doc", ".txt", ".md", ".html"}
+MAX_FILE_SIZE_MB = 50
+MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024
 
 
 @dataclass
@@ -30,6 +32,12 @@ async def parse_document(file_path: str) -> ParseResult:
     """파일에서 구조화된 파싱 결과 반환"""
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"File not found: {file_path}")
+
+    file_size = os.path.getsize(file_path)
+    if file_size > MAX_FILE_SIZE_BYTES:
+        raise ValueError(
+            f"File too large: {file_size / 1024 / 1024:.1f}MB (max {MAX_FILE_SIZE_MB}MB)"
+        )
 
     ext = os.path.splitext(file_path)[1].lower()
     if ext not in SUPPORTED_EXTENSIONS:

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -7,6 +7,7 @@ import logging
 from datetime import timedelta
 
 from temporalio import workflow
+from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
     from app.models.enums import JobStatus
@@ -27,6 +28,29 @@ with workflow.unsafe.imports_passed_through():
     from app.workflows.activities.send_webhook import send_webhook
 
 logger = logging.getLogger(__name__)
+
+# Retry policies
+DEFAULT_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=30),
+    maximum_attempts=3,
+)
+
+LLM_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=2),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=60),
+    maximum_attempts=3,
+    non_retryable_error_types=["ValueError"],
+)
+
+EXTERNAL_API_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=3),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=120),
+    maximum_attempts=4,
+)
 
 
 @workflow.defn
@@ -51,6 +75,7 @@ class InterviewGenerationWorkflow:
                 input_data,
                 start_to_close_timeout=timedelta(minutes=5),
                 heartbeat_timeout=timedelta(seconds=60),
+                retry_policy=EXTERNAL_API_RETRY,
             )
 
             # Phase 1: Planning
@@ -60,6 +85,7 @@ class InterviewGenerationWorkflow:
                 enriched,
                 start_to_close_timeout=timedelta(minutes=3),
                 heartbeat_timeout=timedelta(seconds=60),
+                retry_policy=LLM_RETRY,
             )
 
             # Phase 2: Parallel Analysis
@@ -75,6 +101,7 @@ class InterviewGenerationWorkflow:
                     analyze_jd,
                     raw_input.get("jd_text", ""),
                     start_to_close_timeout=timedelta(minutes=3),
+                    retry_policy=LLM_RETRY,
                 )
             )
 
@@ -86,6 +113,7 @@ class InterviewGenerationWorkflow:
                         raw_input,
                         start_to_close_timeout=timedelta(minutes=5),
                         heartbeat_timeout=timedelta(seconds=60),
+                        retry_policy=DEFAULT_RETRY,
                     )
                 )
 
@@ -101,6 +129,7 @@ class InterviewGenerationWorkflow:
                         ],
                         start_to_close_timeout=timedelta(minutes=10),
                         heartbeat_timeout=timedelta(seconds=120),
+                        retry_policy=EXTERNAL_API_RETRY,
                     )
                 )
 
@@ -123,6 +152,7 @@ class InterviewGenerationWorkflow:
                 select_topics,
                 args=[analysis, enriched],
                 start_to_close_timeout=timedelta(minutes=3),
+                retry_policy=LLM_RETRY,
             )
 
             # 3b. 개별 질문 생성 (병렬)
@@ -133,6 +163,7 @@ class InterviewGenerationWorkflow:
                         craft_question,
                         args=[topic, analysis, enriched],
                         start_to_close_timeout=timedelta(minutes=2),
+                        retry_policy=LLM_RETRY,
                     )
                 )
             questions = await asyncio.gather(*question_tasks)
@@ -147,18 +178,21 @@ class InterviewGenerationWorkflow:
                     enhance_terminology,
                     args=[questions, enriched],
                     start_to_close_timeout=timedelta(minutes=3),
+                    retry_policy=LLM_RETRY,
                 ),
                 # 3d. Scenario Writer Agent
                 workflow.execute_activity(
                     craft_evaluation_scenarios,
                     args=[questions, enriched],
                     start_to_close_timeout=timedelta(minutes=3),
+                    retry_policy=LLM_RETRY,
                 ),
                 # 3e. Follow-up Designer Agent
                 workflow.execute_activity(
                     design_follow_ups,
                     args=[questions, enriched],
                     start_to_close_timeout=timedelta(minutes=3),
+                    retry_policy=LLM_RETRY,
                 ),
             ]
 
@@ -168,12 +202,14 @@ class InterviewGenerationWorkflow:
                     generate_interviewer_notes,
                     args=[questions, enriched],
                     start_to_close_timeout=timedelta(minutes=3),
+                    retry_policy=LLM_RETRY,
                 ),
                 # 3g. Decision Guide Agent
                 workflow.execute_activity(
                     generate_decision_guide,
                     args=[analysis, enriched],
                     start_to_close_timeout=timedelta(minutes=3),
+                    retry_policy=LLM_RETRY,
                 ),
             ]
 
@@ -207,6 +243,7 @@ class InterviewGenerationWorkflow:
                 review_questions,
                 questions,
                 start_to_close_timeout=timedelta(minutes=3),
+                retry_policy=LLM_RETRY,
             )
 
             # 4a-1. Revision loop (최대 3회)
@@ -227,11 +264,13 @@ class InterviewGenerationWorkflow:
                     revise_questions,
                     args=[questions, review, enriched],
                     start_to_close_timeout=timedelta(minutes=3),
+                    retry_policy=LLM_RETRY,
                 )
                 review = await workflow.execute_activity(
                     review_questions,
                     questions,
                     start_to_close_timeout=timedelta(minutes=3),
+                    retry_policy=LLM_RETRY,
                 )
 
             # 4b. 최종화
@@ -241,6 +280,7 @@ class InterviewGenerationWorkflow:
                 args=[questions, analysis, enriched],
                 start_to_close_timeout=timedelta(minutes=5),
                 heartbeat_timeout=timedelta(seconds=60),
+                retry_policy=LLM_RETRY,
             )
             # Attach decision guide to final output
             if isinstance(final_script, dict) and decision_guide:
@@ -254,6 +294,7 @@ class InterviewGenerationWorkflow:
                     persist_result,
                     args=[job_id, final_script],
                     start_to_close_timeout=timedelta(minutes=1),
+                    retry_policy=DEFAULT_RETRY,
                 )
 
             # Webhook callback (fire-and-forget, 실패해도 워크플로우 성공)

--- a/backend/tests/test_retry_policies.py
+++ b/backend/tests/test_retry_policies.py
@@ -1,0 +1,76 @@
+"""Workflow retry policies and document parser limits tests."""
+import pytest
+from datetime import timedelta
+
+
+class TestRetryPolicies:
+    def test_default_retry_exists(self):
+        from app.workflows.interview_workflow import DEFAULT_RETRY
+        assert DEFAULT_RETRY.maximum_attempts == 3
+
+    def test_llm_retry_exists(self):
+        from app.workflows.interview_workflow import LLM_RETRY
+        assert LLM_RETRY.maximum_attempts == 3
+        assert "ValueError" in LLM_RETRY.non_retryable_error_types
+
+    def test_external_api_retry_exists(self):
+        from app.workflows.interview_workflow import EXTERNAL_API_RETRY
+        assert EXTERNAL_API_RETRY.maximum_attempts == 4
+
+    def test_default_retry_backoff(self):
+        from app.workflows.interview_workflow import DEFAULT_RETRY
+        assert DEFAULT_RETRY.backoff_coefficient == 2.0
+
+    def test_llm_retry_initial_interval(self):
+        from app.workflows.interview_workflow import LLM_RETRY
+        assert LLM_RETRY.initial_interval == timedelta(seconds=2)
+
+    def test_external_api_max_interval(self):
+        from app.workflows.interview_workflow import EXTERNAL_API_RETRY
+        assert EXTERNAL_API_RETRY.maximum_interval == timedelta(seconds=120)
+
+
+class TestRetryPolicyImport:
+    def test_retry_policy_imported(self):
+        from temporalio.common import RetryPolicy
+        assert RetryPolicy is not None
+
+    def test_workflow_uses_retry_policy(self):
+        import inspect
+        from app.workflows.interview_workflow import InterviewGenerationWorkflow
+        source = inspect.getsource(InterviewGenerationWorkflow.run)
+        assert "retry_policy" in source
+
+
+class TestDocumentParserLimits:
+    def test_max_file_size_constant(self):
+        from app.services.document_parser import MAX_FILE_SIZE_MB
+        assert MAX_FILE_SIZE_MB == 50
+
+    def test_max_file_size_bytes(self):
+        from app.services.document_parser import MAX_FILE_SIZE_BYTES
+        assert MAX_FILE_SIZE_BYTES == 50 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_large_file_rejected(self, tmp_path):
+        # Create a file that's "too large" by lowering the threshold temporarily
+        from app.services import document_parser
+        original = document_parser.MAX_FILE_SIZE_BYTES
+        document_parser.MAX_FILE_SIZE_BYTES = 10  # 10 bytes
+
+        f = tmp_path / "big.txt"
+        f.write_text("A" * 100)
+
+        try:
+            with pytest.raises(ValueError, match="File too large"):
+                await document_parser.parse_document(str(f))
+        finally:
+            document_parser.MAX_FILE_SIZE_BYTES = original
+
+    @pytest.mark.asyncio
+    async def test_small_file_accepted(self, tmp_path):
+        from app.services.document_parser import parse_document
+        f = tmp_path / "small.txt"
+        f.write_text("Hello")
+        result = await parse_document(str(f))
+        assert result.text == "Hello"


### PR DESCRIPTION
## 요약
- 모든 워크플로우 Activity에 Temporal 재시도 정책 적용으로 일시적 장애 복원력 확보
- 문서 파서에 50MB 파일 크기 제한 추가로 메모리 과부하 방지

## 변경사항
- `interview_workflow.py`: 3가지 RetryPolicy 정의 및 모든 `execute_activity` 호출에 적용
  - `DEFAULT_RETRY`: 3회, 1초 시작, 30초 최대 (DB/일반 작업)
  - `LLM_RETRY`: 3회, 2초 시작, ValueError 비재시도 (LLM 호출)
  - `EXTERNAL_API_RETRY`: 4회, 3초 시작, 120초 최대 (GitHub/LinkedIn/Proxycurl)
- `document_parser.py`: `MAX_FILE_SIZE_MB=50` 상수 및 크기 검증 로직
- `test_retry_policies.py`: 12개 테스트 추가 (133→145 tests)

## 테스트 계획
- [x] 3가지 재시도 정책 상수 검증 (attempts, backoff, interval)
- [x] LLM 재시도 정책의 non_retryable_error_types 확인
- [x] 워크플로우 소스코드에 retry_policy 사용 확인
- [x] 문서 크기 제한 상수 검증
- [x] 큰 파일 거부 동작 확인
- [x] 작은 파일 정상 처리 확인
- [x] 전체 145 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)