### PR TITLE
P22: Auth 환경변수, Job 생성 에러 피드백, WebSocket 재연결

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { setToken, getToken } from '../lib/api'
 
+const BACKEND = import.meta.env.VITE_BACKEND_URL || ''
+
 interface User {
   id: string
   email: string
@@ -19,7 +21,7 @@ export function useAuth() {
       return
     }
     try {
-      const res = await fetch('/auth/me', {
+      const res = await fetch(`${BACKEND}/auth/me`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (!res.ok) throw new Error('Unauthorized')

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -14,15 +14,20 @@ interface UseWebSocketReturn {
   error: string | null
 }
 
+const MAX_RECONNECT_ATTEMPTS = 5
+const BASE_DELAY_MS = 1000
+
 export function useWebSocket(jobId: string | undefined): UseWebSocketReturn {
   const [progress, setProgress] = useState<WSProgress | null>(null)
   const [connected, setConnected] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const attemptRef = useRef(0)
+  const terminalRef = useRef(false)
 
   const connect = useCallback(() => {
-    if (!jobId) return
+    if (!jobId || terminalRef.current) return
 
     const token = getToken()
     if (!token) return
@@ -38,6 +43,7 @@ export function useWebSocket(jobId: string | undefined): UseWebSocketReturn {
       ws.onopen = () => {
         setConnected(true)
         setError(null)
+        attemptRef.current = 0
       }
 
       ws.onmessage = (event) => {
@@ -45,8 +51,8 @@ export function useWebSocket(jobId: string | undefined): UseWebSocketReturn {
           const data = JSON.parse(event.data) as WSProgress
           setProgress(data)
 
-          // Terminal states — close connection
           if (data.event === 'done' || data.status === 'completed' || data.status === 'failed') {
+            terminalRef.current = true
             ws.close()
           }
         } catch {
@@ -57,6 +63,13 @@ export function useWebSocket(jobId: string | undefined): UseWebSocketReturn {
       ws.onclose = () => {
         setConnected(false)
         wsRef.current = null
+
+        // Auto-reconnect with exponential backoff if not terminal
+        if (!terminalRef.current && attemptRef.current < MAX_RECONNECT_ATTEMPTS) {
+          const delay = BASE_DELAY_MS * Math.pow(2, attemptRef.current)
+          attemptRef.current += 1
+          reconnectRef.current = setTimeout(connect, delay)
+        }
       }
 
       ws.onerror = () => {
@@ -69,9 +82,12 @@ export function useWebSocket(jobId: string | undefined): UseWebSocketReturn {
   }, [jobId])
 
   useEffect(() => {
+    terminalRef.current = false
+    attemptRef.current = 0
     connect()
 
     return () => {
+      terminalRef.current = true
       if (wsRef.current) {
         wsRef.current.close()
         wsRef.current = null

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -65,6 +65,14 @@ const resources = {
       go_home: '홈으로 돌아가기',
       // Error states
       fetch_error: '데이터를 불러오는 데 실패했습니다.',
+      // Create job
+      jd_label: '채용공고 (JD)',
+      experience_level: '경험 레벨',
+      level_entry: '신입',
+      level_junior: '주니어',
+      level_mid: '미들',
+      level_senior: '시니어',
+      level_executive: 'CTO/VP',
     },
   },
   en: {
@@ -122,6 +130,13 @@ const resources = {
       page_not_found: 'Page not found.',
       go_home: 'Go Home',
       fetch_error: 'Failed to load data.',
+      jd_label: 'Job Description (JD)',
+      experience_level: 'Experience Level',
+      level_entry: 'Entry',
+      level_junior: 'Junior',
+      level_mid: 'Mid-level',
+      level_senior: 'Senior',
+      level_executive: 'CTO/VP',
     },
   },
 }

--- a/frontend/src/pages/CreateJobPage.tsx
+++ b/frontend/src/pages/CreateJobPage.tsx
@@ -11,12 +11,14 @@ export function CreateJobPage() {
   const [jdText, setJdText] = useState('')
   const [experienceLevel, setExperienceLevel] = useState('미들')
   const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!jdText.trim()) return
 
     setSubmitting(true)
+    setError(null)
     try {
       const job = await createJob({
         jd_text: jdText,
@@ -24,7 +26,7 @@ export function CreateJobPage() {
       })
       navigate(`/jobs/${job.job_id}`)
     } catch (err) {
-      console.error('Failed to create job:', err)
+      setError(err instanceof Error ? err.message : String(err))
     } finally {
       setSubmitting(false)
     }
@@ -36,7 +38,7 @@ export function CreateJobPage() {
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            채용공고 (JD) *
+            {t('jd_label')} *
           </label>
           <textarea
             value={jdText}
@@ -51,20 +53,26 @@ export function CreateJobPage() {
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            경험 레벨
+            {t('experience_level')}
           </label>
           <select
             value={experienceLevel}
             onChange={(e) => setExperienceLevel(e.target.value)}
             className="border border-gray-300 rounded-lg px-3 py-2 text-gray-900"
           >
-            <option value="신입">신입</option>
-            <option value="주니어">주니어</option>
-            <option value="미들">미들</option>
-            <option value="시니어">시니어</option>
-            <option value="CTO/VP">CTO/VP</option>
+            <option value="신입">{t('level_entry')}</option>
+            <option value="주니어">{t('level_junior')}</option>
+            <option value="미들">{t('level_mid')}</option>
+            <option value="시니어">{t('level_senior')}</option>
+            <option value="CTO/VP">{t('level_executive')}</option>
           </select>
         </div>
+
+        {error && (
+          <div className="p-3 bg-red-50 text-red-700 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
 
         <button
           type="submit"


### PR DESCRIPTION
## 요약
- **useAuth**: `/auth/me` 경로에 `VITE_BACKEND_URL` 환경변수 적용 (하드코딩 제거)
- **CreateJobPage**: 제출 실패 시 에러 메시지 UI 표시, 폼 라벨 i18n 적용
- **useWebSocket**: 지수 백오프 자동 재연결 (최대 5회, 1s→2s→4s→8s→16s)
- **i18n**: `jd_label`, `experience_level`, `level_*` 등 7개 번역 키 추가

## 변경 파일
- `frontend/src/hooks/useAuth.ts` — VITE_BACKEND_URL 환경변수
- `frontend/src/pages/CreateJobPage.tsx` — 에러 UI + i18n 라벨
- `frontend/src/hooks/useWebSocket.ts` — 지수 백오프 재연결 로직
- `frontend/src/i18n.ts` — 번역 키 7개 추가

## 테스트 계획
- [ ] Job 생성 실패 시 빨간색 에러 메시지 표시 확인
- [ ] 언어 전환 시 폼 라벨 변경 확인
- [ ] WebSocket 끊김 시 자동 재연결 확인
- [ ] TypeScript 검사 통과 ✅
- [ ] Vite 빌드 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)