### PR TITLE
test: Phase 2 Parallel Analysis 단위 테스트

### DIFF
--- a/backend/tests/test_code_analysis.py
+++ b/backend/tests/test_code_analysis.py
@@ -1,0 +1,203 @@
+"""
+backend/tests/test_code_analysis.py
+Phase 2: Code Analysis Activity 단위 테스트
+
+테스트 항목:
+- P2C-01: JD 매칭 레포 필터링
+- P2C-02: PyDriller diff 추출
+- P2C-03: AST 분석
+- P2C-04: 4-Phase 통합
+- P2C-05: 빈 결과 처리
+"""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+# ============================================================
+# P2C-01: JD 매칭 레포 필터링 테스트
+# ============================================================
+
+class TestJdMatchingRepoFilter:
+    """P2C-01: JD 매칭 레포 필터링 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_filter_repos_by_language(self):
+        """언어 기반 레포 필터링"""
+        from app.services.github_service import GitHubService
+
+        svc = GitHubService()
+
+        async def mock_get_repo_languages(url):
+            if "python-repo" in url:
+                return {"Python": 80000, "JavaScript": 10000}
+            elif "js-repo" in url:
+                return {"JavaScript": 90000}
+            return {}
+
+        async def mock_get_repo_info(url):
+            return {"url": url, "name": url.split("/")[-1]}
+
+        with patch.object(svc, "get_repo_languages", side_effect=mock_get_repo_languages), \
+             patch.object(svc, "get_repo_info", side_effect=mock_get_repo_info):
+
+            result = await svc.filter_repos_by_language(
+                github_urls=[
+                    "https://github.com/user/python-repo",
+                    "https://github.com/user/js-repo",
+                ],
+                target_languages=["Python"],
+                min_language_ratio=0.3,
+            )
+
+            # Python 비율이 30% 이상인 레포만 반환
+            assert len(result) >= 1
+            assert any("python-repo" in r.get("url", "") for r in result)
+
+
+# ============================================================
+# P2C-02: _jd_to_file_types 테스트
+# ============================================================
+
+class TestJdToFileTypes:
+    """P2C-02: JD 기술스택 → 파일 확장자 변환 테스트"""
+
+    def test_python_file_types(self):
+        """Python → .py"""
+        from app.workflows.activities.code_analysis import _jd_to_file_types
+
+        result = _jd_to_file_types(["Python"])
+        assert ".py" in result
+
+    def test_javascript_typescript_file_types(self):
+        """JavaScript/TypeScript → .js, .ts 등"""
+        from app.workflows.activities.code_analysis import _jd_to_file_types
+
+        result = _jd_to_file_types(["JavaScript", "TypeScript"])
+        assert ".js" in result
+        assert ".ts" in result
+        assert ".jsx" in result
+        assert ".tsx" in result
+
+    def test_empty_tech_stack(self):
+        """빈 기술스택 → 기본값 .py"""
+        from app.workflows.activities.code_analysis import _jd_to_file_types
+
+        result = _jd_to_file_types([])
+        assert result == [".py"]
+
+    def test_unknown_tech_stack(self):
+        """알 수 없는 기술스택 → 기본값 .py"""
+        from app.workflows.activities.code_analysis import _jd_to_file_types
+
+        result = _jd_to_file_types(["UnknownLang"])
+        assert result == [".py"]
+
+
+# ============================================================
+# P2C-03: Code Analysis Activity 테스트
+# ============================================================
+
+class TestCodeAnalysisActivity:
+    """P2C-03: Code Analysis Activity 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_analyze_code_no_repos(self):
+        """GitHub URL이 없을 때"""
+        from app.workflows.activities.code_analysis import analyze_code
+        from unittest.mock import patch
+
+        async def mock_filter_repos(github_urls, target_languages, min_language_ratio):
+            return []  # 매칭되는 레포 없음
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity, \
+             patch("app.services.github_service.GitHubService.filter_repos_by_language", side_effect=mock_filter_repos):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await analyze_code(
+                github_urls=[],
+                input_data={"candidate_github_username": "testuser"},
+            )
+
+            assert result["repositories"] == []
+            assert result["top_question_candidates"] == []
+
+    @pytest.mark.asyncio
+    async def test_analyze_code_with_repos(self):
+        """레포가 있을 때 분석 수행"""
+        from app.workflows.activities.code_analysis import analyze_code
+        from unittest.mock import patch
+
+        async def mock_filter_repos(github_urls, target_languages, min_language_ratio):
+            return [
+                {"url": "https://github.com/user/repo", "name": "repo", "languages": {"Python": 80000}}
+            ]
+
+        async def mock_pydriller(repo_url, job_id, author, since_years, file_types):
+            return {
+                "files": [{"path": "main.py", "content": "print('hello')"}],
+                "stats": {"total_commits": 10, "total_additions": 500, "avg_complexity": 5.0},
+            }
+
+        async def mock_ast_analyze(files, primary_language):
+            return {"functions": 5, "classes": 2}
+
+        def mock_rank_files(files, jd_tech_stack, token_budget):
+            return files
+
+        async def mock_llm_analyze(ranked_files, ast_context):
+            return {"notable_implementations": [{"title": "Main function", "complexity": "low"}]}
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity, \
+             patch("app.services.github_service.GitHubService.filter_repos_by_language", side_effect=mock_filter_repos), \
+             patch("app.services.code_analyzer.CodeAnalyzer.analyze_with_pydriller", side_effect=mock_pydriller), \
+             patch("app.services.code_analyzer.CodeAnalyzer.select_top_files", return_value=[]), \
+             patch("app.services.code_analyzer.CodeAnalyzer.analyze_ast", side_effect=mock_ast_analyze), \
+             patch("app.services.code_analyzer.CodeAnalyzer.rank_files_for_llm", side_effect=mock_rank_files), \
+             patch("app.services.code_analyzer.CodeAnalyzer.llm_analyze_code", side_effect=mock_llm_analyze):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await analyze_code(
+                github_urls=["https://github.com/user/repo"],
+                input_data={"candidate_github_username": "testuser", "jd_tech_stack": ["Python"]},
+            )
+
+            assert len(result["repositories"]) == 1
+            assert result["repositories"][0]["repo_name"] == "repo"
+            assert result["repositories"][0]["candidate_commits"] == 10
+
+
+# ============================================================
+# Activity 통합 테스트
+# ============================================================
+
+class TestCodeAnalysisIntegration:
+    """Code Analysis Activity 통합 테스트"""
+
+    def test_activity_is_defn(self):
+        """Activity 데코레이터 확인"""
+        from app.workflows.activities.code_analysis import analyze_code
+        assert hasattr(analyze_code, "__temporal_activity_definition")
+
+    @pytest.mark.asyncio
+    async def test_output_structure_empty(self):
+        """빈 결과 출력 구조"""
+        from app.workflows.activities.code_analysis import analyze_code
+        from unittest.mock import patch
+
+        async def mock_filter_repos(github_urls, target_languages, min_language_ratio):
+            return []
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity, \
+             patch("app.services.github_service.GitHubService.filter_repos_by_language", side_effect=mock_filter_repos):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await analyze_code(
+                github_urls=[],
+                input_data={},
+            )
+
+            assert "repositories" in result
+            assert "top_question_candidates" in result

--- a/backend/tests/test_document_analysis.py
+++ b/backend/tests/test_document_analysis.py
@@ -1,0 +1,182 @@
+"""
+backend/tests/test_document_analysis.py
+Phase 2: Document Analysis Activity 단위 테스트
+
+테스트 항목:
+- P2D-01: 문서 파싱 (Docling primary)
+- P2D-02: 문서 파싱 폴백 (pymupdf4llm)
+- P2D-03: LLM 프로필 추출
+- P2D-04: 문서 없을 때 처리
+"""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+# ============================================================
+# P2D-01: 문서 파싱 테스트
+# ============================================================
+
+class TestDocumentParsing:
+    """P2D-01: 문서 파싱 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_parse_document_txt(self, tmp_path):
+        """TXT 파일 파싱"""
+        from app.services.document_parser import parse_document
+
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("이름: 홍길동\n경력: 5년")
+
+        result = await parse_document(str(test_file))
+
+        assert "홍길동" in result.text
+        assert result.parser_used == "plaintext"
+
+    @pytest.mark.asyncio
+    async def test_parse_document_not_found(self):
+        """존재하지 않는 파일"""
+        from app.services.document_parser import parse_document
+
+        with pytest.raises(FileNotFoundError):
+            await parse_document("/nonexistent/file.pdf")
+
+
+# ============================================================
+# P2D-03: LLM 프로필 추출 테스트
+# ============================================================
+
+class TestLlmProfileExtraction:
+    """P2D-03: LLM 프로필 추출 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_analyze_documents_returns_profile(self):
+        """문서 분석 결과에 프로필 포함"""
+        from app.workflows.activities.document_analysis import analyze_documents
+        from unittest.mock import patch
+
+        input_data = {"resume_path": "/tmp/resume.txt"}
+
+        class MockParseResult:
+            text = "이름: 테스트 유저\n경력: 5년\nGitHub: https://github.com/test"
+            parser_used = "plaintext"
+            sections = ["header", "experience"]
+
+        mock_profile = {
+            "name": "테스트 유저",
+            "experience_years": 5,
+            "skills": ["Python", "FastAPI"],
+        }
+
+        async def mock_parse_document(path):
+            return MockParseResult()
+
+        async def mock_llm_run(prompt):
+            return mock_profile
+
+        with patch("app.workflows.activities.document_analysis.activity") as mock_activity, \
+             patch("app.services.document_parser.parse_document", side_effect=mock_parse_document), \
+             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await analyze_documents(input_data)
+
+            assert "profile" in result
+            assert "raw_texts" in result
+            assert "parse_info" in result
+
+    @pytest.mark.asyncio
+    async def test_analyze_documents_no_documents(self):
+        """문서가 없을 때"""
+        from app.workflows.activities.document_analysis import analyze_documents
+        from unittest.mock import patch
+
+        input_data = {}  # 문서 경로 없음
+
+        with patch("app.workflows.activities.document_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+
+            result = await analyze_documents(input_data)
+
+            assert result["profile"] == {}
+            assert result["raw_texts"] == []
+            assert result["parse_info"] == []
+
+
+# ============================================================
+# P2D-04: 오류 처리 테스트
+# ============================================================
+
+class TestDocumentAnalysisErrorHandling:
+    """문서 분석 오류 처리 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_parse_failure_continues(self):
+        """파싱 실패 시 계속 진행"""
+        from app.workflows.activities.document_analysis import analyze_documents
+        from unittest.mock import patch
+
+        input_data = {
+            "resume_path": "/tmp/bad.pdf",
+            "portfolio_path": "/tmp/good.txt",
+        }
+
+        call_count = [0]
+
+        class MockParseResult:
+            text = "Portfolio content"
+            parser_used = "plaintext"
+            sections = []
+
+        async def mock_parse_document(path):
+            call_count[0] += 1
+            if "bad" in path:
+                raise ValueError("Parse failed")
+            return MockParseResult()
+
+        async def mock_llm_run(prompt):
+            return {"name": "Test"}
+
+        with patch("app.workflows.activities.document_analysis.activity") as mock_activity, \
+             patch("app.services.document_parser.parse_document", side_effect=mock_parse_document), \
+             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await analyze_documents(input_data)
+
+            # 두 파일 모두 시도해야 함
+            assert call_count[0] == 2
+            # 하나는 성공해서 raw_texts에 포함
+            assert len(result["raw_texts"]) == 1
+
+
+# ============================================================
+# Activity 통합 테스트
+# ============================================================
+
+class TestDocumentAnalysisIntegration:
+    """Document Analysis Activity 통합 테스트"""
+
+    def test_activity_is_defn(self):
+        """Activity 데코레이터 확인"""
+        from app.workflows.activities.document_analysis import analyze_documents
+        assert hasattr(analyze_documents, "__temporal_activity_definition")
+
+    @pytest.mark.asyncio
+    async def test_output_structure(self):
+        """출력 구조 검증"""
+        from app.workflows.activities.document_analysis import analyze_documents
+        from unittest.mock import patch
+
+        input_data = {}
+
+        with patch("app.workflows.activities.document_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+
+            result = await analyze_documents(input_data)
+
+            # 필수 필드 확인
+            assert "profile" in result
+            assert "raw_texts" in result
+            assert "parse_info" in result

--- a/backend/tests/test_jd_analysis.py
+++ b/backend/tests/test_jd_analysis.py
@@ -1,0 +1,145 @@
+"""
+backend/tests/test_jd_analysis.py
+Phase 2: JD Analysis Activity 단위 테스트
+
+테스트 항목:
+- P2J-01: JD 요구사항 추출
+- P2J-02: 스킬 추출
+- P2J-03: LLM 실패 시 기본값 반환
+"""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+# ============================================================
+# P2J-01: JD 요구사항 추출 테스트
+# ============================================================
+
+class TestJdRequirementsExtraction:
+    """P2J-01: JD 요구사항 추출 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_analyze_jd_returns_requirements(self, sample_jd_text):
+        """JD 분석 결과에 요구사항 포함"""
+        from app.workflows.activities.jd_analysis import analyze_jd
+        from unittest.mock import patch
+
+        mock_result = {
+            "job_title": "AI Engineer",
+            "company_name": "TechCorp",
+            "requirements": [
+                {"skill": "Python", "level": "필수"},
+                {"skill": "LLM API", "level": "필수"},
+            ],
+            "responsibilities": ["AI 서비스 개발", "백엔드 구축"],
+            "company_culture": [],
+            "tech_stack": ["Python", "TypeScript", "FastAPI"],
+        }
+
+        async def mock_llm_run(prompt):
+            return mock_result
+
+        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+            result = await analyze_jd(sample_jd_text)
+
+            assert result["job_title"] == "AI Engineer"
+            assert len(result["requirements"]) > 0
+            assert len(result["tech_stack"]) > 0
+
+
+# ============================================================
+# P2J-02: 스킬 추출 테스트
+# ============================================================
+
+class TestJdSkillExtraction:
+    """P2J-02: 스킬 추출 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_analyze_jd_extracts_tech_stack(self, sample_jd_text):
+        """JD에서 기술스택 추출"""
+        from app.workflows.activities.jd_analysis import analyze_jd
+        from unittest.mock import patch
+
+        mock_result = {
+            "job_title": "Backend Developer",
+            "tech_stack": ["Python", "TypeScript", "FastAPI", "React"],
+            "requirements": [],
+            "responsibilities": [],
+        }
+
+        async def mock_llm_run(prompt):
+            return mock_result
+
+        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+            result = await analyze_jd(sample_jd_text)
+
+            assert "tech_stack" in result
+            assert "Python" in result["tech_stack"]
+
+
+# ============================================================
+# P2J-03: LLM 실패 시 기본값 반환 테스트
+# ============================================================
+
+class TestJdAnalysisErrorHandling:
+    """P2J-03: LLM 실패 시 기본값 반환 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_analyze_jd_llm_returns_non_dict(self):
+        """LLM이 dict가 아닌 값 반환 시"""
+        from app.workflows.activities.jd_analysis import analyze_jd
+        from unittest.mock import patch
+
+        async def mock_llm_run(prompt):
+            return "Not a dict response"
+
+        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+            result = await analyze_jd("Test JD")
+
+            # 기본값 반환
+            assert result["job_title"] is None
+            assert result["requirements"] == []
+            assert result["tech_stack"] == []
+
+
+# ============================================================
+# Activity 통합 테스트
+# ============================================================
+
+class TestJdAnalysisIntegration:
+    """JD Analysis Activity 통합 테스트"""
+
+    def test_activity_is_defn(self):
+        """Activity 데코레이터 확인"""
+        from app.workflows.activities.jd_analysis import analyze_jd
+        assert hasattr(analyze_jd, "__temporal_activity_definition")
+
+    @pytest.mark.asyncio
+    async def test_output_structure(self, sample_jd_text):
+        """출력 구조 검증"""
+        from app.workflows.activities.jd_analysis import analyze_jd
+        from unittest.mock import patch
+
+        mock_result = {
+            "job_title": "Test",
+            "company_name": "Test Co",
+            "requirements": [],
+            "responsibilities": [],
+            "company_culture": [],
+            "tech_stack": [],
+        }
+
+        async def mock_llm_run(prompt):
+            return mock_result
+
+        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+            result = await analyze_jd(sample_jd_text)
+
+            # 필수 필드 확인
+            required_fields = [
+                "job_title", "company_name", "requirements",
+                "responsibilities", "company_culture", "tech_stack",
+                "skill_matches", "overall_match_score", "gaps", "strengths",
+            ]
+            for field in required_fields:
+                assert field in result, f"Missing field: {field}"


### PR DESCRIPTION
## Summary
- Phase 2 (Parallel Analysis) 3개 Activity 단위 테스트 21개 케이스 구현
- Document Analysis, JD Analysis, Code Analysis 커버리지 확보

## Test Coverage
| Activity | 테스트 케이스 | 상태 |
|----------|-------------|------|
| Document Analysis | 7개 | ✅ Pass |
| JD Analysis | 5개 | ✅ Pass |
| Code Analysis | 9개 | ✅ Pass |

## Test plan
- [x] `pytest tests/test_document_analysis.py -v` - 7 passed
- [x] `pytest tests/test_jd_analysis.py -v` - 5 passed
- [x] `pytest tests/test_code_analysis.py -v` - 9 passed

## Files Changed
- `backend/tests/test_document_analysis.py` - 새로 추가
- `backend/tests/test_jd_analysis.py` - 새로 추가
- `backend/tests/test_code_analysis.py` - 새로 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)