### PR TITLE
P21: 404 페이지, 에러 상태 노출, 환경변수 정리

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { JobListPage } from './pages/JobListPage'
 import { CreateJobPage } from './pages/CreateJobPage'
 import { JobStatusPage } from './pages/JobStatusPage'
 import { ResultPage } from './pages/ResultPage'
+import { NotFoundPage } from './pages/NotFoundPage'
 import { useAuth } from './hooks/useAuth'
 import './i18n'
 
@@ -43,6 +44,7 @@ function App() {
             element={isAuthenticated ? <ResultPage /> : <Navigate to="/login" />}
           />
           <Route path="/" element={<Navigate to={isAuthenticated ? '/jobs' : '/login'} />} />
+          <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/hooks/useJob.ts
+++ b/frontend/src/hooks/useJob.ts
@@ -11,14 +11,16 @@ interface Job {
 export function useJob() {
   const [jobs, setJobs] = useState<Job[]>([])
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const fetchJobs = useCallback(async () => {
     setLoading(true)
+    setError(null)
     try {
       const data = await apiFetch('/jobs')
       setJobs(data)
     } catch (e) {
-      console.error('Failed to fetch jobs:', e)
+      setError(String(e))
     } finally {
       setLoading(false)
     }
@@ -40,5 +42,5 @@ export function useJob() {
     setJobs((prev) => prev.filter((j) => j.job_id !== jobId))
   }, [])
 
-  return { jobs, loading, fetchJobs, createJob, getJob, deleteJob }
+  return { jobs, loading, error, fetchJobs, createJob, getJob, deleteJob }
 }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -60,6 +60,11 @@ const resources = {
       // Error boundary
       error_occurred: '오류가 발생했습니다',
       retry: '다시 시도',
+      // 404
+      page_not_found: '페이지를 찾을 수 없습니다.',
+      go_home: '홈으로 돌아가기',
+      // Error states
+      fetch_error: '데이터를 불러오는 데 실패했습니다.',
     },
   },
   en: {
@@ -114,6 +119,9 @@ const resources = {
       minutes: 'min',
       error_occurred: 'An error occurred',
       retry: 'Retry',
+      page_not_found: 'Page not found.',
+      go_home: 'Go Home',
+      fetch_error: 'Failed to load data.',
     },
   },
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-const API_BASE = '/api/v1'
+const API_BASE = import.meta.env.VITE_API_BASE || '/api/v1'
 
 let accessToken: string | null = null
 

--- a/frontend/src/pages/JobListPage.tsx
+++ b/frontend/src/pages/JobListPage.tsx
@@ -7,7 +7,7 @@ const PAGE_SIZE = 10
 
 export function JobListPage() {
   const { t } = useTranslation()
-  const { jobs, loading, fetchJobs, deleteJob } = useJob()
+  const { jobs, loading, error, fetchJobs, deleteJob } = useJob()
   const [page, setPage] = useState(1)
 
   useEffect(() => {
@@ -15,6 +15,7 @@ export function JobListPage() {
   }, [fetchJobs])
 
   if (loading) return <p>{t('loading')}</p>
+  if (error) return <p className="text-red-600">{t('fetch_error')}</p>
 
   const totalPages = Math.max(1, Math.ceil(jobs.length / PAGE_SIZE))
   const paginated = jobs.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-const BACKEND = 'http://localhost:8000'
+const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000'
 
 export function LoginPage() {
   const { t } = useTranslation()

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+export function NotFoundPage() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+      <h1 className="text-6xl font-bold text-gray-300">404</h1>
+      <p className="text-gray-600">{t('page_not_found')}</p>
+      <Link
+        to="/"
+        className="mt-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+      >
+        {t('go_home')}
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## 요약
- **404 페이지**: `NotFoundPage` 컴포넌트 추가, App.tsx에 `path="*"` catch-all 라우트 등록
- **에러 상태 노출**: `useJob` 훅에 `error` 상태 추가, `JobListPage`에서 에러 메시지 표시
- **환경변수**: `api.ts`의 API_BASE → `VITE_API_BASE`, `LoginPage`의 BACKEND → `VITE_BACKEND_URL`
- **i18n**: `page_not_found`, `go_home`, `fetch_error` 번역 키 추가

## 변경 파일
- `frontend/src/pages/NotFoundPage.tsx` — 신규 404 페이지
- `frontend/src/App.tsx` — catch-all 라우트 추가
- `frontend/src/hooks/useJob.ts` — error 상태 추가
- `frontend/src/pages/JobListPage.tsx` — 에러 UI 표시
- `frontend/src/lib/api.ts` — VITE_API_BASE 환경변수
- `frontend/src/pages/LoginPage.tsx` — VITE_BACKEND_URL 환경변수
- `frontend/src/i18n.ts` — 신규 번역 키 3개

## 테스트 계획
- [ ] 존재하지 않는 URL 접속 시 404 페이지 표시 확인
- [ ] API 오류 시 Job 목록에 에러 메시지 표시 확인
- [ ] `.env`에 `VITE_API_BASE` 설정 시 API 경로 변경 확인
- [ ] TypeScript 검사 통과 ✅
- [ ] Vite 빌드 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)