### PR TITLE
feat: Add Langfuse observability to Temporal worker

### DIFF
--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -9,6 +9,7 @@ from temporalio.worker import Worker
 
 from app.core.config import settings
 from app.core.temporal import get_temporal_client
+from app.core.observability import setup_langfuse, flush_langfuse
 from app.workflows.interview_workflow import InterviewGenerationWorkflow, WORKFLOW_VERSION
 
 logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL))
@@ -65,6 +66,10 @@ ACTIVITIES = [
 
 
 async def main():
+    # Initialize Langfuse for LLM observability
+    if setup_langfuse():
+        logger.info("Langfuse observability enabled")
+
     logger.info(f"Connecting to Temporal at {settings.TEMPORAL_HOST}")
     client = await get_temporal_client()
 
@@ -83,4 +88,8 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    finally:
+        # Flush Langfuse on shutdown
+        flush_langfuse()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-sk-placeholder}
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - BRIGHTDATA_API_TOKEN=${BRIGHTDATA_API_TOKEN:-}
-      - LANGFUSE_HOST=http://langfuse:3000
+      - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse:3000}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}
@@ -59,7 +59,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-sk-placeholder}
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - BRIGHTDATA_API_TOKEN=${BRIGHTDATA_API_TOKEN:-}
-      - LANGFUSE_HOST=http://langfuse:3000
+      - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse:3000}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}


### PR DESCRIPTION
## Summary
- Worker에 Langfuse 초기화 추가 (`setup_langfuse()`)
- Graceful shutdown 시 버퍼 플러시 (`flush_langfuse()`)
- `LANGFUSE_HOST` 환경변수 오버라이드 지원 (셀프호스팅 서버 연결 가능)

## Changes
- `backend/app/worker.py`: Langfuse 설정 및 플러시 로직 추가
- `docker-compose.yml`: `LANGFUSE_HOST`를 `${LANGFUSE_HOST:-http://langfuse:3000}`로 변경

## Test plan
- [ ] Worker 시작 시 "Langfuse observability enabled" 로그 확인
- [ ] 실제 워크플로우 실행 후 Langfuse UI에서 트레이스 확인

🤖 Generated with [Claude Code](https://claude.ai/code)