### PR TITLE
fix: Update test expectations for observability activities and LinkedIn parameter

### DIFF
--- a/backend/tests/test_prompts.py
+++ b/backend/tests/test_prompts.py
@@ -39,7 +39,7 @@ class TestPromptLoader:
     def test_load_candidate_summary(self):
         prompt = get_prompt(
             "finalization.yaml", "candidate_summary",
-            document_analysis="{}", code_analysis="{}",
+            document_analysis="{}", code_analysis="{}", linkedin_profile="{}",
         )
         assert "candidate summary" in prompt
 

--- a/backend/tests/test_workflow.py
+++ b/backend/tests/test_workflow.py
@@ -26,11 +26,15 @@ class TestActivityRegistration:
             "finalize_output",
             "persist_result",
             "send_webhook",
+            # Observability activities (Phase 2 Langfuse)
+            "start_job_trace",
+            "end_job_trace",
+            "log_phase_event",
         ]
         assert names == expected
 
     def test_activity_count(self):
-        assert len(ACTIVITIES) == 17
+        assert len(ACTIVITIES) == 20
 
 
 class TestWorkflow:


### PR DESCRIPTION
## Summary
- Update `test_workflow.py` to expect 20 activities (17 original + 3 observability activities from Phase 2 Langfuse integration)
- Add `linkedin_profile` parameter to `test_prompts.py` candidate_summary test (required after LinkedIn integration)

## Changes
| File | Change |
|------|--------|
| `test_workflow.py` | Added 3 observability activities: `start_job_trace`, `end_job_trace`, `log_phase_event` to expected list and updated count from 17 to 20 |
| `test_prompts.py` | Added `linkedin_profile="{}"` parameter to `test_load_candidate_summary` test |

## Test plan
- [x] All 335 tests pass (previously 332 passed, 3 failed)
- [x] `test_workflow.py::TestActivityRegistration::test_all_activities_registered` ✅
- [x] `test_workflow.py::TestActivityRegistration::test_activity_count` ✅
- [x] `test_prompts.py::TestPromptLoader::test_load_candidate_summary` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)