### PR TITLE
feat: GitHub User/Organization 구분 및 개인 레포만 분석

### DIFF
--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -98,3 +98,270 @@ class GitHubService:
                 matched.append(info)
 
         return matched
+
+    async def get_account_type(self, username: str) -> dict:
+        """
+        GitHub 계정 타입 확인 (User vs Organization)
+
+        Returns:
+            {
+                "username": str,
+                "type": "User" | "Organization" | "unknown",
+                "name": str | None,
+                "avatar_url": str | None,
+                "error": str | None
+            }
+        """
+        import httpx
+
+        # 먼저 인증된 PyGithub 시도
+        try:
+            g = self._get_github()
+            try:
+                user = g.get_user(username)
+                return {
+                    "username": username,
+                    "type": user.type,  # "User" or "Organization"
+                    "name": user.name,
+                    "avatar_url": user.avatar_url,
+                    "bio": user.bio if hasattr(user, 'bio') else None,
+                    "company": user.company if hasattr(user, 'company') else None,
+                    "error": None,
+                }
+            except Exception:
+                org = g.get_organization(username)
+                return {
+                    "username": username,
+                    "type": "Organization",
+                    "name": org.name,
+                    "avatar_url": org.avatar_url,
+                    "error": None,
+                }
+        except Exception as e:
+            logger.warning(f"PyGithub failed for {username}: {e}, trying unauthenticated...")
+
+        # Fallback: 인증 없이 공개 API 직접 호출
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"https://api.github.com/users/{username}",
+                    headers={"Accept": "application/vnd.github.v3+json"},
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    return {
+                        "username": username,
+                        "type": data.get("type", "unknown"),
+                        "name": data.get("name"),
+                        "avatar_url": data.get("avatar_url"),
+                        "bio": data.get("bio"),
+                        "company": data.get("company"),
+                        "error": None,
+                    }
+                elif resp.status_code == 404:
+                    return {
+                        "username": username,
+                        "type": "unknown",
+                        "name": None,
+                        "avatar_url": None,
+                        "error": "not_found",
+                    }
+                else:
+                    logger.warning(f"GitHub API returned {resp.status_code} for {username}")
+        except Exception as e2:
+            logger.warning(f"Unauthenticated request also failed for {username}: {e2}")
+
+        return {
+            "username": username,
+            "type": "unknown",
+            "name": None,
+            "avatar_url": None,
+            "error": "api_failed",
+        }
+
+    async def get_repo_contributors(self, url: str, limit: int = 5) -> list[dict]:
+        """
+        레포지토리 기여자 목록 조회 (기여도 순)
+
+        Returns:
+            [{"username": str, "contributions": int, "type": str}, ...]
+        """
+        import httpx
+
+        path = self._parse_repo_path(url)
+        if not path:
+            return []
+
+        # 먼저 PyGithub 시도
+        try:
+            g = self._get_github()
+            repo = g.get_repo(path)
+            contributors = []
+
+            for contrib in repo.get_contributors()[:limit]:
+                contributors.append({
+                    "username": contrib.login,
+                    "contributions": contrib.contributions,
+                    "type": contrib.type,
+                    "avatar_url": contrib.avatar_url,
+                })
+
+            return contributors
+        except Exception as e:
+            logger.warning(f"PyGithub failed for contributors {url}: {e}, trying unauthenticated...")
+
+        # Fallback: 인증 없이 공개 API 직접 호출
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"https://api.github.com/repos/{path}/contributors",
+                    headers={"Accept": "application/vnd.github.v3+json"},
+                    params={"per_page": limit},
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    return [
+                        {
+                            "username": c.get("login"),
+                            "contributions": c.get("contributions", 0),
+                            "type": c.get("type", "User"),
+                            "avatar_url": c.get("avatar_url"),
+                        }
+                        for c in data[:limit]
+                    ]
+        except Exception as e2:
+            logger.warning(f"Unauthenticated contributors request also failed: {e2}")
+
+        return []
+
+    async def infer_candidate_username(
+        self,
+        github_urls: list[str],
+        candidate_name: str | None = None,
+    ) -> dict:
+        """
+        GitHub URL들에서 후보자 개인 username 확인
+
+        ⚠️ 개인 계정(User) URL만 사용. Organization URL은 무시.
+        임의 추론(기여자 분석)은 하지 않음 - 신뢰성 문제.
+
+        Strategy:
+        1. URL에서 owner 추출
+        2. owner가 User인지 Organization인지 확인
+        3. User 계정만 유효한 것으로 처리
+        4. Organization URL은 건너뜀 (code_analysis 대상에서 제외)
+
+        Returns:
+            {
+                "username": str | None,
+                "confidence": "high" | "none",
+                "source": str,
+                "personal_repos": list[str],  # 개인 레포 URL만
+                "skipped_org_repos": list[str],  # 건너뛴 조직 레포
+            }
+        """
+        if not github_urls:
+            return {
+                "username": None,
+                "confidence": "none",
+                "source": "no_urls",
+                "personal_repos": [],
+                "skipped_org_repos": [],
+            }
+
+        personal_repos = []
+        skipped_org_repos = []
+        found_username = None
+
+        for url in github_urls[:10]:  # 최대 10개 URL 처리
+            owner = self._extract_owner(url)
+            if not owner:
+                continue
+
+            account_info = await self.get_account_type(owner)
+
+            if account_info["type"] == "User":
+                # 개인 계정 → 유효
+                personal_repos.append(url)
+                if not found_username:
+                    found_username = owner
+                    logger.info(f"Found personal GitHub account: {owner} from {url}")
+
+            elif account_info["type"] == "Organization":
+                # 조직 계정 → 건너뜀 (임의 추론 안 함)
+                skipped_org_repos.append(url)
+                logger.info(f"Skipping organization repo (no inference): {owner} from {url}")
+
+            else:
+                # unknown (API 실패 등) → 건너뜀
+                skipped_org_repos.append(url)
+                logger.warning(f"Unknown account type for {owner}, skipping: {url}")
+
+        if found_username and personal_repos:
+            return {
+                "username": found_username,
+                "confidence": "high",
+                "source": f"personal_repo:{personal_repos[0]}",
+                "personal_repos": personal_repos,
+                "skipped_org_repos": skipped_org_repos,
+            }
+
+        return {
+            "username": None,
+            "confidence": "none",
+            "source": "no_personal_repos",
+            "personal_repos": [],
+            "skipped_org_repos": skipped_org_repos,
+        }
+
+    def _extract_owner(self, url: str) -> str | None:
+        """GitHub URL에서 owner(첫 번째 경로) 추출"""
+        match = re.match(r'https?://github\.com/([\w\-]+)', url)
+        return match.group(1) if match else None
+
+    def _names_match(self, name1: str, name2: str) -> bool:
+        """
+        두 이름이 매칭되는지 확인 (다양한 형식 지원)
+
+        Examples:
+            - "BYUN SANGHOON" ≈ "Sanghoon Byun" → True
+            - "변상훈" ≈ "Sanghoon Byun" → False (다른 스크립트)
+            - "John Doe" ≈ "John D." → True (부분 매칭)
+        """
+        if not name1 or not name2:
+            return False
+
+        # 정규화: 소문자, 여분 공백 제거
+        n1 = " ".join(name1.lower().split())
+        n2 = " ".join(name2.lower().split())
+
+        # 1. 완전 일치
+        if n1 == n2:
+            return True
+
+        # 2. 단어 집합 비교 (순서 무관)
+        words1 = set(n1.split())
+        words2 = set(n2.split())
+
+        # 공통 단어가 2개 이상이면 매칭
+        common = words1 & words2
+        if len(common) >= 2:
+            return True
+
+        # 3. 한쪽이 다른쪽에 포함
+        if n1 in n2 or n2 in n1:
+            return True
+
+        # 4. 성/이름 조합 체크 (동양 이름: 성+이름 vs 서양: 이름+성)
+        # "byun sanghoon" vs "sanghoon byun"
+        if len(words1) >= 2 and len(words2) >= 2:
+            # 순서 뒤집어서 비교
+            reversed_n1 = " ".join(reversed(list(words1)))
+            reversed_n2 = " ".join(reversed(list(words2)))
+            if n1 == reversed_n2 or n2 == reversed_n1:
+                return True
+            # 단어 집합이 동일 (순서만 다름)
+            if words1 == words2:
+                return True
+
+        return False

--- a/backend/app/workflows/activities/input_enrichment.py
+++ b/backend/app/workflows/activities/input_enrichment.py
@@ -8,7 +8,7 @@ import logging
 from temporalio import activity
 
 from app.core.observability import observe_activity
-from app.exceptions import DocumentParseError, LinkedInFetchError
+from app.exceptions import LinkedInFetchError
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,8 @@ async def enrich_input(input_data: dict) -> dict:
     extracted_urls: dict[str, set] = {"github": set(), "linkedin": set()}
     extraction_sources: dict[str, list] = {}
 
+    document_errors: list[dict] = []
+
     # 1. Resume에서 URL 추출
     if input_data.get("resume_path"):
         activity.heartbeat("Extracting URLs from resume...")
@@ -46,9 +48,8 @@ async def enrich_input(input_data: dict) -> dict:
                 extracted_urls["linkedin"].add(url)
                 extraction_sources.setdefault("linkedin_url", []).append("resume")
         except Exception as e:
-            raise DocumentParseError(
-                f"Resume 파싱 실패: {input_data['resume_path']}", source="resume"
-            ) from e
+            logger.warning(f"Resume 파싱 실패 (계속 진행): {e}")
+            document_errors.append({"source": "resume", "error": str(e)})
 
     # 2. Portfolio에서 URL 추출
     if input_data.get("portfolio_path"):
@@ -60,9 +61,8 @@ async def enrich_input(input_data: dict) -> dict:
                 extracted_urls["github"].add(url)
                 extraction_sources.setdefault("github_urls", []).append("portfolio")
         except Exception as e:
-            raise DocumentParseError(
-                f"Portfolio 파싱 실패: {input_data['portfolio_path']}", source="portfolio"
-            ) from e
+            logger.warning(f"Portfolio 파싱 실패 (계속 진행): {e}")
+            document_errors.append({"source": "portfolio", "error": str(e)})
 
     # 3. Cover Letter에서 URL 추출
     if input_data.get("cover_letter_path"):
@@ -74,9 +74,8 @@ async def enrich_input(input_data: dict) -> dict:
                 extracted_urls["github"].add(url)
                 extraction_sources.setdefault("github_urls", []).append("cover_letter")
         except Exception as e:
-            raise DocumentParseError(
-                f"Cover letter 파싱 실패: {input_data['cover_letter_path']}", source="cover_letter"
-            ) from e
+            logger.warning(f"Cover letter 파싱 실패 (계속 진행): {e}")
+            document_errors.append({"source": "cover_letter", "error": str(e)})
 
     # 4. 직접 입력된 URL 병합
     for url in input_data.get("github_urls", []):
@@ -106,26 +105,58 @@ async def enrich_input(input_data: dict) -> dict:
             extracted_urls["github"].add(linkedin_profile["github_url"])
             extraction_sources.setdefault("github_urls", []).append("linkedin")
 
-    # 6. GitHub username 자동 추론
+    # 6. GitHub username 확인 (개인 계정만, Organization은 무시)
     github_urls = list(extracted_urls["github"])
     candidate_username = input_data.get("candidate_github_username")
-    if not candidate_username and github_urls:
-        candidate_username = _extract_github_username(github_urls[0])
+    username_inference = None
+    personal_github_urls = []  # code_analysis에 실제 사용할 URL
+
+    if github_urls:
+        activity.heartbeat("Validating GitHub URLs (User vs Organization)...")
+        try:
+            from app.services.github_service import GitHubService
+            github_svc = GitHubService()
+
+            username_inference = await github_svc.infer_candidate_username(
+                github_urls=github_urls,
+                candidate_name=linkedin_profile.get("full_name") if linkedin_profile else None,
+            )
+
+            # 개인 레포 URL만 사용
+            personal_github_urls = username_inference.get("personal_repos", [])
+
+            # username이 명시적으로 입력되지 않았으면 추론 결과 사용
+            if not candidate_username:
+                candidate_username = username_inference.get("username")
+
+            # 건너뛴 조직 레포 로깅
+            skipped = username_inference.get("skipped_org_repos", [])
+            if skipped:
+                logger.info(f"Skipped {len(skipped)} organization repos (no inference)")
+
+        except Exception as e:
+            logger.warning(f"GitHub URL validation failed: {e}")
+            # 실패 시 URL 그대로 유지하되 username은 없음
+            personal_github_urls = github_urls
 
     # 7. 사용 가능한 분석 목록
     available = ["jd_analysis"]  # JD는 항상
     if any(input_data.get(k) for k in ("resume_path", "portfolio_path", "cover_letter_path")) or linkedin_profile:
         available.append("document_analysis")
-    if github_urls:
+    # code_analysis는 개인 레포가 있을 때만 (조직 레포만 있으면 제외)
+    if personal_github_urls:
         available.append("code_analysis")
 
     return {
         "raw_input": input_data,
-        "github_urls": github_urls,
+        "github_urls": personal_github_urls,  # 개인 레포만 (조직 레포 제외)
+        "all_extracted_github_urls": github_urls,  # 원본 전체 (로깅/디버깅용)
         "candidate_github_username": candidate_username,
+        "github_validation": username_inference,  # 검증 상세 정보
         "linkedin_profile": linkedin_profile,
         "extraction_sources": extraction_sources,
         "available_analyses": available,
+        "document_errors": document_errors,
     }
 
 


### PR DESCRIPTION
## 📋 요약

GitHub URL에서 개인 계정(User)과 조직(Organization)을 구분하여, **개인 레포만 code_analysis 대상**으로 제한합니다.

## 🔄 변경 사항

### 1. GitHub 계정 타입 검증 (`github_service.py`)
- `get_account_type()`: GitHub API로 User/Organization 구분
- PyGithub 토큰 제한 시 unauthenticated API fallback
- `infer_candidate_username()`: 개인 레포만 추출, 조직 레포 건너뜀

### 2. Input Enrichment 개선 (`input_enrichment.py`)
- 문서 파싱 실패 시 graceful fallback (예외 대신 계속 진행)
- `document_errors` 필드로 실패 원인 추적
- `github_validation` 필드로 검증 상세 정보 반환
- 조직 레포는 `skipped_org_repos`로 분류

## 📊 동작 변경

| 시나리오 | 이전 | 이후 |
|---------|------|------|
| 조직 레포 URL | 기여자 추론 시도 | ❌ 건너뜀 |
| 개인 레포 URL | 사용 | ✅ 사용 |
| 개인 레포 없음 | code_analysis 포함 | ❌ code_analysis 제외 |

## ✅ 테스트 결과

```
📂 원본 추출 URL: ['https://github.com/42cats/crime-cat']
✅ 사용할 개인 레포: []
건너뛴 조직 레포: ['https://github.com/42cats/crime-cat']

📊 Available Analyses: ['jd_analysis', 'document_analysis']
⚠️ code_analysis 비활성화 (개인 레포 없음)
```

## 🎯 이유

- 조직 레포에서 임의로 기여자를 추론하면 잘못된 사람의 코드를 분석할 위험
- 후보자가 **명시적으로 개인 GitHub URL을 제공**해야만 코드 분석 수행

---
🤖 Generated with [Claude Code](https://claude.ai/code)