### PR TITLE
feat: Langfuse Phase 3 - 프롬프트 관리 통합

### DIFF
--- a/backend/app/prompts/__init__.py
+++ b/backend/app/prompts/__init__.py
@@ -1,30 +1,212 @@
 """
 backend/app/prompts/__init__.py
-YAML 프롬프트 템플릿 로더
+YAML 프롬프트 템플릿 로더 + Langfuse 프롬프트 관리 통합
 """
+import logging
 import os
 from functools import lru_cache
+from typing import Any
 
 import yaml
 
+logger = logging.getLogger(__name__)
 PROMPTS_DIR = os.path.dirname(__file__)
+
+# Cache for Langfuse prompts (name -> prompt object)
+_langfuse_prompt_cache: dict[str, Any] = {}
 
 
 @lru_cache(maxsize=32)
 def _load_yaml(filename: str) -> dict:
+    """Load YAML file from local prompts directory."""
     path = os.path.join(PROMPTS_DIR, filename)
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
+def _get_langfuse_prompt_name(filename: str, key: str) -> str:
+    """Generate Langfuse prompt name from filename and key.
+
+    Convention: filename without .yaml + underscore + key
+    Example: jd_analysis.yaml + analyze → jd_analysis_analyze
+    """
+    base = filename.replace(".yaml", "")
+    return f"{base}_{key}"
+
+
+def _fetch_langfuse_prompt(prompt_name: str, **kwargs) -> str | None:
+    """Try to fetch and compile a prompt from Langfuse.
+
+    Args:
+        prompt_name: Langfuse prompt name (e.g., "jd_analysis_analyze")
+        **kwargs: Variables to compile into the prompt
+
+    Returns:
+        Compiled prompt string if successful, None otherwise
+    """
+    from app.core.observability import is_langfuse_enabled, get_langfuse_client
+
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        # Check cache first
+        if prompt_name not in _langfuse_prompt_cache:
+            # Fetch prompt from Langfuse
+            prompt = client.get_prompt(prompt_name)
+            _langfuse_prompt_cache[prompt_name] = prompt
+            logger.debug(f"Fetched Langfuse prompt: {prompt_name} v{prompt.version}")
+
+        prompt = _langfuse_prompt_cache[prompt_name]
+
+        # Compile prompt with variables
+        compiled = prompt.compile(**kwargs)
+
+        # Log prompt usage for observability
+        _log_prompt_usage(prompt_name, prompt.version, "langfuse", kwargs.keys())
+
+        return compiled
+
+    except Exception as e:
+        logger.debug(f"Langfuse prompt fetch failed for {prompt_name}: {e}")
+        return None
+
+
+def _log_prompt_usage(
+    prompt_name: str,
+    version: str | int | None,
+    source: str,
+    variable_names: list[str] | None = None,
+):
+    """Log prompt usage to Langfuse for tracking."""
+    from app.core.observability import is_langfuse_enabled, log_event
+
+    if not is_langfuse_enabled():
+        return
+
+    log_event(
+        name="prompt_usage",
+        metadata={
+            "prompt_name": prompt_name,
+            "prompt_version": str(version) if version else "local",
+            "source": source,  # "langfuse" or "yaml"
+            "variables": list(variable_names) if variable_names else [],
+        },
+    )
+
+
 def get_prompt(filename: str, key: str, **kwargs) -> str:
-    """YAML에서 프롬프트 템플릿을 로드하고 변수를 치환합니다.
+    """프롬프트 템플릿을 로드하고 변수를 치환합니다.
+
+    Langfuse에서 먼저 프롬프트를 가져오고, 실패하면 로컬 YAML에서 로드합니다.
 
     Args:
         filename: YAML 파일명 (예: "jd_analysis.yaml")
         key: 프롬프트 키 (예: "analyze")
         **kwargs: 템플릿 변수
+
+    Returns:
+        Compiled prompt string
     """
+    # Try Langfuse first
+    langfuse_name = _get_langfuse_prompt_name(filename, key)
+    prompt = _fetch_langfuse_prompt(langfuse_name, **kwargs)
+
+    if prompt is not None:
+        return prompt
+
+    # Fallback to local YAML
     data = _load_yaml(filename)
     template = data["prompts"][key]["template"]
-    return template.format(**kwargs)
+    result = template.format(**kwargs)
+
+    # Log YAML fallback usage
+    _log_prompt_usage(langfuse_name, None, "yaml", kwargs.keys())
+
+    return result
+
+
+def get_prompt_with_metadata(filename: str, key: str, **kwargs) -> dict:
+    """프롬프트와 메타데이터를 함께 반환합니다.
+
+    Args:
+        filename: YAML 파일명
+        key: 프롬프트 키
+        **kwargs: 템플릿 변수
+
+    Returns:
+        {
+            "prompt": str,
+            "source": "langfuse" | "yaml",
+            "version": str | None,
+            "name": str
+        }
+    """
+    from app.core.observability import is_langfuse_enabled, get_langfuse_client
+
+    langfuse_name = _get_langfuse_prompt_name(filename, key)
+
+    # Try Langfuse
+    if is_langfuse_enabled():
+        try:
+            client = get_langfuse_client()
+            if client:
+                if langfuse_name not in _langfuse_prompt_cache:
+                    prompt_obj = client.get_prompt(langfuse_name)
+                    _langfuse_prompt_cache[langfuse_name] = prompt_obj
+
+                prompt_obj = _langfuse_prompt_cache[langfuse_name]
+                compiled = prompt_obj.compile(**kwargs)
+
+                _log_prompt_usage(langfuse_name, prompt_obj.version, "langfuse", kwargs.keys())
+
+                return {
+                    "prompt": compiled,
+                    "source": "langfuse",
+                    "version": str(prompt_obj.version),
+                    "name": langfuse_name,
+                }
+        except Exception as e:
+            logger.debug(f"Langfuse prompt not available: {e}")
+
+    # Fallback to YAML
+    data = _load_yaml(filename)
+    template = data["prompts"][key]["template"]
+    result = template.format(**kwargs)
+
+    _log_prompt_usage(langfuse_name, None, "yaml", kwargs.keys())
+
+    return {
+        "prompt": result,
+        "source": "yaml",
+        "version": None,
+        "name": langfuse_name,
+    }
+
+
+def clear_prompt_cache():
+    """Clear the Langfuse prompt cache (useful for testing or hot-reload)."""
+    _langfuse_prompt_cache.clear()
+    _load_yaml.cache_clear()
+    logger.info("Prompt cache cleared")
+
+
+def list_local_prompts() -> dict[str, list[str]]:
+    """List all available prompts from local YAML files.
+
+    Returns:
+        {filename: [prompt_keys]}
+    """
+    result = {}
+    for filename in os.listdir(PROMPTS_DIR):
+        if filename.endswith(".yaml"):
+            try:
+                data = _load_yaml(filename)
+                result[filename] = list(data.get("prompts", {}).keys())
+            except Exception:
+                pass
+    return result

--- a/backend/tests/test_prompts.py
+++ b/backend/tests/test_prompts.py
@@ -1,4 +1,4 @@
-"""Unit tests for prompt template loader."""
+"""Unit tests for prompt template loader and Langfuse integration."""
 import pytest
 from app.prompts import get_prompt, _load_yaml
 
@@ -87,3 +87,225 @@ class TestYamlStructure:
             for key, value in data["prompts"].items():
                 assert "template" in value, f"{f}:{key} missing 'template'"
                 assert len(value["template"]) > 10, f"{f}:{key} template too short"
+
+
+# =============================================================================
+# Phase 3: Langfuse Prompt Management Integration Tests
+# =============================================================================
+
+class TestPhase3LangfusePromptFunctions:
+    """Test new Phase 3 prompt management functions."""
+
+    def test_get_prompt_with_metadata_importable(self):
+        """get_prompt_with_metadata function is importable."""
+        from app.prompts import get_prompt_with_metadata
+        assert callable(get_prompt_with_metadata)
+
+    def test_clear_prompt_cache_importable(self):
+        """clear_prompt_cache function is importable."""
+        from app.prompts import clear_prompt_cache
+        assert callable(clear_prompt_cache)
+
+    def test_list_local_prompts_importable(self):
+        """list_local_prompts function is importable."""
+        from app.prompts import list_local_prompts
+        assert callable(list_local_prompts)
+
+    def test_get_langfuse_prompt_name_importable(self):
+        """_get_langfuse_prompt_name function is importable."""
+        from app.prompts import _get_langfuse_prompt_name
+        assert callable(_get_langfuse_prompt_name)
+
+    def test_fetch_langfuse_prompt_importable(self):
+        """_fetch_langfuse_prompt function is importable."""
+        from app.prompts import _fetch_langfuse_prompt
+        assert callable(_fetch_langfuse_prompt)
+
+
+class TestPhase3PromptNameGeneration:
+    """Test Langfuse prompt name generation."""
+
+    def test_prompt_name_from_jd_analysis(self):
+        """Generates correct name for jd_analysis prompts."""
+        from app.prompts import _get_langfuse_prompt_name
+        name = _get_langfuse_prompt_name("jd_analysis.yaml", "analyze")
+        assert name == "jd_analysis_analyze"
+
+    def test_prompt_name_from_question_generation(self):
+        """Generates correct name for question_generation prompts."""
+        from app.prompts import _get_langfuse_prompt_name
+        name = _get_langfuse_prompt_name("question_generation.yaml", "craft_question")
+        assert name == "question_generation_craft_question"
+
+    def test_prompt_name_from_finalization(self):
+        """Generates correct name for finalization prompts."""
+        from app.prompts import _get_langfuse_prompt_name
+        name = _get_langfuse_prompt_name("finalization.yaml", "candidate_summary")
+        assert name == "finalization_candidate_summary"
+
+
+class TestPhase3PromptMetadata:
+    """Test prompt metadata functionality."""
+
+    def test_get_prompt_with_metadata_returns_dict(self, monkeypatch):
+        """get_prompt_with_metadata returns proper structure."""
+        # Disable Langfuse for predictable behavior
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.prompts import get_prompt_with_metadata
+        result = get_prompt_with_metadata(
+            "jd_analysis.yaml",
+            "analyze",
+            jd_text="Test JD"
+        )
+
+        assert isinstance(result, dict)
+        assert "prompt" in result
+        assert "source" in result
+        assert "version" in result
+        assert "name" in result
+
+    def test_yaml_fallback_sets_correct_metadata(self, monkeypatch):
+        """YAML fallback sets source to 'yaml' and version to None."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.prompts import get_prompt_with_metadata
+        result = get_prompt_with_metadata(
+            "jd_analysis.yaml",
+            "analyze",
+            jd_text="Test JD"
+        )
+
+        assert result["source"] == "yaml"
+        assert result["version"] is None
+        assert result["name"] == "jd_analysis_analyze"
+        assert "Test JD" in result["prompt"]
+
+
+class TestPhase3PromptCache:
+    """Test prompt caching functionality."""
+
+    def test_clear_cache_function(self):
+        """clear_prompt_cache executes without error."""
+        from app.prompts import clear_prompt_cache, _langfuse_prompt_cache
+
+        # Add test item to cache
+        _langfuse_prompt_cache["test_key"] = "test_value"
+        assert "test_key" in _langfuse_prompt_cache
+
+        # Clear cache
+        clear_prompt_cache()
+
+        # Verify cleared
+        assert "test_key" not in _langfuse_prompt_cache
+
+    def test_list_local_prompts_returns_all_files(self):
+        """list_local_prompts returns all YAML files."""
+        from app.prompts import list_local_prompts
+
+        result = list_local_prompts()
+
+        assert isinstance(result, dict)
+        assert "jd_analysis.yaml" in result
+        assert "question_generation.yaml" in result
+        assert "document_analysis.yaml" in result
+        assert "quality_review.yaml" in result
+        assert "finalization.yaml" in result
+
+    def test_list_local_prompts_includes_keys(self):
+        """list_local_prompts includes prompt keys for each file."""
+        from app.prompts import list_local_prompts
+
+        result = list_local_prompts()
+
+        # Check specific keys exist
+        assert "analyze" in result["jd_analysis.yaml"]
+        assert "select_topics" in result["question_generation.yaml"]
+        assert "craft_question" in result["question_generation.yaml"]
+
+
+class TestPhase3LangfuseFallback:
+    """Test Langfuse to YAML fallback behavior."""
+
+    def test_langfuse_disabled_uses_yaml(self, monkeypatch):
+        """When Langfuse disabled, get_prompt uses YAML."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.prompts import get_prompt
+        prompt = get_prompt("jd_analysis.yaml", "analyze", jd_text="Test")
+
+        # Should work with YAML fallback
+        assert "Test" in prompt
+
+    def test_fetch_langfuse_prompt_returns_none_when_disabled(self, monkeypatch):
+        """_fetch_langfuse_prompt returns None when Langfuse disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.prompts import _fetch_langfuse_prompt
+        result = _fetch_langfuse_prompt("test_prompt", jd_text="test")
+
+        assert result is None
+
+    def test_get_prompt_backward_compatible(self, monkeypatch):
+        """get_prompt remains backward compatible with existing code."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.prompts import get_prompt
+
+        # Test all existing prompt types still work
+        prompt1 = get_prompt("jd_analysis.yaml", "analyze", jd_text="JD")
+        assert "JD" in prompt1
+
+        prompt2 = get_prompt(
+            "question_generation.yaml", "select_topics",
+            max_questions=25, experience_level="Senior", candidates="data"
+        )
+        assert "25" in prompt2
+
+
+class TestPhase3PromptLogging:
+    """Test prompt usage logging."""
+
+    def test_log_prompt_usage_importable(self):
+        """_log_prompt_usage function is importable."""
+        from app.prompts import _log_prompt_usage
+        assert callable(_log_prompt_usage)
+
+    def test_log_prompt_usage_no_error_when_disabled(self, monkeypatch):
+        """_log_prompt_usage doesn't raise when Langfuse disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.prompts import _log_prompt_usage
+
+        # Should not raise
+        _log_prompt_usage("test_prompt", "v1", "yaml", ["var1"])


### PR DESCRIPTION
## 요약

Langfuse 프롬프트 관리 기능을 기존 YAML 프롬프트 시스템에 통합했습니다.

### 주요 기능
- **Langfuse 우선**: 프롬프트를 먼저 Langfuse에서 가져옴
- **YAML 폴백**: Langfuse 실패/비활성화 시 로컬 YAML 사용
- **버전 추적**: 어떤 프롬프트 버전이 사용되었는지 추적
- **100% 하위 호환**: 기존 `get_prompt()` API 변경 없음

## 프롬프트 이름 규칙

```
{yaml_filename}_{prompt_key}

예시:
- jd_analysis.yaml + analyze → jd_analysis_analyze
- question_generation.yaml + craft_question → question_generation_craft_question
```

## 새 함수들

### `get_prompt_with_metadata(filename, key, **kwargs)`
프롬프트와 함께 소스 정보를 반환합니다:
```python
{
    "prompt": "...",
    "source": "langfuse" | "yaml",
    "version": "v2" | None,
    "name": "jd_analysis_analyze"
}
```

### `clear_prompt_cache()`
프롬프트 캐시를 초기화합니다 (핫 리로드 용도).

### `list_local_prompts()`
로컬 YAML 파일의 모든 프롬프트를 나열합니다.

## 폴백 동작

```
Langfuse 활성화 시:
1. Langfuse에서 프롬프트 검색
2. 성공 → Langfuse 프롬프트 사용 + 버전 로깅
3. 실패 → YAML 폴백 + 폴백 로깅

Langfuse 비활성화 시:
→ YAML 직접 사용 (기존 동작)
```

## 테스트

- ✅ 18개 Phase 3 신규 테스트 추가
- ✅ 전체 56개 테스트 통과 (observability + prompts)

## 테스트 계획

- [x] 기존 프롬프트 로딩 테스트 (하위 호환성)
- [x] 새 함수 import 테스트
- [x] 프롬프트 이름 생성 테스트
- [x] 메타데이터 반환 테스트
- [x] 캐시 동작 테스트
- [x] Langfuse 비활성화 시 YAML 폴백 테스트
- [x] 프롬프트 사용 로깅 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)