### PR TITLE
P19: 결과 내보내기 및 Job 목록 페이지네이션

### DIFF
--- a/frontend/src/pages/JobListPage.tsx
+++ b/frontend/src/pages/JobListPage.tsx
@@ -1,17 +1,23 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useJob } from '../hooks/useJob'
 
+const PAGE_SIZE = 10
+
 export function JobListPage() {
   const { t } = useTranslation()
   const { jobs, loading, fetchJobs, deleteJob } = useJob()
+  const [page, setPage] = useState(1)
 
   useEffect(() => {
     fetchJobs()
   }, [fetchJobs])
 
   if (loading) return <p>{t('loading')}</p>
+
+  const totalPages = Math.max(1, Math.ceil(jobs.length / PAGE_SIZE))
+  const paginated = jobs.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
 
   return (
     <div>
@@ -28,27 +34,52 @@ export function JobListPage() {
       {jobs.length === 0 ? (
         <p className="text-gray-500">{t('no_jobs')}</p>
       ) : (
-        <div className="space-y-3">
-          {jobs.map((job) => (
-            <div key={job.job_id} className="bg-white rounded-lg shadow p-4 flex items-center justify-between">
-              <div>
-                <Link to={`/jobs/${job.job_id}`} className="text-blue-600 hover:underline font-medium">
-                  {job.job_id.slice(0, 8)}...
-                </Link>
-                <span className="ml-3 text-sm text-gray-500">{job.status}</span>
-                <span className="ml-3 text-sm text-gray-400">
-                  {new Date(job.created_at).toLocaleString()}
-                </span>
+        <>
+          <div className="space-y-3">
+            {paginated.map((job) => (
+              <div key={job.job_id} className="bg-white rounded-lg shadow p-4 flex items-center justify-between">
+                <div>
+                  <Link to={`/jobs/${job.job_id}`} className="text-blue-600 hover:underline font-medium">
+                    {job.job_id.slice(0, 8)}...
+                  </Link>
+                  <span className="ml-3 text-sm text-gray-500">{job.status}</span>
+                  <span className="ml-3 text-sm text-gray-400">
+                    {new Date(job.created_at).toLocaleString()}
+                  </span>
+                </div>
+                <button
+                  onClick={() => deleteJob(job.job_id)}
+                  className="text-sm text-red-500 hover:text-red-700"
+                >
+                  삭제
+                </button>
               </div>
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex justify-center items-center gap-2 mt-6">
               <button
-                onClick={() => deleteJob(job.job_id)}
-                className="text-sm text-red-500 hover:text-red-700"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+                className="px-3 py-1 text-sm rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-100"
               >
-                삭제
+                이전
+              </button>
+              <span className="text-sm text-gray-600">
+                {page} / {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                className="px-3 py-1 text-sm rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-100"
+              >
+                다음
               </button>
             </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -4,6 +4,16 @@ import { useTranslation } from 'react-i18next'
 import { apiFetch } from '../lib/api'
 import { QuestionCard } from '../components/QuestionCard'
 
+function downloadJSON(data: unknown, filename: string) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
 const CATEGORIES = [
   { key: 'all', label: '전체' },
   { key: 'role_fit', label: '직무 적합성' },
@@ -57,11 +67,25 @@ export function ResultPage() {
       {/* Header */}
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold text-gray-900">면접 스크립트</h1>
-        {maxScore > 0 && (
-          <div className="text-lg font-semibold text-gray-700">
-            점수: {totalScore}/{maxScore} ({Math.round((totalScore / maxScore) * 100)}%)
-          </div>
-        )}
+        <div className="flex items-center gap-3">
+          {maxScore > 0 && (
+            <div className="text-lg font-semibold text-gray-700">
+              점수: {totalScore}/{maxScore} ({Math.round((totalScore / maxScore) * 100)}%)
+            </div>
+          )}
+          <button
+            onClick={() => downloadJSON(script, `interview-${jobId?.slice(0, 8)}.json`)}
+            className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200"
+          >
+            JSON 내보내기
+          </button>
+          <button
+            onClick={() => window.print()}
+            className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200"
+          >
+            PDF 인쇄
+          </button>
+        </div>
       </div>
 
       {/* Candidate Summary */}


### PR DESCRIPTION
## 요약
- ResultPage에 **JSON 내보내기** 버튼 추가 (Blob 다운로드)
- ResultPage에 **PDF 인쇄** 버튼 추가 (`window.print()`)
- JobListPage에 **클라이언트 사이드 페이지네이션** 추가 (10개/페이지)

## 변경 파일
- `frontend/src/pages/ResultPage.tsx` — 내보내기 버튼 2개 추가
- `frontend/src/pages/JobListPage.tsx` — 페이지네이션 UI 및 로직

## 테스트 계획
- [ ] 결과 페이지에서 JSON 내보내기 클릭 시 파일 다운로드 확인
- [ ] PDF 인쇄 클릭 시 브라우저 인쇄 다이얼로그 표시 확인
- [ ] Job 11개 이상일 때 페이지네이션 버튼 표시 확인
- [ ] Vite 빌드 및 TypeScript 검사 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)