### PR TITLE
P23: 접근성(a11y) 개선 — 포커스 링, 스킵 링크, ARIA, 키보드

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { Navbar } from './Navbar'
 
 interface LayoutProps {
@@ -7,10 +8,15 @@ interface LayoutProps {
 }
 
 export function Layout({ user, onLogout }: LayoutProps) {
+  const { t } = useTranslation()
+
   return (
     <div className="min-h-screen bg-gray-50">
+      <a href="#main-content" className="skip-link">
+        {t('skip_to_content')}
+      </a>
       <Navbar user={user} onLogout={onLogout} />
-      <main className="max-w-5xl mx-auto px-4 py-8">
+      <main id="main-content" className="max-w-5xl mx-auto px-4 py-8">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -14,17 +14,21 @@ export function Navbar({ user, onLogout }: NavbarProps) {
   }
 
   return (
-    <nav className="bg-gray-900 text-white px-6 py-3 flex items-center justify-between">
+    <nav className="bg-gray-900 text-white px-6 py-3 flex items-center justify-between" aria-label={t('nav_label')}>
       <Link to="/" className="text-xl font-bold">{t('app_title')}</Link>
       <div className="flex items-center gap-4">
-        <button onClick={toggleLang} className="text-sm px-2 py-1 border border-gray-600 rounded">
+        <button
+          onClick={toggleLang}
+          className="text-sm px-2 py-1 border border-gray-600 rounded"
+          aria-label={t('switch_language')}
+        >
           {i18n.language === 'ko' ? 'EN' : 'KO'}
         </button>
         {user ? (
           <>
             <Link to="/jobs" className="hover:text-gray-300">{t('jobs')}</Link>
             <Link to="/jobs/new" className="hover:text-gray-300">{t('create_job')}</Link>
-            <span className="text-sm text-gray-400">{user.display_name}</span>
+            <span className="text-sm text-gray-400" aria-label={t('logged_in_as')}>{user.display_name}</span>
             <button onClick={onLogout} className="text-sm text-red-400 hover:text-red-300">
               {t('logout')}
             </button>

--- a/frontend/src/components/QuestionCard.tsx
+++ b/frontend/src/components/QuestionCard.tsx
@@ -37,9 +37,12 @@ export function QuestionCard({ question, index, onScoreChange }: QuestionCardPro
 
   return (
     <div className="bg-white rounded-lg shadow border border-gray-200 overflow-hidden">
-      <div
-        className="p-4 cursor-pointer flex items-center justify-between hover:bg-gray-50"
+      <button
+        type="button"
+        className="w-full p-4 cursor-pointer flex items-center justify-between hover:bg-gray-50 text-left"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-controls={`question-${index}-details`}
       >
         <div className="flex-1">
           <span className="text-sm text-gray-500 mr-2">Q{index + 1}</span>
@@ -52,12 +55,12 @@ export function QuestionCard({ question, index, onScoreChange }: QuestionCardPro
           {question.time_allocation_minutes && (
             <span className="text-xs text-gray-400">{question.time_allocation_minutes}{t('minutes')}</span>
           )}
-          <span className="text-gray-400">{expanded ? '▲' : '▼'}</span>
+          <span className="text-gray-400" aria-hidden="true">{expanded ? '▲' : '▼'}</span>
         </div>
-      </div>
+      </button>
 
       {expanded && (
-        <div className="px-4 pb-4 space-y-3 border-t border-gray-100">
+        <div id={`question-${index}-details`} className="px-4 pb-4 space-y-3 border-t border-gray-100" role="region" aria-label={`Q${index + 1} ${t('expected_answer')}`}>
           {question.expected_answer && (
             <div className="mt-3">
               <h4 className="text-sm font-semibold text-gray-700 mb-1">{t('expected_answer')}</h4>
@@ -110,6 +113,8 @@ export function QuestionCard({ question, index, onScoreChange }: QuestionCardPro
               <button
                 key={s}
                 onClick={() => handleScore(s)}
+                aria-label={`${t('scoring')} ${s}/5`}
+                aria-pressed={score === s}
                 className={`w-8 h-8 rounded-full text-sm font-medium border ${
                   score === s
                     ? 'bg-blue-600 text-white border-blue-600'

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -73,6 +73,11 @@ const resources = {
       level_mid: '미들',
       level_senior: '시니어',
       level_executive: 'CTO/VP',
+      // Accessibility
+      skip_to_content: '본문으로 건너뛰기',
+      nav_label: '메인 네비게이션',
+      switch_language: '언어 전환',
+      logged_in_as: '로그인 사용자',
     },
   },
   en: {
@@ -137,6 +142,10 @@ const resources = {
       level_mid: 'Mid-level',
       level_senior: 'Senior',
       level_executive: 'CTO/VP',
+      skip_to_content: 'Skip to content',
+      nav_label: 'Main navigation',
+      switch_language: 'Switch language',
+      logged_in_as: 'Logged in as',
     },
   },
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,28 @@
 @import "tailwindcss";
 
+/* Focus ring for keyboard navigation */
+*:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Skip to content link */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 999;
+  padding: 0.5rem 1rem;
+  background: #1f2937;
+  color: white;
+  font-size: 0.875rem;
+}
+
+.skip-link:focus {
+  left: 0;
+}
+
 @media print {
   body {
     background: white !important;


### PR DESCRIPTION
## 요약
- **포커스 링**: `focus-visible` 스타일 추가 (파란색 2px outline)
- **스킵 링크**: Layout에 `skip-to-content` 링크 추가 (Tab 키로 접근)
- **ARIA 속성**: Navbar(`aria-label`), QuestionCard(`aria-expanded`, `aria-controls`, `aria-pressed`)
- **키보드 지원**: QuestionCard 헤더를 `<div>` → `<button>`으로 변경 (Enter/Space로 펼침)
- **i18n**: 접근성 관련 번역 키 4개 추가

## 변경 파일
- `frontend/src/index.css` — focus-visible, skip-link 스타일
- `frontend/src/components/Layout.tsx` — skip-to-content 링크, main id
- `frontend/src/components/Navbar.tsx` — aria-label 속성
- `frontend/src/components/QuestionCard.tsx` — button 전환, ARIA 속성
- `frontend/src/i18n.ts` — 접근성 번역 키 4개

## 테스트 계획
- [ ] Tab 키로 모든 인터랙티브 요소 순회 가능 확인
- [ ] Tab 첫 번째에 "본문으로 건너뛰기" 링크 표시 확인
- [ ] QuestionCard Enter/Space로 펼치기/접기 확인
- [ ] 포커스 링 파란색 outline 확인
- [ ] TypeScript 검사 통과 ✅
- [ ] Vite 빌드 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)