### PR TITLE
feat: Langfuse Phase 4 - 평가/분석 및 Agent Graph 시각화

### DIFF
--- a/backend/app/core/evaluation.py
+++ b/backend/app/core/evaluation.py
@@ -1,0 +1,410 @@
+"""
+backend/app/core/evaluation.py
+Langfuse 평가 기능: Dataset, Score, Metrics 유틸리티
+"""
+import logging
+from typing import Any
+
+from app.core.observability import is_langfuse_enabled, get_langfuse_client
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Score Configuration - 사전 정의된 평가 점수 타입
+# =============================================================================
+
+SCORE_CONFIGS = {
+    # 품질 평가 점수
+    "question_quality": {
+        "name": "question_quality",
+        "data_type": "NUMERIC",
+        "description": "면접 질문의 전반적인 품질 (0.0-1.0)",
+        "min_value": 0.0,
+        "max_value": 1.0,
+    },
+    "relevance": {
+        "name": "relevance",
+        "data_type": "NUMERIC",
+        "description": "JD와 질문의 관련성 (0.0-1.0)",
+        "min_value": 0.0,
+        "max_value": 1.0,
+    },
+    "difficulty_accuracy": {
+        "name": "difficulty_accuracy",
+        "data_type": "CATEGORICAL",
+        "description": "난이도 적절성",
+        "categories": ["too_easy", "appropriate", "too_hard"],
+    },
+    "completion_status": {
+        "name": "completion_status",
+        "data_type": "CATEGORICAL",
+        "description": "Job 완료 상태",
+        "categories": ["success", "partial", "failed"],
+    },
+    # Boolean 평가
+    "has_follow_ups": {
+        "name": "has_follow_ups",
+        "data_type": "BOOLEAN",
+        "description": "후속 질문 포함 여부",
+    },
+    "has_terminology": {
+        "name": "has_terminology",
+        "data_type": "BOOLEAN",
+        "description": "용어 설명 포함 여부",
+    },
+}
+
+
+def get_score_config(score_name: str) -> dict | None:
+    """사전 정의된 Score 설정 반환."""
+    return SCORE_CONFIGS.get(score_name)
+
+
+def list_score_configs() -> list[str]:
+    """사용 가능한 Score 이름 목록 반환."""
+    return list(SCORE_CONFIGS.keys())
+
+
+# =============================================================================
+# Score 생성 유틸리티
+# =============================================================================
+
+def create_score(
+    trace_id: str,
+    name: str,
+    value: float | str | bool,
+    observation_id: str | None = None,
+    comment: str | None = None,
+    data_type: str | None = None,
+) -> dict | None:
+    """Langfuse Score 생성.
+
+    Args:
+        trace_id: 연결할 Trace ID
+        name: Score 이름 (SCORE_CONFIGS에 정의된 것 권장)
+        value: 점수 값 (NUMERIC: float, CATEGORICAL: str, BOOLEAN: bool)
+        observation_id: 특정 Observation에 연결 (선택)
+        comment: 코멘트 (선택)
+        data_type: 데이터 타입 (자동 추론 가능)
+
+    Returns:
+        생성된 Score 정보 또는 None (Langfuse 비활성화 시)
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        # Score config에서 data_type 자동 설정
+        if data_type is None and name in SCORE_CONFIGS:
+            data_type = SCORE_CONFIGS[name].get("data_type")
+
+        score = client.score(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            observation_id=observation_id,
+            comment=comment,
+            data_type=data_type,
+        )
+
+        logger.debug(f"Created score: {name}={value} for trace {trace_id}")
+        return {"id": score.id if hasattr(score, "id") else None, "name": name, "value": value}
+
+    except Exception as e:
+        logger.warning(f"Failed to create score: {e}")
+        return None
+
+
+def create_scores_batch(
+    trace_id: str,
+    scores: list[dict],
+) -> list[dict]:
+    """여러 Score 일괄 생성.
+
+    Args:
+        trace_id: 연결할 Trace ID
+        scores: [{"name": str, "value": any, "comment": str | None}, ...]
+
+    Returns:
+        생성된 Score 목록
+    """
+    results = []
+    for score_data in scores:
+        result = create_score(
+            trace_id=trace_id,
+            name=score_data["name"],
+            value=score_data["value"],
+            comment=score_data.get("comment"),
+        )
+        if result:
+            results.append(result)
+    return results
+
+
+# =============================================================================
+# Dataset 관리 유틸리티
+# =============================================================================
+
+def create_dataset(
+    name: str,
+    description: str | None = None,
+    metadata: dict | None = None,
+) -> dict | None:
+    """평가용 Dataset 생성.
+
+    Args:
+        name: Dataset 이름
+        description: 설명
+        metadata: 추가 메타데이터
+
+    Returns:
+        생성된 Dataset 정보 또는 None
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        dataset = client.create_dataset(
+            name=name,
+            description=description,
+            metadata=metadata or {},
+        )
+
+        logger.info(f"Created dataset: {name}")
+        return {
+            "id": dataset.id if hasattr(dataset, "id") else None,
+            "name": name,
+            "description": description,
+        }
+
+    except Exception as e:
+        logger.warning(f"Failed to create dataset: {e}")
+        return None
+
+
+def add_dataset_item(
+    dataset_name: str,
+    input_data: dict,
+    expected_output: dict | None = None,
+    metadata: dict | None = None,
+) -> dict | None:
+    """Dataset에 평가 항목 추가.
+
+    Args:
+        dataset_name: Dataset 이름
+        input_data: 입력 데이터
+        expected_output: 기대 출력 (선택)
+        metadata: 추가 메타데이터
+
+    Returns:
+        생성된 Item 정보 또는 None
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        item = client.create_dataset_item(
+            dataset_name=dataset_name,
+            input=input_data,
+            expected_output=expected_output,
+            metadata=metadata or {},
+        )
+
+        logger.debug(f"Added item to dataset: {dataset_name}")
+        return {
+            "id": item.id if hasattr(item, "id") else None,
+            "dataset_name": dataset_name,
+        }
+
+    except Exception as e:
+        logger.warning(f"Failed to add dataset item: {e}")
+        return None
+
+
+def get_dataset(name: str) -> Any | None:
+    """Dataset 조회.
+
+    Args:
+        name: Dataset 이름
+
+    Returns:
+        Dataset 객체 또는 None
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        return client.get_dataset(name)
+
+    except Exception as e:
+        logger.warning(f"Failed to get dataset: {e}")
+        return None
+
+
+# =============================================================================
+# Interview Generation 전용 Dataset 템플릿
+# =============================================================================
+
+def create_interview_evaluation_dataset(
+    name: str = "interview-generation-benchmark",
+    description: str = "면접 스크립트 생성 품질 평가용 데이터셋",
+) -> dict | None:
+    """면접 생성 평가용 Dataset 템플릿 생성."""
+    return create_dataset(
+        name=name,
+        description=description,
+        metadata={
+            "type": "evaluation",
+            "domain": "interview-generation",
+            "version": "v1",
+            "expected_fields": {
+                "input": ["jd_text", "experience_level", "output_language"],
+                "output": ["question_count", "categories", "has_follow_ups"],
+            },
+        },
+    )
+
+
+def add_interview_test_case(
+    dataset_name: str,
+    jd_text: str,
+    experience_level: str = "시니어",
+    output_language: str = "ko",
+    expected_question_count: int = 25,
+    expected_categories: list[str] | None = None,
+    metadata: dict | None = None,
+) -> dict | None:
+    """면접 생성 평가 테스트 케이스 추가."""
+    if expected_categories is None:
+        expected_categories = [
+            "role_fit",
+            "technical_depth",
+            "execution_ownership",
+            "communication",
+            "risk_flags",
+        ]
+
+    return add_dataset_item(
+        dataset_name=dataset_name,
+        input_data={
+            "jd_text": jd_text,
+            "experience_level": experience_level,
+            "output_language": output_language,
+        },
+        expected_output={
+            "question_count": expected_question_count,
+            "categories": expected_categories,
+            "has_follow_ups": True,
+            "has_terminology": True,
+            "has_evaluation_scenarios": True,
+        },
+        metadata=metadata or {},
+    )
+
+
+# =============================================================================
+# Metrics 조회 유틸리티
+# =============================================================================
+
+def get_trace_metrics(
+    trace_id: str,
+) -> dict | None:
+    """특정 Trace의 메트릭 조회.
+
+    Args:
+        trace_id: Trace ID
+
+    Returns:
+        메트릭 정보 또는 None
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        # Trace 조회
+        trace = client.get_trace(trace_id)
+        if not trace:
+            return None
+
+        return {
+            "trace_id": trace_id,
+            "name": trace.name if hasattr(trace, "name") else None,
+            "input_tokens": trace.input if hasattr(trace, "input") else None,
+            "output_tokens": trace.output if hasattr(trace, "output") else None,
+            "total_cost": trace.total_cost if hasattr(trace, "total_cost") else None,
+            "latency_ms": trace.latency if hasattr(trace, "latency") else None,
+            "scores": trace.scores if hasattr(trace, "scores") else [],
+        }
+
+    except Exception as e:
+        logger.warning(f"Failed to get trace metrics: {e}")
+        return None
+
+
+def get_session_metrics(
+    session_id: str,
+) -> dict | None:
+    """특정 Session(Job)의 메트릭 조회.
+
+    Args:
+        session_id: Session ID (= Job ID)
+
+    Returns:
+        세션 메트릭 정보 또는 None
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        # Session의 모든 Trace 조회
+        traces = client.get_traces(session_id=session_id)
+        if not traces:
+            return None
+
+        total_cost = 0.0
+        total_latency = 0
+        trace_count = 0
+
+        for trace in traces.data if hasattr(traces, "data") else []:
+            trace_count += 1
+            if hasattr(trace, "total_cost") and trace.total_cost:
+                total_cost += trace.total_cost
+            if hasattr(trace, "latency") and trace.latency:
+                total_latency += trace.latency
+
+        return {
+            "session_id": session_id,
+            "trace_count": trace_count,
+            "total_cost": total_cost,
+            "total_latency_ms": total_latency,
+            "avg_latency_ms": total_latency / trace_count if trace_count > 0 else 0,
+        }
+
+    except Exception as e:
+        logger.warning(f"Failed to get session metrics: {e}")
+        return None

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -293,6 +293,176 @@ def score_trace(
         logger.debug(f"Failed to add score to trace: {e}")
 
 
+# =============================================================================
+# Phase 4: Agent Graph Visualization (Custom Observation Types)
+# =============================================================================
+
+def create_agent_observation(
+    trace_id: str,
+    name: str,
+    input_data: dict | None = None,
+    output_data: dict | None = None,
+    metadata: dict | None = None,
+    parent_observation_id: str | None = None,
+):
+    """Agent 타입 Observation 생성 (Agent Graph 시각화용).
+
+    Args:
+        trace_id: 연결할 Trace ID
+        name: Agent 이름
+        input_data: 입력 데이터
+        output_data: 출력 데이터
+        metadata: 추가 메타데이터
+        parent_observation_id: 부모 Observation ID (계층 구조)
+
+    Returns:
+        생성된 Observation 또는 None
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        observation = client.span(
+            trace_id=trace_id,
+            name=name,
+            input=input_data,
+            output=output_data,
+            metadata={
+                "observation_type": "agent",
+                **(metadata or {}),
+            },
+            parent_observation_id=parent_observation_id,
+        )
+        logger.debug(f"Created agent observation: {name}")
+        return observation
+    except Exception as e:
+        logger.warning(f"Failed to create agent observation: {e}")
+        return None
+
+
+def create_tool_observation(
+    trace_id: str,
+    name: str,
+    input_data: dict | None = None,
+    output_data: dict | None = None,
+    metadata: dict | None = None,
+    parent_observation_id: str | None = None,
+):
+    """Tool 타입 Observation 생성 (Agent Graph 시각화용).
+
+    Args:
+        trace_id: 연결할 Trace ID
+        name: Tool 이름
+        input_data: 입력 데이터
+        output_data: 출력 데이터
+        metadata: 추가 메타데이터
+        parent_observation_id: 부모 Observation ID
+
+    Returns:
+        생성된 Observation 또는 None
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        observation = client.span(
+            trace_id=trace_id,
+            name=name,
+            input=input_data,
+            output=output_data,
+            metadata={
+                "observation_type": "tool",
+                **(metadata or {}),
+            },
+            parent_observation_id=parent_observation_id,
+        )
+        logger.debug(f"Created tool observation: {name}")
+        return observation
+    except Exception as e:
+        logger.warning(f"Failed to create tool observation: {e}")
+        return None
+
+
+def create_retrieval_observation(
+    trace_id: str,
+    name: str,
+    query: str | None = None,
+    documents: list[dict] | None = None,
+    metadata: dict | None = None,
+    parent_observation_id: str | None = None,
+):
+    """Retrieval 타입 Observation 생성 (RAG Agent Graph 시각화용).
+
+    Args:
+        trace_id: 연결할 Trace ID
+        name: Retrieval 이름
+        query: 검색 쿼리
+        documents: 검색된 문서 목록
+        metadata: 추가 메타데이터
+        parent_observation_id: 부모 Observation ID
+
+    Returns:
+        생성된 Observation 또는 None
+    """
+    if not is_langfuse_enabled():
+        return None
+
+    try:
+        client = get_langfuse_client()
+        if not client:
+            return None
+
+        observation = client.span(
+            trace_id=trace_id,
+            name=name,
+            input={"query": query} if query else None,
+            output={"documents": documents} if documents else None,
+            metadata={
+                "observation_type": "retrieval",
+                "document_count": len(documents) if documents else 0,
+                **(metadata or {}),
+            },
+            parent_observation_id=parent_observation_id,
+        )
+        logger.debug(f"Created retrieval observation: {name}")
+        return observation
+    except Exception as e:
+        logger.warning(f"Failed to create retrieval observation: {e}")
+        return None
+
+
+def end_observation(observation, output_data: dict | None = None, status: str = "success"):
+    """Observation 종료 (Agent Graph 노드 완료 마킹).
+
+    Args:
+        observation: 종료할 Observation 객체
+        output_data: 출력 데이터
+        status: 완료 상태 (success/error)
+    """
+    if observation is None:
+        return
+
+    try:
+        observation.end(
+            output=output_data,
+            metadata={"status": status},
+        )
+    except Exception as e:
+        logger.debug(f"Failed to end observation: {e}")
+
+
+# =============================================================================
+# Phase 1: @observe 데코레이터 래퍼
+# =============================================================================
+
 def observe_activity(name: str, phase: str = "unknown"):
     """Activity용 Langfuse @observe 래퍼 데코레이터
 

--- a/backend/tests/test_evaluation.py
+++ b/backend/tests/test_evaluation.py
@@ -1,0 +1,365 @@
+"""Langfuse evaluation module tests."""
+import pytest
+
+
+class TestScoreConfigurations:
+    """Test score configuration constants."""
+
+    def test_score_configs_importable(self):
+        """SCORE_CONFIGS is importable and has expected keys."""
+        from app.core.evaluation import SCORE_CONFIGS
+        assert isinstance(SCORE_CONFIGS, dict)
+        assert "question_quality" in SCORE_CONFIGS
+        assert "relevance" in SCORE_CONFIGS
+        assert "difficulty_accuracy" in SCORE_CONFIGS
+        assert "completion_status" in SCORE_CONFIGS
+        assert "has_follow_ups" in SCORE_CONFIGS
+        assert "has_terminology" in SCORE_CONFIGS
+
+    def test_numeric_score_config_structure(self):
+        """NUMERIC score configs have required fields."""
+        from app.core.evaluation import SCORE_CONFIGS
+
+        numeric_config = SCORE_CONFIGS["question_quality"]
+        assert numeric_config["name"] == "question_quality"
+        assert numeric_config["data_type"] == "NUMERIC"
+        assert "min_value" in numeric_config
+        assert "max_value" in numeric_config
+        assert numeric_config["min_value"] == 0.0
+        assert numeric_config["max_value"] == 1.0
+
+    def test_categorical_score_config_structure(self):
+        """CATEGORICAL score configs have required fields."""
+        from app.core.evaluation import SCORE_CONFIGS
+
+        categorical_config = SCORE_CONFIGS["difficulty_accuracy"]
+        assert categorical_config["name"] == "difficulty_accuracy"
+        assert categorical_config["data_type"] == "CATEGORICAL"
+        assert "categories" in categorical_config
+        assert isinstance(categorical_config["categories"], list)
+        assert len(categorical_config["categories"]) > 0
+
+    def test_boolean_score_config_structure(self):
+        """BOOLEAN score configs have required fields."""
+        from app.core.evaluation import SCORE_CONFIGS
+
+        boolean_config = SCORE_CONFIGS["has_follow_ups"]
+        assert boolean_config["name"] == "has_follow_ups"
+        assert boolean_config["data_type"] == "BOOLEAN"
+
+    def test_get_score_config_returns_config(self):
+        """get_score_config returns correct config."""
+        from app.core.evaluation import get_score_config
+
+        config = get_score_config("question_quality")
+        assert config is not None
+        assert config["name"] == "question_quality"
+
+    def test_get_score_config_returns_none_for_unknown(self):
+        """get_score_config returns None for unknown score names."""
+        from app.core.evaluation import get_score_config
+
+        config = get_score_config("nonexistent_score")
+        assert config is None
+
+    def test_list_score_configs(self):
+        """list_score_configs returns all score names."""
+        from app.core.evaluation import list_score_configs
+
+        names = list_score_configs()
+        assert isinstance(names, list)
+        assert "question_quality" in names
+        assert "relevance" in names
+        assert len(names) >= 6
+
+
+class TestScoreCreation:
+    """Test score creation functions."""
+
+    def test_create_score_importable(self):
+        """create_score function is importable."""
+        from app.core.evaluation import create_score
+        assert callable(create_score)
+
+    def test_create_scores_batch_importable(self):
+        """create_scores_batch function is importable."""
+        from app.core.evaluation import create_scores_batch
+        assert callable(create_scores_batch)
+
+    def test_create_score_returns_none_when_disabled(self, monkeypatch):
+        """create_score returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import create_score
+
+        result = create_score("trace-123", "question_quality", 0.8)
+        assert result is None
+
+    def test_create_scores_batch_returns_empty_when_disabled(self, monkeypatch):
+        """create_scores_batch returns empty list when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import create_scores_batch
+
+        scores = [
+            {"name": "question_quality", "value": 0.8},
+            {"name": "relevance", "value": 0.9},
+        ]
+        result = create_scores_batch("trace-123", scores)
+        assert result == []
+
+
+class TestDatasetManagement:
+    """Test dataset management functions."""
+
+    def test_create_dataset_importable(self):
+        """create_dataset function is importable."""
+        from app.core.evaluation import create_dataset
+        assert callable(create_dataset)
+
+    def test_add_dataset_item_importable(self):
+        """add_dataset_item function is importable."""
+        from app.core.evaluation import add_dataset_item
+        assert callable(add_dataset_item)
+
+    def test_get_dataset_importable(self):
+        """get_dataset function is importable."""
+        from app.core.evaluation import get_dataset
+        assert callable(get_dataset)
+
+    def test_create_dataset_returns_none_when_disabled(self, monkeypatch):
+        """create_dataset returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import create_dataset
+
+        result = create_dataset("test-dataset", "Test description")
+        assert result is None
+
+    def test_add_dataset_item_returns_none_when_disabled(self, monkeypatch):
+        """add_dataset_item returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import add_dataset_item
+
+        result = add_dataset_item(
+            "test-dataset",
+            {"input": "test"},
+            {"output": "expected"},
+        )
+        assert result is None
+
+    def test_get_dataset_returns_none_when_disabled(self, monkeypatch):
+        """get_dataset returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import get_dataset
+
+        result = get_dataset("test-dataset")
+        assert result is None
+
+
+class TestInterviewEvaluationTemplates:
+    """Test interview-specific evaluation templates."""
+
+    def test_create_interview_evaluation_dataset_importable(self):
+        """create_interview_evaluation_dataset function is importable."""
+        from app.core.evaluation import create_interview_evaluation_dataset
+        assert callable(create_interview_evaluation_dataset)
+
+    def test_add_interview_test_case_importable(self):
+        """add_interview_test_case function is importable."""
+        from app.core.evaluation import add_interview_test_case
+        assert callable(add_interview_test_case)
+
+    def test_create_interview_evaluation_dataset_returns_none_when_disabled(self, monkeypatch):
+        """create_interview_evaluation_dataset returns None when disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import create_interview_evaluation_dataset
+
+        result = create_interview_evaluation_dataset()
+        assert result is None
+
+    def test_add_interview_test_case_returns_none_when_disabled(self, monkeypatch):
+        """add_interview_test_case returns None when disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import add_interview_test_case
+
+        result = add_interview_test_case(
+            "test-dataset",
+            jd_text="Software Engineer position...",
+            experience_level="Senior",
+        )
+        assert result is None
+
+
+class TestMetricsQueries:
+    """Test metrics query functions."""
+
+    def test_get_trace_metrics_importable(self):
+        """get_trace_metrics function is importable."""
+        from app.core.evaluation import get_trace_metrics
+        assert callable(get_trace_metrics)
+
+    def test_get_session_metrics_importable(self):
+        """get_session_metrics function is importable."""
+        from app.core.evaluation import get_session_metrics
+        assert callable(get_session_metrics)
+
+    def test_get_trace_metrics_returns_none_when_disabled(self, monkeypatch):
+        """get_trace_metrics returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import get_trace_metrics
+
+        result = get_trace_metrics("trace-123")
+        assert result is None
+
+    def test_get_session_metrics_returns_none_when_disabled(self, monkeypatch):
+        """get_session_metrics returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.evaluation import get_session_metrics
+
+        result = get_session_metrics("session-123")
+        assert result is None
+
+
+class TestPhase4AgentGraphFunctions:
+    """Test Phase 4 Agent Graph visualization functions."""
+
+    def test_create_agent_observation_importable(self):
+        """create_agent_observation function is importable."""
+        from app.core.observability import create_agent_observation
+        assert callable(create_agent_observation)
+
+    def test_create_tool_observation_importable(self):
+        """create_tool_observation function is importable."""
+        from app.core.observability import create_tool_observation
+        assert callable(create_tool_observation)
+
+    def test_create_retrieval_observation_importable(self):
+        """create_retrieval_observation function is importable."""
+        from app.core.observability import create_retrieval_observation
+        assert callable(create_retrieval_observation)
+
+    def test_end_observation_importable(self):
+        """end_observation function is importable."""
+        from app.core.observability import end_observation
+        assert callable(end_observation)
+
+    def test_create_agent_observation_returns_none_when_disabled(self, monkeypatch):
+        """create_agent_observation returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.observability import create_agent_observation
+
+        result = create_agent_observation(
+            trace_id="trace-123",
+            name="test-agent",
+            input_data={"query": "test"},
+        )
+        assert result is None
+
+    def test_create_tool_observation_returns_none_when_disabled(self, monkeypatch):
+        """create_tool_observation returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.observability import create_tool_observation
+
+        result = create_tool_observation(
+            trace_id="trace-123",
+            name="test-tool",
+            input_data={"param": "value"},
+        )
+        assert result is None
+
+    def test_create_retrieval_observation_returns_none_when_disabled(self, monkeypatch):
+        """create_retrieval_observation returns None when Langfuse is disabled."""
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_PUBLIC_KEY", None
+        )
+        monkeypatch.setattr(
+            "app.core.observability.settings.LANGFUSE_SECRET_KEY", None
+        )
+
+        from app.core.observability import create_retrieval_observation
+
+        result = create_retrieval_observation(
+            trace_id="trace-123",
+            name="test-retrieval",
+            query="search query",
+            documents=[{"content": "doc1"}],
+        )
+        assert result is None
+
+    def test_end_observation_handles_none(self):
+        """end_observation handles None observation gracefully."""
+        from app.core.observability import end_observation
+
+        # Should not raise
+        end_observation(None)
+
+    def test_end_observation_handles_none_with_output(self):
+        """end_observation handles None observation with output data."""
+        from app.core.observability import end_observation
+
+        # Should not raise
+        end_observation(None, output_data={"result": "test"}, status="success")


### PR DESCRIPTION
## Summary

Langfuse 통합의 네 번째 단계로 평가(Evaluation), 분석(Analytics), Agent Graph 시각화 기능을 구현했습니다.

### 주요 변경사항

#### 1. 평가(Evaluation) 기능 (`app/core/evaluation.py`)

**Score 설정 시스템**
- `SCORE_CONFIGS`: 사전 정의된 평가 점수 타입
  - `question_quality`: 질문 품질 점수 (NUMERIC, 0.0-1.0)
  - `relevance`: JD 관련성 점수 (NUMERIC, 0.0-1.0)
  - `difficulty_accuracy`: 난이도 적절성 (CATEGORICAL)
  - `completion_status`: Job 완료 상태 (CATEGORICAL)
  - `has_follow_ups`, `has_terminology`: Boolean 평가

**Score 생성 유틸리티**
- `create_score()`: 단일 Score 생성
- `create_scores_batch()`: 여러 Score 일괄 생성

**Dataset 관리**
- `create_dataset()`: 평가용 Dataset 생성
- `add_dataset_item()`: Dataset에 테스트 케이스 추가
- `get_dataset()`: Dataset 조회

**Interview 전용 템플릿**
- `create_interview_evaluation_dataset()`: 면접 평가 전용 Dataset
- `add_interview_test_case()`: 면접 테스트 케이스 추가

**Metrics 조회**
- `get_trace_metrics()`: Trace별 메트릭 조회 (tokens, cost, latency)
- `get_session_metrics()`: Session(Job)별 집계 메트릭 조회

#### 2. Agent Graph 시각화 (`app/core/observability.py`)

Custom Observation Type 방식으로 Agent Graph 시각화 지원:

- `create_agent_observation()`: Agent 타입 노드 생성
- `create_tool_observation()`: Tool 타입 노드 생성
- `create_retrieval_observation()`: Retrieval(RAG) 타입 노드 생성
- `end_observation()`: Observation 완료 마킹

> LangGraph 통합 대신 Custom Observation Type 방식을 선택한 이유:
> Temporal.io 기반 워크플로우에서는 LangGraph 프레임워크가 필요하지 않고,
> 기존 인프라를 그대로 활용하면서 Langfuse의 Agent Graph 시각화 기능을 사용할 수 있음

### 테스트

```bash
# Phase 4 테스트 실행
cd backend
PYTHONPATH=. ../.venv/bin/python -m pytest tests/test_evaluation.py -v
```

- ✅ 34개 테스트 모두 통과
  - Score 설정 테스트: 7개
  - Score 생성 테스트: 4개
  - Dataset 관리 테스트: 6개
  - Interview 템플릿 테스트: 4개
  - Metrics 조회 테스트: 4개
  - Agent Graph 함수 테스트: 9개

### Langfuse 통합 완료 현황

| Phase | 기능 | 상태 |
|-------|------|------|
| Phase 1 | @observe 데코레이터 | ✅ PR #32 |
| Phase 2 | Session/Trace 계층 | ✅ PR #33 |
| Phase 3 | Prompt 관리 | ✅ PR #34 |
| Phase 4 | 평가/분석 + Agent Graph | ✅ 이 PR |

## Test Plan

- [x] Phase 4 evaluation 테스트 실행 (34개 통과)
- [x] Score 설정 구조 검증
- [x] Dataset 관리 함수 검증
- [x] Metrics 조회 함수 검증
- [x] Agent Graph 시각화 함수 검증
- [x] Langfuse 비활성화 시 graceful degradation 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)