### PR TITLE
test: Phase 0 Input Enrichment 단위 테스트

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,231 @@
+"""
+backend/tests/conftest.py
+공통 Fixtures 및 테스트 설정
+"""
+import os
+import sys
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# 프로젝트 루트를 Python 경로에 추가
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ============================================================
+# Phase 0: Input Enrichment Fixtures
+# ============================================================
+
+@pytest.fixture
+def sample_jd_text():
+    """샘플 JD 텍스트"""
+    return """
+주요업무
+• AI 활용 서비스 개발 : 기존 AI 서비스 고도화 및 LLM을 활용한 신규 AI 서비스를 직접 개발
+• AI 모델 백엔드 구축 : AI 모델을 상용 애플리케이션과 효율적으로 연동
+
+자격요건
+• 관련 경력 3년 이상
+• LLM API 활용 경험
+• Python과 TypeScript를 활용한 API 개발 및 대규모 데이터 처리 로직 구현에 능숙
+
+우대사항
+• AI 모델 Fine-tuning 경험
+• 대규모 AI 서비스 운영 경험
+"""
+
+
+@pytest.fixture
+def sample_input_data(sample_jd_text):
+    """Phase 0 입력 데이터"""
+    return {
+        "resume_path": None,
+        "portfolio_path": None,
+        "linkedin_url": "https://www.linkedin.com/in/test-user",
+        "github_urls": [],
+        "candidate_github_username": None,
+        "jd_text": sample_jd_text,
+        "experience_level": "시니어",
+        "language_config": {
+            "output_language": "ko",
+            "terminology_languages": ["ko", "en"],
+        },
+        "max_questions": 25,
+        "include_expected_answers": True,
+    }
+
+
+@pytest.fixture
+def sample_linkedin_profile():
+    """샘플 LinkedIn 프로필 (Bright Data 정규화 결과)"""
+    return {
+        "profile_url": "https://www.linkedin.com/in/test-user",
+        "full_name": "Test User",
+        "headline": "Software Engineer at TechCorp",
+        "summary": "Experienced developer with 5 years of experience",
+        "country": "KR",
+        "city": "Seoul",
+        "avatar_url": "https://example.com/avatar.jpg",
+        "current_company": "TechCorp",
+        "experiences": [
+            {
+                "title": "Senior Engineer",
+                "company": "TechCorp",
+                "description": "Building AI systems",
+                "starts_at": "2022-01",
+                "ends_at": None,
+            }
+        ],
+        "education": [
+            {
+                "school": "Seoul National University",
+                "degree": "Bachelor",
+                "field": "Computer Science",
+            }
+        ],
+        "skills": ["Python", "TypeScript", "FastAPI", "React"],
+        "languages": ["Korean", "English"],
+        "certifications": [],
+        "projects": [
+            {
+                "title": "AI Interview Generator",
+                "description": "GitHub: https://github.com/testuser/interview-gen",
+            }
+        ],
+        "honors_and_awards": [],
+        "activity": [],
+        "followers": 500,
+        "connections": 500,
+        "github_url": None,
+        "websites": [],
+    }
+
+
+@pytest.fixture
+def mock_enriched_input(sample_input_data, sample_linkedin_profile):
+    """Phase 0 완료 후 예상 결과 (Phase 1+ 테스트용)"""
+    return {
+        "raw_input": sample_input_data,
+        "github_urls": ["https://github.com/testuser/interview-gen"],
+        "all_extracted_github_urls": ["https://github.com/testuser/interview-gen"],
+        "candidate_github_username": "testuser",
+        "github_validation": {
+            "username": "testuser",
+            "confidence": "high",
+            "source": "personal_repo:https://github.com/testuser/interview-gen",
+            "personal_repos": ["https://github.com/testuser/interview-gen"],
+            "skipped_org_repos": [],
+        },
+        "linkedin_profile": sample_linkedin_profile,
+        "extraction_sources": {
+            "github_urls": ["linkedin_project"],
+        },
+        "available_analyses": ["jd_analysis", "document_analysis", "code_analysis"],
+        "document_errors": [],
+    }
+
+
+# ============================================================
+# Mock Services
+# ============================================================
+
+@pytest.fixture
+def mock_linkedin_service():
+    """LinkedIn 서비스 모킹"""
+    mock = AsyncMock()
+    mock.get_profile.return_value = {
+        "profile_url": "https://www.linkedin.com/in/test-user",
+        "full_name": "Test User",
+        "projects": [
+            {"title": "Project", "description": "GitHub: https://github.com/testuser/repo"}
+        ],
+    }
+    return mock
+
+
+@pytest.fixture
+def mock_github_service():
+    """GitHub 서비스 모킹"""
+    mock = AsyncMock()
+    mock.get_account_type.return_value = {
+        "username": "testuser",
+        "type": "User",
+        "name": "Test User",
+        "error": None,
+    }
+    mock.infer_candidate_username.return_value = {
+        "username": "testuser",
+        "confidence": "high",
+        "source": "personal_repo",
+        "personal_repos": ["https://github.com/testuser/repo"],
+        "skipped_org_repos": [],
+    }
+    return mock
+
+
+@pytest.fixture
+def mock_document_parser():
+    """Document Parser 모킹"""
+    mock = AsyncMock()
+    mock.return_value = "Extracted text from document"
+    return mock
+
+
+# ============================================================
+# Temporal Activity 테스트용
+# ============================================================
+
+@pytest.fixture
+def mock_heartbeat():
+    """Temporal heartbeat 모킹"""
+    with patch("temporalio.activity.heartbeat") as mock:
+        mock.side_effect = lambda msg: print(f"  ♥ {msg}")
+        yield mock
+
+
+# ============================================================
+# Phase 2: Analysis Fixtures
+# ============================================================
+
+@pytest.fixture
+def mock_aggregated_analysis():
+    """Phase 2 완료 후 집계 결과 (Phase 3 테스트용)"""
+    return {
+        "document_analysis": {
+            "name": "Test User",
+            "experience_years": 5,
+            "skills": ["Python", "TypeScript", "FastAPI"],
+            "education": [{"school": "Seoul National University"}],
+            "work_history": [{"company": "TechCorp", "title": "Senior Engineer"}],
+            "projects": [{"name": "AI Interview Generator"}],
+            "summary": "Experienced software engineer",
+        },
+        "code_analysis": {
+            "repositories": [
+                {
+                    "repo_url": "https://github.com/testuser/interview-gen",
+                    "repo_name": "interview-gen",
+                    "language": "Python",
+                    "candidate_commits": 150,
+                    "notable_implementations": [
+                        {"title": "Async workflow engine", "complexity": "high"}
+                    ],
+                }
+            ],
+            "combined_tech_stack": ["Python", "FastAPI", "Temporal"],
+            "total_patterns": 5,
+            "total_notable_implementations": 3,
+            "top_question_candidates": [
+                {"title": "Async workflow design", "question_potential": 0.9}
+            ],
+        },
+        "jd_analysis": {
+            "job_title": "AI Engineer",
+            "company_name": "TechCorp",
+            "requirements": [
+                {"skill": "LLM API", "category": "필수"},
+                {"skill": "Python", "category": "필수"},
+            ],
+            "responsibilities": ["AI 서비스 개발", "백엔드 구축"],
+            "company_culture": [],
+        },
+    }

--- a/backend/tests/test_input_enrichment.py
+++ b/backend/tests/test_input_enrichment.py
@@ -1,0 +1,572 @@
+"""
+backend/tests/test_input_enrichment.py
+Phase 0: Input Enrichment Activity 단위 테스트
+
+테스트 항목:
+- P0-01: PDF 텍스트 추출
+- P0-02: GitHub URL 추출 (정규식)
+- P0-03: LinkedIn URL 추출
+- P0-04: LinkedIn 프로필 수집 (Bright Data)
+- P0-05: GitHub User/Org 검증
+- P0-06: available_analyses 결정
+- P0-07: 문서 파싱 실패 graceful 처리
+"""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+# ============================================================
+# P0-01: PDF 텍스트 추출
+# ============================================================
+
+class TestPdfTextExtraction:
+    """P0-01: PDF 텍스트 추출 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_extract_text_from_txt(self, tmp_path):
+        """TXT 파일 추출 (plaintext fallback)"""
+        from app.services.document_parser import extract_text
+
+        test_file = tmp_path / "resume.txt"
+        test_file.write_text("이름: 홍길동\nGitHub: https://github.com/honggildong/project")
+
+        result = await extract_text(str(test_file))
+        assert "홍길동" in result
+        assert "github.com" in result
+
+    @pytest.mark.asyncio
+    async def test_extract_text_file_not_found(self):
+        """존재하지 않는 파일"""
+        from app.services.document_parser import extract_text
+
+        with pytest.raises(FileNotFoundError):
+            await extract_text("/nonexistent/resume.pdf")
+
+    @pytest.mark.asyncio
+    async def test_extract_text_unsupported_format(self, tmp_path):
+        """지원하지 않는 형식"""
+        from app.services.document_parser import extract_text
+
+        test_file = tmp_path / "resume.xyz"
+        test_file.write_text("data")
+
+        with pytest.raises(ValueError, match="Unsupported"):
+            await extract_text(str(test_file))
+
+
+# ============================================================
+# P0-02: GitHub URL 추출
+# ============================================================
+
+class TestGitHubUrlExtraction:
+    """P0-02: GitHub URL 추출 테스트"""
+
+    def test_extract_github_urls_from_text(self):
+        """텍스트에서 GitHub URL 추출"""
+        from app.workflows.activities.input_enrichment import _extract_urls
+
+        text = """
+        Portfolio
+        - Project A: https://github.com/user/project-a
+        - Project B: https://github.com/user/project-b
+        - LinkedIn: https://linkedin.com/in/user
+        """
+        result = _extract_urls(text)
+
+        assert len(result["github"]) == 2
+        assert "https://github.com/user/project-a" in result["github"]
+        assert "https://github.com/user/project-b" in result["github"]
+
+    def test_extract_github_urls_with_org(self):
+        """조직 레포 URL도 추출되는지 확인"""
+        from app.workflows.activities.input_enrichment import _extract_urls
+
+        text = "https://github.com/42cats/crime-cat 프로젝트"
+        result = _extract_urls(text)
+
+        assert "https://github.com/42cats/crime-cat" in result["github"]
+
+    def test_extract_no_github_urls(self):
+        """GitHub URL이 없는 경우"""
+        from app.workflows.activities.input_enrichment import _extract_urls
+
+        text = "일반 텍스트만 있습니다."
+        result = _extract_urls(text)
+
+        assert result["github"] == []
+
+    def test_extract_github_username(self):
+        """GitHub URL에서 username 추출"""
+        from app.workflows.activities.input_enrichment import _extract_github_username
+
+        assert _extract_github_username("https://github.com/user/repo") == "user"
+        assert _extract_github_username("https://github.com/org-name/project") == "org-name"
+        assert _extract_github_username("invalid-url") is None
+
+
+# ============================================================
+# P0-03: LinkedIn URL 추출
+# ============================================================
+
+class TestLinkedInUrlExtraction:
+    """P0-03: LinkedIn URL 추출 테스트"""
+
+    def test_extract_linkedin_url(self):
+        """텍스트에서 LinkedIn URL 추출"""
+        from app.workflows.activities.input_enrichment import _extract_urls
+
+        text = """
+        Contact Info:
+        LinkedIn: https://www.linkedin.com/in/john-doe
+        Email: john@example.com
+        """
+        result = _extract_urls(text)
+
+        assert len(result["linkedin"]) == 1
+        assert "https://www.linkedin.com/in/john-doe" in result["linkedin"]
+
+    def test_extract_linkedin_url_no_www(self):
+        """www 없는 LinkedIn URL"""
+        from app.workflows.activities.input_enrichment import _extract_urls
+
+        text = "LinkedIn: https://linkedin.com/in/john-doe"
+        result = _extract_urls(text)
+
+        assert len(result["linkedin"]) == 1
+
+    def test_extract_no_linkedin_url(self):
+        """LinkedIn URL이 없는 경우"""
+        from app.workflows.activities.input_enrichment import _extract_urls
+
+        text = "No social media links"
+        result = _extract_urls(text)
+
+        assert result["linkedin"] == []
+
+
+# ============================================================
+# P0-04: LinkedIn 프로필 수집 (Bright Data)
+# ============================================================
+
+class TestLinkedInProfileFetch:
+    """P0-04: LinkedIn 프로필 수집 테스트"""
+
+    def test_validate_linkedin_url(self):
+        """LinkedIn URL 유효성 검증"""
+        from app.services.linkedin_service import LinkedInService
+
+        # 유효한 URL
+        assert LinkedInService.validate_url("https://www.linkedin.com/in/john-doe")
+        assert LinkedInService.validate_url("https://linkedin.com/in/john-doe")
+        assert LinkedInService.validate_url("https://linkedin.com/in/john-doe/")
+
+        # 무효한 URL
+        assert not LinkedInService.validate_url("https://linkedin.com/company/acme")
+        assert not LinkedInService.validate_url("https://example.com/in/john")
+        assert not LinkedInService.validate_url("")
+
+    @pytest.mark.asyncio
+    async def test_get_profile_without_token(self):
+        """API 토큰 없으면 None 반환"""
+        from app.services.linkedin_service import LinkedInService
+        from unittest.mock import patch
+
+        # settings.BRIGHTDATA_API_TOKEN도 None으로 설정해야 함
+        with patch("app.services.linkedin_service.settings") as mock_settings:
+            mock_settings.BRIGHTDATA_API_TOKEN = None
+
+            svc = LinkedInService(api_token=None)
+            result = await svc.get_profile("https://linkedin.com/in/john-doe")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_profile_invalid_url(self):
+        """잘못된 URL이면 예외 발생"""
+        from app.services.linkedin_service import LinkedInService
+        from app.exceptions import LinkedInFetchError
+
+        svc = LinkedInService(api_token="test-key")
+        with pytest.raises(LinkedInFetchError, match="Invalid"):
+            await svc.get_profile("not-a-linkedin-url")
+
+    def test_normalize_profile_extracts_github(self):
+        """프로필에서 GitHub URL 추출"""
+        from app.services.linkedin_service import LinkedInService
+
+        svc = LinkedInService(api_token="test")
+        data = {
+            "name": "Test User",
+            "websites": ["https://github.com/testuser"],
+        }
+        result = svc._normalize_profile(data, "https://linkedin.com/in/test")
+
+        assert result["github_url"] == "https://github.com/testuser"
+
+    def test_normalize_profile_handles_null_fields(self):
+        """null 필드 처리"""
+        from app.services.linkedin_service import LinkedInService
+
+        svc = LinkedInService(api_token="test")
+        data = {
+            "name": "Test User",
+            "experience": None,  # null일 수 있음
+            "education": None,
+            "skills": None,
+        }
+        result = svc._normalize_profile(data, "https://linkedin.com/in/test")
+
+        assert result["experiences"] == []
+        assert result["education"] == []
+        assert result["skills"] == []
+
+
+# ============================================================
+# P0-05: GitHub User/Org 검증
+# ============================================================
+
+class TestGitHubUserOrgValidation:
+    """P0-05: GitHub User vs Organization 검증 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_get_account_type_user(self):
+        """개인 계정 타입 확인"""
+        from app.services.github_service import GitHubService
+
+        svc = GitHubService()
+
+        with patch.object(svc, "_get_github") as mock_github:
+            mock_user = MagicMock()
+            mock_user.type = "User"
+            mock_user.name = "Test User"
+            mock_user.avatar_url = "https://example.com/avatar.jpg"
+            mock_user.bio = "Developer"
+            mock_user.company = "TechCorp"
+            mock_github.return_value.get_user.return_value = mock_user
+
+            result = await svc.get_account_type("testuser")
+
+            assert result["type"] == "User"
+            assert result["username"] == "testuser"
+            assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_account_type_organization(self):
+        """조직 계정 타입 확인"""
+        from app.services.github_service import GitHubService
+
+        svc = GitHubService()
+
+        with patch.object(svc, "_get_github") as mock_github:
+            # get_user가 실패하고 get_organization이 성공
+            mock_github.return_value.get_user.side_effect = Exception("Not a user")
+            mock_org = MagicMock()
+            mock_org.name = "42cats"
+            mock_org.avatar_url = "https://example.com/org.jpg"
+            mock_github.return_value.get_organization.return_value = mock_org
+
+            result = await svc.get_account_type("42cats")
+
+            assert result["type"] == "Organization"
+            assert result["username"] == "42cats"
+
+    @pytest.mark.asyncio
+    async def test_infer_username_personal_repo_only(self):
+        """개인 레포 URL만 사용 (조직 레포 건너뜀)"""
+        from app.services.github_service import GitHubService
+
+        svc = GitHubService()
+
+        # Mock get_account_type
+        async def mock_get_account_type(username):
+            if username == "42cats":
+                return {"username": "42cats", "type": "Organization", "error": None}
+            elif username == "sabyunrepo":
+                return {"username": "sabyunrepo", "type": "User", "error": None}
+            return {"username": username, "type": "unknown", "error": "not_found"}
+
+        with patch.object(svc, "get_account_type", side_effect=mock_get_account_type):
+            result = await svc.infer_candidate_username(
+                github_urls=[
+                    "https://github.com/42cats/crime-cat",  # Organization
+                    "https://github.com/sabyunrepo/Sesami",  # User (sabyunrepo 계정)
+                ],
+                candidate_name="BYUN SANGHOON",
+            )
+
+            assert result["username"] == "sabyunrepo"
+            assert result["confidence"] == "high"
+            assert "https://github.com/42cats/crime-cat" in result["skipped_org_repos"]
+            assert "https://github.com/sabyunrepo/Sesami" in result["personal_repos"]
+
+    @pytest.mark.asyncio
+    async def test_infer_username_real_api_call(self):
+        """실제 GitHub API 호출 테스트 (sabyunrepo 계정)"""
+        from app.services.github_service import GitHubService
+
+        svc = GitHubService()
+
+        # 실제 API 호출 (인증 없이 공개 API)
+        result = await svc.get_account_type("sabyunrepo")
+
+        # sabyunrepo는 User 타입
+        assert result["username"] == "sabyunrepo"
+        assert result["type"] == "User"
+        assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_infer_username_no_personal_repos(self):
+        """개인 레포가 없으면 username None"""
+        from app.services.github_service import GitHubService
+
+        svc = GitHubService()
+
+        async def mock_get_account_type(username):
+            return {"username": username, "type": "Organization", "error": None}
+
+        with patch.object(svc, "get_account_type", side_effect=mock_get_account_type):
+            result = await svc.infer_candidate_username(
+                github_urls=["https://github.com/org1/repo", "https://github.com/org2/repo"],
+            )
+
+            assert result["username"] is None
+            assert result["confidence"] == "none"
+            assert len(result["skipped_org_repos"]) == 2
+            assert len(result["personal_repos"]) == 0
+
+
+# ============================================================
+# P0-06: available_analyses 결정
+# ============================================================
+
+class TestAvailableAnalysesDecision:
+    """P0-06: 사용 가능한 분석 결정 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_jd_only_analysis(self):
+        """JD만 있을 때"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        from unittest.mock import patch
+
+        input_data = {
+            "jd_text": "Test JD",
+            "resume_path": None,
+            "portfolio_path": None,
+            "cover_letter_path": None,
+            "linkedin_url": None,
+            "github_urls": [],
+        }
+
+        with patch("app.workflows.activities.input_enrichment.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+
+            result = await enrich_input(input_data)
+
+            assert "jd_analysis" in result["available_analyses"]
+            assert "document_analysis" not in result["available_analyses"]
+            assert "code_analysis" not in result["available_analyses"]
+
+    @pytest.mark.asyncio
+    async def test_all_analyses_available(self):
+        """모든 분석 가능할 때"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        from unittest.mock import patch
+
+        input_data = {
+            "jd_text": "Test JD",
+            "resume_path": "/tmp/resume.pdf",  # 문서 있음
+            "portfolio_path": None,
+            "cover_letter_path": None,
+            "linkedin_url": None,
+            "github_urls": ["https://github.com/user/repo"],  # GitHub 있음
+        }
+
+        # Mock 설정
+        async def mock_extract_text(path):
+            return "Mock resume content with GitHub: https://github.com/user/repo"
+
+        async def mock_get_account_type(username):
+            return {"username": username, "type": "User", "error": None}
+
+        async def mock_infer_username(github_urls, candidate_name=None):
+            return {
+                "username": "user",
+                "confidence": "high",
+                "personal_repos": github_urls,
+                "skipped_org_repos": [],
+            }
+
+        # extract_text는 함수 내부에서 동적으로 import되므로 소스 모듈을 mock
+        with patch("app.workflows.activities.input_enrichment.activity") as mock_activity, \
+             patch("app.services.document_parser.extract_text", side_effect=mock_extract_text), \
+             patch("app.services.github_service.GitHubService.get_account_type", side_effect=mock_get_account_type), \
+             patch("app.services.github_service.GitHubService.infer_candidate_username", side_effect=mock_infer_username):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await enrich_input(input_data)
+
+            assert "jd_analysis" in result["available_analyses"]
+            # document_analysis는 resume_path가 있으면 포함
+            # code_analysis는 personal_repos가 있으면 포함
+
+    @pytest.mark.asyncio
+    async def test_code_analysis_disabled_without_personal_repos(self):
+        """개인 레포 없으면 code_analysis 비활성화"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        from unittest.mock import patch
+
+        input_data = {
+            "jd_text": "Test JD",
+            "github_urls": ["https://github.com/org/repo"],  # 조직 레포만
+        }
+
+        async def mock_infer_username(github_urls, candidate_name=None):
+            return {
+                "username": None,
+                "confidence": "none",
+                "personal_repos": [],  # 개인 레포 없음
+                "skipped_org_repos": github_urls,
+            }
+
+        with patch("app.workflows.activities.input_enrichment.activity") as mock_activity, \
+             patch("app.services.github_service.GitHubService.infer_candidate_username", side_effect=mock_infer_username):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await enrich_input(input_data)
+
+            assert "code_analysis" not in result["available_analyses"]
+
+
+# ============================================================
+# P0-07: 문서 파싱 실패 graceful 처리
+# ============================================================
+
+class TestGracefulDocumentParsingFailure:
+    """P0-07: 문서 파싱 실패 시 graceful 처리 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_resume_parse_failure_continues(self):
+        """이력서 파싱 실패해도 계속 진행"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        from unittest.mock import patch
+
+        input_data = {
+            "jd_text": "Test JD",
+            "resume_path": "/tmp/corrupted.pdf",
+            "linkedin_url": "https://www.linkedin.com/in/test-user",
+        }
+
+        async def mock_extract_text(path):
+            raise ValueError("All parsers failed for: /tmp/corrupted.pdf")
+
+        mock_linkedin_profile = {
+            "profile_url": "https://www.linkedin.com/in/test-user",
+            "full_name": "Test User",
+            "github_url": None,
+        }
+
+        # extract_text는 함수 내부에서 동적으로 import되므로 소스 모듈을 mock
+        with patch("app.workflows.activities.input_enrichment.activity") as mock_activity, \
+             patch("app.services.document_parser.extract_text", side_effect=mock_extract_text), \
+             patch("app.services.linkedin_service.LinkedInService.get_profile", return_value=mock_linkedin_profile):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await enrich_input(input_data)
+
+            # 파싱 실패해도 결과 반환
+            assert result is not None
+            # document_errors에 실패 기록
+            assert len(result.get("document_errors", [])) >= 1
+            assert result["document_errors"][0]["source"] == "resume"
+            # LinkedIn은 성공
+            assert result.get("linkedin_profile") is not None
+
+    @pytest.mark.asyncio
+    async def test_all_documents_fail_continues(self):
+        """모든 문서 파싱 실패해도 계속 진행"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        from unittest.mock import patch
+
+        input_data = {
+            "jd_text": "Test JD",
+            "resume_path": "/tmp/bad1.pdf",
+            "portfolio_path": "/tmp/bad2.pdf",
+            "cover_letter_path": "/tmp/bad3.pdf",
+        }
+
+        async def mock_extract_text(path):
+            raise ValueError(f"All parsers failed for: {path}")
+
+        # extract_text는 함수 내부에서 동적으로 import되므로 소스 모듈을 mock
+        with patch("app.workflows.activities.input_enrichment.activity") as mock_activity, \
+             patch("app.services.document_parser.extract_text", side_effect=mock_extract_text):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await enrich_input(input_data)
+
+            # 모두 실패해도 결과 반환
+            assert result is not None
+            # 3개 모두 기록
+            assert len(result.get("document_errors", [])) == 3
+            # JD 분석은 여전히 가능
+            assert "jd_analysis" in result["available_analyses"]
+
+
+# ============================================================
+# 통합 테스트
+# ============================================================
+
+class TestInputEnrichmentIntegration:
+    """Input Enrichment Activity 통합 테스트"""
+
+    def test_activity_is_defn(self):
+        """Activity 데코레이터 확인"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        assert hasattr(enrich_input, "__temporal_activity_definition")
+
+    @pytest.mark.asyncio
+    async def test_minimal_input(self):
+        """최소 입력 (JD만)"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        from unittest.mock import patch
+
+        input_data = {"jd_text": "Simple JD for testing"}
+
+        with patch("app.workflows.activities.input_enrichment.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+
+            result = await enrich_input(input_data)
+
+            assert result["raw_input"] == input_data
+            assert result["github_urls"] == []
+            assert result["linkedin_profile"] is None
+            assert "jd_analysis" in result["available_analyses"]
+
+    @pytest.mark.asyncio
+    async def test_output_structure(self):
+        """출력 구조 검증"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        from unittest.mock import patch
+
+        input_data = {"jd_text": "Test JD"}
+
+        with patch("app.workflows.activities.input_enrichment.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+
+            result = await enrich_input(input_data)
+
+            # 필수 필드 확인
+            required_fields = [
+                "raw_input",
+                "github_urls",
+                "candidate_github_username",
+                "linkedin_profile",
+                "extraction_sources",
+                "available_analyses",
+                "document_errors",
+            ]
+            for field in required_fields:
+                assert field in result, f"Missing field: {field}"

--- a/backend/tests/test_linkedin_service.py
+++ b/backend/tests/test_linkedin_service.py
@@ -61,7 +61,7 @@ class TestNormalizeProfile:
         result = svc._normalize_profile(data, "https://linkedin.com/in/john")
         assert result["full_name"] == "John Doe"
         assert result["country"] == "Korea"
-        assert result["url"] == "https://linkedin.com/in/john"
+        assert result["profile_url"] == "https://linkedin.com/in/john"
 
     def test_github_extraction_from_personal_urls(self):
         from app.services.linkedin_service import LinkedInService
@@ -118,9 +118,15 @@ class TestGetProfileNoKey:
     @pytest.mark.asyncio
     async def test_returns_none_without_token(self):
         from app.services.linkedin_service import LinkedInService
-        svc = LinkedInService(api_token="")
-        result = await svc.get_profile("https://linkedin.com/in/john")
-        assert result is None
+        from unittest.mock import patch
+
+        # settings.BRIGHTDATA_API_TOKEN도 None으로 설정해야 함
+        with patch("app.services.linkedin_service.settings") as mock_settings:
+            mock_settings.BRIGHTDATA_API_TOKEN = None
+
+            svc = LinkedInService(api_token=None)
+            result = await svc.get_profile("https://linkedin.com/in/john")
+            assert result is None
 
     @pytest.mark.asyncio
     async def test_invalid_url_raises(self):

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,525 @@
+# Vantict Sniper v4.0 - 단위 테스트 계획서
+
+> 전체 워크플로우를 단위별로 분해하여 체계적인 테스트 진행
+
+---
+
+## 1. 테스트 단위 분해 (Phase별)
+
+### 전체 파이프라인 개요
+
+```
+Phase 0: Input Enrichment (enrich_input)
+    ↓
+Phase 1: Planning (create_execution_plan)
+    ↓
+Phase 2: Parallel Analysis
+    ├── analyze_documents
+    ├── analyze_code (4-Channel)
+    └── analyze_jd
+    ↓
+Phase 3: Question Generation (Multi-Agent)
+    ├── 3a. select_topics
+    ├── 3b. craft_question (×25 병렬)
+    ├── 3c. enhance_terminology
+    ├── 3d. craft_evaluation_scenarios
+    ├── 3e. design_follow_ups
+    ├── 3f. generate_interviewer_notes
+    ├── 3g. generate_decision_guide
+    └── 3h. review_questions (+ revise_questions)
+    ↓
+Phase 4: Finalization (finalize_output)
+```
+
+---
+
+## 2. 테스트 단위 상세
+
+### 2.1 Phase 0: Input Enrichment
+
+| 테스트 ID | 테스트 항목 | 입력 | 예상 출력 | 토큰 비용 |
+|-----------|-------------|------|----------|----------|
+| P0-01 | PDF 텍스트 추출 | resume.pdf | 텍스트 문자열 | 0 |
+| P0-02 | GitHub URL 추출 | PDF 텍스트 | `["https://github.com/..."]` | 0 |
+| P0-03 | LinkedIn URL 추출 | PDF 텍스트 | `"https://linkedin.com/in/..."` | 0 |
+| P0-04 | LinkedIn 프로필 수집 | linkedin_url | LinkedInProfile dict | ~$0.01 (Bright Data) |
+| P0-05 | GitHub User/Org 검증 | github_urls | personal_repos, skipped_org_repos | 0 (GitHub API) |
+| P0-06 | available_analyses 결정 | enriched_input | `["jd_analysis", ...]` | 0 |
+| P0-07 | 문서 파싱 실패 처리 | 손상된 PDF | document_errors 필드에 기록, 계속 진행 | 0 |
+
+**테스트 스크립트 위치**: `backend/tests/test_input_enrichment.py`
+
+```python
+# P0-05 테스트 예시: GitHub User/Org 검증
+async def test_github_user_org_validation():
+    """조직 URL은 건너뛰고, 개인 레포만 반환"""
+    from app.services.github_service import GitHubService
+
+    svc = GitHubService()
+    result = await svc.infer_candidate_username(
+        github_urls=[
+            "https://github.com/42cats/crime-cat",  # Organization
+            "https://github.com/sabyunrepo/Sesami",  # User
+        ],
+        candidate_name="BYUN SANGHOON"
+    )
+
+    assert result["username"] == "sabyunrepo"
+    assert result["confidence"] == "high"
+    assert "https://github.com/42cats/crime-cat" in result["skipped_org_repos"]
+    assert "https://github.com/sabyunrepo/Sesami" in result["personal_repos"]
+```
+
+---
+
+### 2.2 Phase 1: Planning
+
+| 테스트 ID | 테스트 항목 | 입력 | 예상 출력 | 토큰 비용 |
+|-----------|-------------|------|----------|----------|
+| P1-01 | JD 기술스택 추출 | jd_text | `["Python", "FastAPI", ...]` | ~500 토큰 |
+| P1-02 | GitHub 워크로드 추정 | github_urls | repo별 size, languages | 0 (GitHub API) |
+| P1-03 | 실행 계획 생성 | enriched_input | ExecutionPlan dict | ~500 토큰 |
+| P1-04 | phases 활성화 결정 | available_analyses | `[{name, enabled}, ...]` | 0 |
+
+**테스트 스크립트 위치**: `backend/tests/test_planning.py`
+
+---
+
+### 2.3 Phase 2: Parallel Analysis
+
+#### 2.3.1 Document Analysis
+
+| 테스트 ID | 테스트 항목 | 입력 | 예상 출력 | 토큰 비용 |
+|-----------|-------------|------|----------|----------|
+| P2D-01 | Docling PDF 파싱 | resume.pdf | Markdown 텍스트 | 0 |
+| P2D-02 | pymupdf4llm 폴백 | Docling 실패 PDF | Markdown 텍스트 | 0 |
+| P2D-03 | LLM 프로필 추출 | parsed_text | CandidateProfile | ~2,000 토큰 |
+| P2D-04 | LinkedIn 프로필 통합 | linkedin_profile | 통합된 프로필 | ~500 토큰 |
+
+**테스트 스크립트 위치**: `backend/tests/test_document_analysis.py`
+
+#### 2.3.2 Code Analysis (4-Channel)
+
+| 테스트 ID | 테스트 항목 | 입력 | 예상 출력 | 토큰 비용 |
+|-----------|-------------|------|----------|----------|
+| P2C-01 | JD 매칭 레포 필터링 | github_urls, jd_tech_stack | matched_repos | 0 (GitHub API) |
+| P2C-02 | PyDriller diff 추출 | repo_url, author | commits, files | 0 |
+| P2C-03 | AST 분석 (Python) | .py 파일들 | functions, classes, patterns | 0 |
+| P2C-04 | AST 분석 (JS/TS) | .ts 파일들 | functions, classes | 0 |
+| P2C-05 | LLM 코드 의미 분석 | ranked_files | notable_implementations | ~5,000 토큰/레포 |
+| P2C-06 | Channel B: OSS PR | username | merged_prs | 0 (GitHub API) |
+| P2C-07 | Channel C: Issues | username | issues | 0 (GitHub API) |
+| P2C-08 | Channel D: Reviews | username | code_reviews | 0 (GitHub API) |
+| P2C-09 | 4-Channel 통합 | all_channels | aggregated_result | 0 |
+
+**테스트 스크립트 위치**: `backend/tests/test_code_analysis.py`
+
+#### 2.3.3 JD Analysis
+
+| 테스트 ID | 테스트 항목 | 입력 | 예상 출력 | 토큰 비용 |
+|-----------|-------------|------|----------|----------|
+| P2J-01 | JD 파싱 | jd_text | JDAnalysis | ~1,500 토큰 |
+| P2J-02 | requirements 추출 | jd_text | `[{skill, category}, ...]` | 포함 |
+| P2J-03 | company_culture 추출 | jd_text | `["...", ...]` | 포함 |
+
+**테스트 스크립트 위치**: `backend/tests/test_jd_analysis.py`
+
+---
+
+### 2.4 Phase 3: Question Generation
+
+| 테스트 ID | 테스트 항목 | 입력 | 예상 출력 | 토큰 비용 |
+|-----------|-------------|------|----------|----------|
+| P3a-01 | 토픽 선정 | aggregated_analysis | 25개 토픽 | ~3,000 토큰 |
+| P3b-01 | 단일 질문 생성 | topic, analysis | InterviewQuestion | ~1,500 토큰 |
+| P3b-02 | 25개 질문 병렬 생성 | 25 topics | 25 questions | ~37,500 토큰 |
+| P3c-01 | 용어 설명 생성 | questions | terminology_map | ~2,000 토큰 |
+| P3d-01 | 평가 시나리오 생성 | questions | evaluation_scenarios | ~3,000 토큰 |
+| P3e-01 | 꼬리질문 설계 | questions | follow_ups | ~2,500 토큰 |
+| P3f-01 | 면접관 노트 생성 | questions | interviewer_notes | ~2,000 토큰 |
+| P3g-01 | 결정 가이드 생성 | aggregated | decision_guide | ~2,000 토큰 |
+| P3h-01 | 품질 검토 | questions | review_result | ~3,000 토큰 |
+| P3h-02 | 질문 수정 | questions, feedback | revised_questions | ~2,000 토큰 |
+
+**테스트 스크립트 위치**: `backend/tests/test_question_generation.py`
+
+---
+
+### 2.5 Phase 4: Finalization
+
+| 테스트 ID | 테스트 항목 | 입력 | 예상 출력 | 토큰 비용 |
+|-----------|-------------|------|----------|----------|
+| P4-01 | Hallucination 검증 | questions | validated_questions | ~1,000 토큰 |
+| P4-02 | 용어집 통합 | questions | full_glossary | 0 |
+| P4-03 | 후보자 요약 생성 | analysis | candidate_summary | ~1,500 토큰 |
+| P4-04 | 면접관 가이드 생성 | questions | interviewer_guide | ~1,500 토큰 |
+| P4-05 | S3 저장 | final_script | s3_path | 0 |
+
+**테스트 스크립트 위치**: `backend/tests/test_finalization.py`
+
+---
+
+## 3. 토큰 최적화 전략
+
+### 3.1 단계별 테스트 분리
+
+**원칙**: 각 Phase를 독립적으로 테스트하여 불필요한 LLM 호출 방지
+
+```
+# ❌ 비효율적 (전체 파이프라인)
+pytest tests/test_workflow.py  # ~70,000 토큰
+
+# ✅ 효율적 (Phase별 분리)
+pytest tests/test_input_enrichment.py  # ~0 토큰
+pytest tests/test_planning.py          # ~1,000 토큰
+pytest tests/test_code_analysis.py     # ~5,000 토큰
+pytest tests/test_question_generation.py --topic-only  # ~3,000 토큰
+```
+
+### 3.2 Mock/Fixture 활용
+
+```python
+# conftest.py
+import pytest
+from unittest.mock import AsyncMock
+
+@pytest.fixture
+def mock_enriched_input():
+    """Phase 0 결과를 미리 준비 (Phase 1+ 테스트용)"""
+    return {
+        "raw_input": {...},
+        "github_urls": ["https://github.com/user/repo"],
+        "linkedin_profile": {"full_name": "Test User"},
+        "available_analyses": ["jd_analysis", "document_analysis", "code_analysis"],
+    }
+
+@pytest.fixture
+def mock_aggregated_analysis():
+    """Phase 2 결과를 미리 준비 (Phase 3 테스트용)"""
+    return {
+        "document_analysis": {...},
+        "code_analysis": {...},
+        "jd_analysis": {...},
+    }
+
+@pytest.fixture
+def mock_llm_service():
+    """LLM 호출 모킹 (토큰 0)"""
+    mock = AsyncMock()
+    mock.run.return_value.data = MockResponse()
+    return mock
+```
+
+### 3.3 캐시 활용
+
+```python
+# LiteLLM Redis 캐시 활용
+# 동일 프롬프트 재테스트 시 API 호출 0
+
+# 테스트 환경에서 캐시 강제 활성화
+import litellm
+litellm.cache = litellm.Cache(type="redis", host="localhost", port=6379)
+
+# 캐시 히트 확인
+@pytest.mark.parametrize("run", range(3))
+async def test_with_cache(run):
+    result = await llm_service.run(SAME_PROMPT)
+    # run 1: API 호출 (캐시 미스)
+    # run 2, 3: 캐시 히트 (토큰 0)
+```
+
+### 3.4 토큰 예산 추정
+
+| Phase | 예상 토큰 | 예상 비용 (GPT-4o) |
+|-------|----------|-------------------|
+| Phase 0 | ~0 | $0.00 |
+| Phase 1 | ~1,000 | $0.01 |
+| Phase 2 (docs) | ~2,500 | $0.025 |
+| Phase 2 (code) | ~15,000 | $0.15 |
+| Phase 2 (jd) | ~1,500 | $0.015 |
+| Phase 3 | ~55,000 | $0.55 |
+| Phase 4 | ~5,000 | $0.05 |
+| **총계** | **~80,000** | **~$0.80/job** |
+
+---
+
+## 4. 테스트 실행 순서
+
+### 4.1 권장 테스트 순서
+
+```bash
+# 1단계: 외부 의존성 없는 유틸리티 테스트
+pytest tests/test_utils.py -v
+
+# 2단계: Phase 0 (API 호출 최소)
+pytest tests/test_input_enrichment.py -v
+
+# 3단계: Phase 1 (LLM 1회)
+pytest tests/test_planning.py -v --mock-llm  # 모킹 모드
+pytest tests/test_planning.py -v             # 실제 LLM
+
+# 4단계: Phase 2 개별 (병렬 가능)
+pytest tests/test_document_analysis.py -v
+pytest tests/test_code_analysis.py -v
+pytest tests/test_jd_analysis.py -v
+
+# 5단계: Phase 3 (가장 비용 큼 - 신중히)
+pytest tests/test_question_generation.py -v --topic-only  # 토픽만
+pytest tests/test_question_generation.py -v -k "craft_question"  # 질문 1개만
+
+# 6단계: Phase 4
+pytest tests/test_finalization.py -v
+
+# 7단계: E2E 통합 (최종 확인용)
+pytest tests/test_e2e_workflow.py -v
+```
+
+### 4.2 CI/CD 환경 설정
+
+```yaml
+# .github/workflows/test.yml
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unit Tests (Mock LLM)
+        run: pytest tests/ -v --mock-llm -x
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Integration Tests (Real LLM)
+        run: pytest tests/test_e2e_workflow.py -v
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+---
+
+## 5. 디버깅 및 프롬프트 개발 워크플로우
+
+### 5.1 프롬프트 디버깅 프로세스
+
+```
+1. 문제 발견
+   └─ 로그 확인: docker logs vantict-worker
+   └─ Langfuse 트레이스 확인
+
+2. 프롬프트 격리
+   └─ 해당 Activity만 단독 테스트
+   └─ 입력 데이터 덤프 (JSON)
+
+3. 프롬프트 수정
+   └─ backend/app/prompts/*.yaml 편집
+   └─ Langfuse에서 버전 관리
+
+4. 단위 테스트
+   └─ pytest tests/test_<activity>.py -v -k "specific_test"
+
+5. 통합 확인
+   └─ Docker에서 해당 Phase만 재실행
+```
+
+### 5.2 Activity 단독 테스트 템플릿
+
+```python
+# scratchpad/test_activity_isolated.py
+"""단일 Activity 격리 테스트"""
+import asyncio
+import json
+from temporalio import activity as temporal_activity
+
+# Heartbeat 모킹
+temporal_activity.heartbeat = lambda msg: print(f"♥ {msg}")
+
+async def test_isolated():
+    # 1. 입력 데이터 로드 (이전 Phase 결과)
+    with open("/tmp/enriched_input.json") as f:
+        enriched_input = json.load(f)
+
+    # 2. 테스트 대상 Activity import
+    from app.workflows.activities.planning import create_execution_plan
+
+    # 3. 실행
+    result = await create_execution_plan("test-job-001", enriched_input)
+
+    # 4. 결과 저장
+    with open("/tmp/execution_plan.json", "w") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+if __name__ == "__main__":
+    asyncio.run(test_isolated())
+```
+
+### 5.3 Langfuse 트레이스 활용
+
+```python
+# 프롬프트 버전 관리
+from langfuse import Langfuse
+
+langfuse = Langfuse()
+
+# 프롬프트 가져오기 (버전 지정)
+prompt = langfuse.get_prompt("select_topics", version=3)
+
+# 트레이스 생성
+trace = langfuse.trace(name="test_select_topics", metadata={"test": True})
+
+# LLM 호출
+generation = trace.generation(
+    name="select_topics",
+    model="gpt-4o",
+    input=prompt.compile(context=analysis),
+)
+
+result = await llm.run(prompt.compile(context=analysis))
+
+generation.end(output=result)
+trace.update(output={"topics_count": len(result)})
+```
+
+---
+
+## 6. Docker 테스트 환경
+
+### 6.1 테스트용 Docker 명령
+
+```bash
+# 서비스 시작
+make up
+
+# 백엔드 컨테이너 진입
+docker exec -it vantict-backend bash
+
+# Python 경로 확인
+which python  # /usr/local/bin/python
+
+# 테스트 실행 (컨테이너 내부)
+cd /app
+python -m pytest tests/test_input_enrichment.py -v
+
+# 단독 Activity 테스트
+python scratchpad/test_activity_isolated.py
+```
+
+### 6.2 테스트 파일 복사
+
+```bash
+# 호스트 → 컨테이너
+docker cp ./test_data/resume.pdf vantict-backend:/tmp/
+docker cp ./test_data/portfolio.pdf vantict-backend:/tmp/
+
+# 컨테이너 → 호스트
+docker cp vantict-backend:/tmp/result.json ./test_output/
+```
+
+### 6.3 로그 확인
+
+```bash
+# Worker 로그
+docker logs -f vantict-worker
+
+# 특정 Phase 로그 필터링
+docker logs vantict-worker 2>&1 | grep "Phase 2"
+
+# Temporal Web UI
+open http://localhost:8233
+```
+
+---
+
+## 7. 테스트 체크리스트
+
+### Phase 0: Input Enrichment
+- [ ] P0-01: PDF 텍스트 추출
+- [ ] P0-02: GitHub URL 추출 (정규식)
+- [ ] P0-03: LinkedIn URL 추출
+- [ ] P0-04: Bright Data LinkedIn 프로필
+- [ ] P0-05: GitHub User/Org 검증 ✅ (PR #37)
+- [ ] P0-06: available_analyses 결정
+- [ ] P0-07: 문서 파싱 실패 graceful 처리 ✅ (PR #37)
+
+### Phase 1: Planning
+- [ ] P1-01: JD 기술스택 추출
+- [ ] P1-02: GitHub 워크로드 추정
+- [ ] P1-03: 실행 계획 생성
+- [ ] P1-04: phases 활성화 결정
+
+### Phase 2: Analysis
+- [ ] P2D-01~04: Document Analysis
+- [ ] P2C-01~09: Code Analysis (4-Channel)
+- [ ] P2J-01~03: JD Analysis
+
+### Phase 3: Question Generation
+- [ ] P3a-01: 토픽 선정
+- [ ] P3b-01~02: 질문 생성
+- [ ] P3c-01: 용어 설명
+- [ ] P3d-01: 평가 시나리오
+- [ ] P3e-01: 꼬리질문
+- [ ] P3f-01: 면접관 노트
+- [ ] P3g-01: 결정 가이드
+- [ ] P3h-01~02: 품질 검토/수정
+
+### Phase 4: Finalization
+- [ ] P4-01: Hallucination 검증
+- [ ] P4-02: 용어집 통합
+- [ ] P4-03: 후보자 요약
+- [ ] P4-04: 면접관 가이드
+- [ ] P4-05: S3 저장
+
+---
+
+## 8. 빠른 참조
+
+### 테스트 파일 위치
+```
+backend/tests/
+├── conftest.py                    # Fixtures
+├── test_input_enrichment.py       # Phase 0
+├── test_planning.py               # Phase 1
+├── test_document_analysis.py      # Phase 2
+├── test_code_analysis.py          # Phase 2
+├── test_jd_analysis.py            # Phase 2
+├── test_question_generation.py    # Phase 3
+├── test_quality_review.py         # Phase 3
+├── test_finalization.py           # Phase 4
+└── test_e2e_workflow.py           # E2E
+```
+
+### 자주 사용하는 명령
+```bash
+# Phase별 테스트
+pytest tests/test_input_enrichment.py -v
+
+# 특정 테스트만
+pytest tests/test_code_analysis.py -v -k "test_github_user_org"
+
+# Mock LLM 모드
+pytest tests/ --mock-llm -v
+
+# Docker 내 테스트
+docker exec -it vantict-backend pytest tests/test_input_enrichment.py -v
+
+# 단독 Activity 테스트
+docker exec -it vantict-backend python /tmp/test_activity.py
+```
+
+### 환경 변수
+```bash
+# 테스트 모드 활성화
+export VANTICT_TEST_MODE=true
+
+# LLM 캐시 강제 활성화
+export LITELLM_CACHE=redis
+
+# GitHub API 토큰 (rate limit 회피)
+export GITHUB_TOKEN=ghp_xxxxx
+```
+
+---
+
+*작성일: 2026-02-04*
+*마지막 업데이트: PR #37 (GitHub User/Org Validation) 반영*


### PR DESCRIPTION
## Summary
- Phase 0 (Input Enrichment) Activity의 단위 테스트 28개 케이스 구현
- 전체 워크플로우 테스트 계획 문서(TEST_PLAN.md) 추가
- pytest fixtures 및 공통 테스트 유틸리티 설정

## Test Coverage
| 항목 | 테스트 케이스 | 상태 |
|------|-------------|------|
| P0-01: PDF 텍스트 추출 | 3개 | ✅ Pass |
| P0-02: GitHub URL 추출 | 4개 | ✅ Pass |
| P0-03: LinkedIn URL 추출 | 3개 | ✅ Pass |
| P0-04: LinkedIn 프로필 수집 | 5개 | ✅ Pass |
| P0-05: GitHub User/Org 검증 | 5개 | ✅ Pass |
| P0-06: available_analyses 결정 | 3개 | ✅ Pass |
| P0-07: 문서 파싱 실패 처리 | 2개 | ✅ Pass |
| 통합 테스트 | 3개 | ✅ Pass |

## Test plan
- [x] `pytest tests/test_input_enrichment.py -v` - 28 passed
- [x] `pytest tests/test_linkedin_service.py -v` - 22 passed
- [x] Docker 컨테이너 환경에서 모든 테스트 통과 확인

## Files Changed
- `backend/tests/conftest.py` - 새로 추가 (공통 fixtures)
- `backend/tests/test_input_enrichment.py` - 새로 추가 (28개 테스트)
- `backend/tests/test_linkedin_service.py` - 수정 (API 토큰 테스트 개선)
- `docs/TEST_PLAN.md` - 새로 추가 (전체 테스트 계획)

🤖 Generated with [Claude Code](https://claude.com/claude-code)