### PR TITLE
feat: Knowledge Graph 통합 (Claim-Evidence 검증 및 그래프 기반 질문 생성)

### DIFF
--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -132,3 +132,79 @@ class EmbeddingDB(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     job = relationship("JobDB")
+
+
+# ============================================
+# Knowledge Graph Tables
+# ============================================
+
+class KGNodeDB(Base):
+    """Knowledge Graph nodes for entity storage."""
+    __tablename__ = "kg_nodes"
+    __table_args__ = (
+        Index("idx_kg_nodes_job", "job_id"),
+        Index("idx_kg_nodes_type", "entity_type"),
+        Index("idx_kg_nodes_job_type", "job_id", "entity_type"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    job_id = Column(UUID(as_uuid=True), ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False)
+    entity_type = Column(String(100), nullable=False)  # 'Skill', 'CodePattern', 'Requirement', etc.
+    name = Column(String(500), nullable=False)  # Entity name for quick lookup
+    properties = Column(JSONB, nullable=False, server_default="{}")  # Entity attributes
+    embedding = Column(Vector(1536))  # Optional: for hybrid graph+vector search
+    provenance = Column(JSONB)  # W3C PROV-O tracking: source, extraction_method, confidence
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    job = relationship("JobDB")
+    outgoing_edges = relationship("KGEdgeDB", foreign_keys="KGEdgeDB.source_id", back_populates="source_node")
+    incoming_edges = relationship("KGEdgeDB", foreign_keys="KGEdgeDB.target_id", back_populates="target_node")
+
+
+class KGEdgeDB(Base):
+    """Knowledge Graph edges for relationship storage."""
+    __tablename__ = "kg_edges"
+    __table_args__ = (
+        Index("idx_kg_edges_job", "job_id"),
+        Index("idx_kg_edges_source", "source_id"),
+        Index("idx_kg_edges_target", "target_id"),
+        Index("idx_kg_edges_relation", "relation_type"),
+        Index("idx_kg_edges_job_relation", "job_id", "relation_type"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    job_id = Column(UUID(as_uuid=True), ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False)
+    source_id = Column(UUID(as_uuid=True), ForeignKey("kg_nodes.id", ondelete="CASCADE"), nullable=False)
+    target_id = Column(UUID(as_uuid=True), ForeignKey("kg_nodes.id", ondelete="CASCADE"), nullable=False)
+    relation_type = Column(String(100), nullable=False)  # 'has_skill', 'demonstrated_by', 'matches', etc.
+    properties = Column(JSONB, server_default="{}")  # Relation attributes
+    confidence = Column("confidence", BigInteger, nullable=False, default=100)  # 0-100 scale
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    job = relationship("JobDB")
+    source_node = relationship("KGNodeDB", foreign_keys=[source_id], back_populates="outgoing_edges")
+    target_node = relationship("KGNodeDB", foreign_keys=[target_id], back_populates="incoming_edges")
+
+
+class ClaimEvidenceDB(Base):
+    """Claim-Evidence verification records for interview probing."""
+    __tablename__ = "claim_evidence"
+    __table_args__ = (
+        Index("idx_claim_evidence_job", "job_id"),
+        Index("idx_claim_evidence_type", "evidence_type"),
+        Index("idx_claim_evidence_strength", "evidence_strength"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    job_id = Column(UUID(as_uuid=True), ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False)
+    claim_node_id = Column(UUID(as_uuid=True), ForeignKey("kg_nodes.id", ondelete="SET NULL"))
+    evidence_node_id = Column(UUID(as_uuid=True), ForeignKey("kg_nodes.id", ondelete="SET NULL"))
+    evidence_type = Column(String(50), nullable=False)  # 'supporting', 'contradicting', 'neutral', 'missing'
+    evidence_strength = Column("evidence_strength", BigInteger, nullable=False)  # 0-100 scale
+    analysis = Column(Text)  # LLM analysis of claim vs evidence
+    recommended_probe = Column(Text)  # Suggested interview question to verify claim
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    job = relationship("JobDB")
+    claim_node = relationship("KGNodeDB", foreign_keys=[claim_node_id])
+    evidence_node = relationship("KGNodeDB", foreign_keys=[evidence_node_id])

--- a/backend/app/services/conflict_detector.py
+++ b/backend/app/services/conflict_detector.py
@@ -1,0 +1,301 @@
+"""
+backend/app/services/conflict_detector.py
+Claim-Evidence Conflict Detection for Interview Question Generation
+Detects discrepancies between resume claims and code evidence
+"""
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .graph_store import GraphStore, get_graph_store
+from .knowledge_graph import KnowledgeGraphService, get_knowledge_graph
+
+logger = logging.getLogger(__name__)
+
+
+class ConflictAnalysis(BaseModel):
+    """Analysis of a claim-evidence conflict."""
+    claim: str
+    claim_source: str  # e.g., "resume", "linkedin"
+    expected_evidence: str
+    actual_evidence: str | None
+    conflict_type: str  # "missing", "contradicting", "overstated", "understated"
+    severity: str  # "high", "medium", "low"
+    confidence: int  # 0-100
+    analysis: str
+    recommended_probe: str
+
+
+class ConflictReport(BaseModel):
+    """Complete conflict detection report."""
+    job_id: str
+    total_claims_analyzed: int
+    conflicts: list[ConflictAnalysis] = Field(default_factory=list)
+    verified_claims: list[dict[str, Any]] = Field(default_factory=list)
+    summary: dict[str, Any] = Field(default_factory=dict)
+
+
+class ConflictDetector:
+    """Detects conflicts between candidate claims and code evidence.
+
+    Uses Knowledge Graph traversal to find:
+    1. Skills claimed but not demonstrated in code
+    2. Experience levels that don't match code complexity
+    3. Technologies mentioned but not found in repositories
+    4. Inconsistencies between resume and actual contributions
+    """
+
+    def __init__(self, job_id: str):
+        self.job_id = job_id
+        self.kg = get_knowledge_graph(job_id)
+        self.store = get_graph_store(job_id)
+
+    async def detect_all_conflicts(self) -> ConflictReport:
+        """Run all conflict detection checks and generate a report."""
+        logger.info(f"[{self.job_id}] Starting conflict detection")
+
+        conflicts: list[ConflictAnalysis] = []
+        verified: list[dict[str, Any]] = []
+
+        # 1. Check for unverified skill claims
+        skill_conflicts = await self._detect_skill_conflicts()
+        conflicts.extend(skill_conflicts["conflicts"])
+        verified.extend(skill_conflicts["verified"])
+
+        # 2. Check for experience level mismatches
+        exp_conflicts = await self._detect_experience_conflicts()
+        conflicts.extend(exp_conflicts)
+
+        # 3. Check for technology claim gaps
+        tech_conflicts = await self._detect_technology_conflicts()
+        conflicts.extend(tech_conflicts)
+
+        # Store conflicts in graph for later use
+        await self._store_conflicts(conflicts)
+
+        report = ConflictReport(
+            job_id=self.job_id,
+            total_claims_analyzed=len(conflicts) + len(verified),
+            conflicts=conflicts,
+            verified_claims=verified,
+            summary={
+                "total_conflicts": len(conflicts),
+                "high_severity": len([c for c in conflicts if c.severity == "high"]),
+                "medium_severity": len([c for c in conflicts if c.severity == "medium"]),
+                "low_severity": len([c for c in conflicts if c.severity == "low"]),
+                "conflict_types": self._count_by_type(conflicts),
+                "verification_rate": len(verified) / (len(conflicts) + len(verified)) * 100 if conflicts or verified else 0,
+            },
+        )
+
+        logger.info(
+            f"[{self.job_id}] Conflict detection complete: "
+            f"{len(conflicts)} conflicts, {len(verified)} verified"
+        )
+
+        return report
+
+    async def _detect_skill_conflicts(self) -> dict[str, Any]:
+        """Detect conflicts between claimed skills and code evidence."""
+        skills_with_evidence = await self.kg.get_skills_with_evidence()
+
+        conflicts = []
+        verified = []
+
+        for skill_data in skills_with_evidence:
+            skill_name = skill_data["skill"]
+            is_claimed = skill_data["is_claimed"]
+            is_verified = skill_data["verified"]
+            evidence = skill_data["evidence"]
+
+            if is_claimed and not is_verified:
+                # Skill claimed but not found in code
+                conflicts.append(ConflictAnalysis(
+                    claim=f"Proficiency in {skill_name}",
+                    claim_source="resume",
+                    expected_evidence=f"Code demonstrating {skill_name} usage",
+                    actual_evidence=None,
+                    conflict_type="missing",
+                    severity=self._determine_skill_severity(skill_name),
+                    confidence=85,
+                    analysis=f"Candidate claims {skill_name} on resume, but no evidence found in analyzed code repositories.",
+                    recommended_probe=self._generate_skill_probe(skill_name),
+                ))
+            elif is_claimed and is_verified:
+                # Verified claim
+                verified.append({
+                    "skill": skill_name,
+                    "evidence_count": skill_data["evidence_count"],
+                    "evidence_sources": [e["name"] for e in evidence[:3]],
+                })
+
+        return {"conflicts": conflicts, "verified": verified}
+
+    async def _detect_experience_conflicts(self) -> list[ConflictAnalysis]:
+        """Detect conflicts between stated experience level and code complexity."""
+        conflicts = []
+
+        # Get candidate profile info from KG
+        work_experiences = await self.store.get_nodes_by_type("WorkExperience")
+        repositories = await self.store.get_nodes_by_type("Repository")
+
+        if not work_experiences or not repositories:
+            return conflicts
+
+        # Calculate average code complexity from repositories
+        total_complexity = 0
+        repo_count = 0
+        for repo in repositories:
+            if contrib := repo.get("properties", {}).get("candidate_contribution", {}):
+                if avg_complexity := contrib.get("avg_complexity"):
+                    total_complexity += avg_complexity
+                    repo_count += 1
+
+        if repo_count == 0:
+            return conflicts
+
+        avg_complexity = total_complexity / repo_count
+
+        # Check if complexity matches stated experience
+        # Note: This is a simplified heuristic - real implementation would be more nuanced
+        for exp in work_experiences:
+            position = exp.get("properties", {}).get("position", "")
+            position_lower = position.lower()
+
+            expected_complexity = self._expected_complexity_for_role(position_lower)
+
+            if expected_complexity and avg_complexity < expected_complexity * 0.5:
+                conflicts.append(ConflictAnalysis(
+                    claim=f"Experience as {position}",
+                    claim_source="resume",
+                    expected_evidence=f"Code complexity >= {expected_complexity} for {position} role",
+                    actual_evidence=f"Average complexity: {avg_complexity:.1f}",
+                    conflict_type="overstated",
+                    severity="medium",
+                    confidence=70,
+                    analysis=f"Code complexity ({avg_complexity:.1f}) appears lower than expected for stated {position} experience.",
+                    recommended_probe=f"Can you walk me through a complex problem you solved as a {position}? What was the architectural approach?",
+                ))
+
+        return conflicts
+
+    async def _detect_technology_conflicts(self) -> list[ConflictAnalysis]:
+        """Detect conflicts between stated technologies and actual usage."""
+        conflicts = []
+
+        # Get skills from profile vs code
+        profile_skills = await self.store.get_nodes_by_type("Skill")
+        resume_skills = [s for s in profile_skills if s.get("properties", {}).get("source_type") == "resume"]
+        code_skills = [s for s in profile_skills if s.get("properties", {}).get("source_type") == "code"]
+
+        resume_skill_names = {s["name"].lower() for s in resume_skills}
+        code_skill_names = {s["name"].lower() for s in code_skills}
+
+        # Check for major technologies claimed but not in code
+        major_techs = ["python", "java", "javascript", "react", "vue", "angular", "node.js",
+                       "django", "fastapi", "spring", "postgresql", "mongodb", "kubernetes", "docker"]
+
+        for tech in major_techs:
+            if tech in resume_skill_names and tech not in code_skill_names:
+                # Check if there might be related technologies
+                related_found = self._find_related_tech(tech, code_skill_names)
+
+                if not related_found:
+                    conflicts.append(ConflictAnalysis(
+                        claim=f"Experience with {tech.title()}",
+                        claim_source="resume",
+                        expected_evidence=f"Code using {tech.title()}",
+                        actual_evidence="Not found in analyzed repositories",
+                        conflict_type="missing",
+                        severity="medium" if tech in ["python", "java", "javascript"] else "low",
+                        confidence=75,
+                        analysis=f"{tech.title()} listed on resume but not found in provided code samples.",
+                        recommended_probe=f"Tell me about a project where you used {tech.title()}. What was your role and contribution?",
+                    ))
+
+        return conflicts
+
+    async def _store_conflicts(self, conflicts: list[ConflictAnalysis]) -> None:
+        """Store detected conflicts in the graph for later query."""
+        for conflict in conflicts:
+            # Find or create claim node
+            claim_node = await self.store.find_node_by_name("Skill", conflict.claim.replace("Proficiency in ", "").replace("Experience with ", ""))
+            claim_node_id = claim_node["id"] if claim_node else None
+
+            # Create claim-evidence record
+            await self.store.create_claim_evidence(
+                claim_node_id=claim_node_id,
+                evidence_node_id=None,
+                evidence_type=conflict.conflict_type,
+                evidence_strength=conflict.confidence,
+                analysis=conflict.analysis,
+                recommended_probe=conflict.recommended_probe,
+            )
+
+    def _determine_skill_severity(self, skill_name: str) -> str:
+        """Determine severity of a missing skill based on its importance."""
+        critical_skills = ["python", "java", "javascript", "sql", "git"]
+        important_skills = ["react", "node.js", "docker", "kubernetes", "aws"]
+
+        skill_lower = skill_name.lower()
+        if any(s in skill_lower for s in critical_skills):
+            return "high"
+        elif any(s in skill_lower for s in important_skills):
+            return "medium"
+        return "low"
+
+    def _generate_skill_probe(self, skill_name: str) -> str:
+        """Generate an interview probe question for an unverified skill."""
+        probes = {
+            "python": "Can you describe your approach to structuring Python projects? What patterns do you typically use?",
+            "java": "Walk me through how you would design a Java service with dependency injection. What frameworks have you used?",
+            "javascript": "How do you handle asynchronous operations in JavaScript? Can you compare callbacks, promises, and async/await?",
+            "react": "Explain your state management approach in React. When would you use context vs. Redux vs. other solutions?",
+            "docker": "How do you structure a multi-container Docker application? Walk me through your docker-compose setup.",
+            "kubernetes": "Describe how you would deploy a microservices application to Kubernetes. What resources would you define?",
+            "postgresql": "How do you optimize PostgreSQL queries? Can you explain your approach to indexing?",
+            "aws": "Walk me through designing a scalable architecture on AWS. What services would you use and why?",
+        }
+
+        skill_lower = skill_name.lower()
+        for key, probe in probes.items():
+            if key in skill_lower:
+                return probe
+
+        return f"Can you describe a specific project where you used {skill_name}? What challenges did you face and how did you solve them?"
+
+    def _expected_complexity_for_role(self, position: str) -> float | None:
+        """Return expected code complexity for different roles."""
+        if any(t in position for t in ["senior", "lead", "principal", "staff"]):
+            return 15.0
+        elif any(t in position for t in ["mid", "regular", "software engineer"]):
+            return 10.0
+        elif any(t in position for t in ["junior", "associate", "entry"]):
+            return 5.0
+        return None
+
+    def _find_related_tech(self, tech: str, code_skills: set[str]) -> bool:
+        """Check if related technologies are present."""
+        tech_relations = {
+            "python": ["django", "fastapi", "flask", "pandas", "numpy"],
+            "javascript": ["node.js", "react", "vue", "angular", "typescript"],
+            "java": ["spring", "maven", "gradle", "kotlin"],
+            "react": ["javascript", "typescript", "next.js"],
+            "vue": ["javascript", "typescript", "nuxt"],
+        }
+
+        related = tech_relations.get(tech.lower(), [])
+        return any(r in code_skills for r in related)
+
+    def _count_by_type(self, conflicts: list[ConflictAnalysis]) -> dict[str, int]:
+        """Count conflicts by type."""
+        counts: dict[str, int] = {}
+        for c in conflicts:
+            counts[c.conflict_type] = counts.get(c.conflict_type, 0) + 1
+        return counts
+
+
+def get_conflict_detector(job_id: str) -> ConflictDetector:
+    """Factory function to create a ConflictDetector instance."""
+    return ConflictDetector(job_id)

--- a/backend/app/services/entity_extractors.py
+++ b/backend/app/services/entity_extractors.py
@@ -1,0 +1,511 @@
+"""
+backend/app/services/entity_extractors.py
+Domain-specific entity extractors for Knowledge Graph population
+"""
+import logging
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================
+# Pydantic Models for Extracted Entities
+# ============================================
+
+class ExtractedEntity(BaseModel):
+    """Base model for extracted KG entities."""
+    entity_type: str
+    name: str
+    properties: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+
+class ExtractedRelation(BaseModel):
+    """Model for extracted KG relations."""
+    source_name: str
+    source_type: str
+    target_name: str
+    target_type: str
+    relation_type: str
+    confidence: int = 100  # 0-100 scale
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class ExtractionResult(BaseModel):
+    """Result of entity extraction from a document or analysis."""
+    entities: list[ExtractedEntity] = Field(default_factory=list)
+    relations: list[ExtractedRelation] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+# ============================================
+# Candidate Profile Extractor
+# ============================================
+
+class CandidateEntityExtractor:
+    """Extract KG entities from candidate profile analysis."""
+
+    def __init__(self, source: str = "document_analysis"):
+        self.source = source
+
+    def extract(self, profile: dict[str, Any]) -> ExtractionResult:
+        """Extract entities and relations from a CandidateProfile."""
+        entities: list[ExtractedEntity] = []
+        relations: list[ExtractedRelation] = []
+
+        provenance_base = {
+            "source": self.source,
+            "extraction_method": "structured_extraction",
+        }
+
+        # Extract Skills
+        for skill in profile.get("skills", []):
+            skill_name = skill if isinstance(skill, str) else skill.get("name", str(skill))
+            skill_level = skill.get("level", "unknown") if isinstance(skill, dict) else "mentioned"
+
+            entities.append(ExtractedEntity(
+                entity_type="Skill",
+                name=skill_name,
+                properties={
+                    "level": skill_level,
+                    "category": self._categorize_skill(skill_name),
+                    "source_type": "resume",
+                },
+                provenance={
+                    **provenance_base,
+                    "field": "skills",
+                },
+            ))
+
+        # Extract Work Experience
+        for exp in profile.get("work_history", []):
+            exp_name = f"{exp.get('position', 'Unknown')} at {exp.get('company', 'Unknown')}"
+            entities.append(ExtractedEntity(
+                entity_type="WorkExperience",
+                name=exp_name,
+                properties={
+                    "company": exp.get("company"),
+                    "position": exp.get("position"),
+                    "period": exp.get("period"),
+                    "description": exp.get("description"),
+                    "tech_stack": exp.get("tech_stack", []),
+                },
+                provenance={
+                    **provenance_base,
+                    "field": "work_history",
+                },
+            ))
+
+            # Create relations for tech stack in work experience
+            for tech in exp.get("tech_stack", []):
+                relations.append(ExtractedRelation(
+                    source_name=exp_name,
+                    source_type="WorkExperience",
+                    target_name=tech,
+                    target_type="Skill",
+                    relation_type="used_technology",
+                    confidence=90,
+                ))
+
+        # Extract Education
+        for edu in profile.get("education", []):
+            edu_name = f"{edu.get('degree', '')} in {edu.get('major', 'Unknown')} from {edu.get('institution', 'Unknown')}"
+            entities.append(ExtractedEntity(
+                entity_type="Education",
+                name=edu_name.strip(),
+                properties={
+                    "institution": edu.get("institution"),
+                    "degree": edu.get("degree"),
+                    "major": edu.get("major"),
+                    "graduation_year": edu.get("graduation_year"),
+                },
+                provenance={
+                    **provenance_base,
+                    "field": "education",
+                },
+            ))
+
+        # Extract Projects
+        for proj in profile.get("projects", []):
+            proj_name = proj.get("name", "Unknown Project")
+            entities.append(ExtractedEntity(
+                entity_type="Project",
+                name=proj_name,
+                properties={
+                    "description": proj.get("description"),
+                    "role": proj.get("role"),
+                    "tech_stack": proj.get("tech_stack", []),
+                    "period": proj.get("period"),
+                    "url": proj.get("url"),
+                },
+                provenance={
+                    **provenance_base,
+                    "field": "projects",
+                },
+            ))
+
+            # Create relations for project tech stack
+            for tech in proj.get("tech_stack", []):
+                relations.append(ExtractedRelation(
+                    source_name=proj_name,
+                    source_type="Project",
+                    target_name=tech,
+                    target_type="Skill",
+                    relation_type="used_technology",
+                    confidence=85,
+                ))
+
+        # Create has_skill relations from candidate to skills
+        candidate_name = profile.get("name", "Candidate")
+        for skill_entity in [e for e in entities if e.entity_type == "Skill"]:
+            relations.append(ExtractedRelation(
+                source_name=candidate_name,
+                source_type="Candidate",
+                target_name=skill_entity.name,
+                target_type="Skill",
+                relation_type="has_skill",
+                confidence=80,  # Claims from resume need verification
+            ))
+
+        logger.info(f"Extracted {len(entities)} entities and {len(relations)} relations from profile")
+
+        return ExtractionResult(
+            entities=entities,
+            relations=relations,
+            metadata={
+                "candidate_name": candidate_name,
+                "experience_years": profile.get("experience_years"),
+                "source": self.source,
+            },
+        )
+
+    def _categorize_skill(self, skill_name: str) -> str:
+        """Categorize a skill based on common patterns."""
+        skill_lower = skill_name.lower()
+
+        categories = {
+            "programming_language": ["python", "java", "javascript", "typescript", "c++", "c#", "go", "rust", "ruby", "php", "swift", "kotlin"],
+            "frontend": ["react", "vue", "angular", "svelte", "html", "css", "tailwind", "bootstrap", "next.js", "nuxt"],
+            "backend": ["fastapi", "django", "flask", "express", "spring", "node.js", "rails", "laravel", "asp.net"],
+            "database": ["postgresql", "mysql", "mongodb", "redis", "elasticsearch", "cassandra", "dynamodb", "sqlite"],
+            "cloud": ["aws", "gcp", "azure", "docker", "kubernetes", "terraform", "ansible"],
+            "data_science": ["pandas", "numpy", "scikit-learn", "tensorflow", "pytorch", "spark", "hadoop"],
+            "devops": ["ci/cd", "jenkins", "github actions", "gitlab", "docker", "kubernetes"],
+        }
+
+        for category, keywords in categories.items():
+            if any(kw in skill_lower for kw in keywords):
+                return category
+
+        return "other"
+
+
+# ============================================
+# Code Analysis Extractor
+# ============================================
+
+class CodeEntityExtractor:
+    """Extract KG entities from code analysis results."""
+
+    def __init__(self, source: str = "code_analysis"):
+        self.source = source
+
+    def extract(self, code_analysis: dict[str, Any]) -> ExtractionResult:
+        """Extract entities and relations from CodeAnalysis."""
+        entities: list[ExtractedEntity] = []
+        relations: list[ExtractedRelation] = []
+
+        provenance_base = {
+            "source": self.source,
+            "extraction_method": "code_analysis",
+        }
+
+        # Extract from repositories
+        for repo in code_analysis.get("repositories", []):
+            repo_name = repo.get("repo_name", repo.get("name", "Unknown"))
+            repo_url = repo.get("repo_url", "")
+
+            # Repository entity
+            entities.append(ExtractedEntity(
+                entity_type="Repository",
+                name=repo_name,
+                properties={
+                    "url": repo_url,
+                    "language": repo.get("language"),
+                    "language_ratio": repo.get("language_ratio"),
+                    "total_files": repo.get("total_files"),
+                    "analyzed_files": repo.get("analyzed_files"),
+                    "jd_match_score": repo.get("jd_match_score", 0),
+                    "contributors_count": repo.get("contributors_count", 0),
+                },
+                provenance={
+                    **provenance_base,
+                    "repo_url": repo_url,
+                },
+            ))
+
+            # Tech stack entities with demonstrated_by relation
+            for tech in repo.get("tech_stack", []):
+                # Create skill entity if not exists
+                skill_exists = any(e.name == tech and e.entity_type == "Skill" for e in entities)
+                if not skill_exists:
+                    entities.append(ExtractedEntity(
+                        entity_type="Skill",
+                        name=tech,
+                        properties={
+                            "source_type": "code",
+                            "verified": True,  # Found in actual code
+                        },
+                        provenance={
+                            **provenance_base,
+                            "repo_url": repo_url,
+                            "field": "tech_stack",
+                        },
+                    ))
+
+                relations.append(ExtractedRelation(
+                    source_name=tech,
+                    source_type="Skill",
+                    target_name=repo_name,
+                    target_type="Repository",
+                    relation_type="demonstrated_by",
+                    confidence=95,  # High confidence - found in code
+                ))
+
+            # Code patterns
+            for pattern in repo.get("patterns", []):
+                pattern_name = f"{pattern.get('pattern_type', 'unknown')}:{pattern.get('name', 'unnamed')}"
+                entities.append(ExtractedEntity(
+                    entity_type="CodePattern",
+                    name=pattern_name,
+                    properties={
+                        "pattern_type": pattern.get("pattern_type"),
+                        "file_path": pattern.get("file_path"),
+                        "line_start": pattern.get("line_start"),
+                        "line_end": pattern.get("line_end"),
+                        "code_snippet": pattern.get("code_snippet", "")[:500],  # Truncate for storage
+                        "explanation": pattern.get("explanation"),
+                    },
+                    provenance={
+                        **provenance_base,
+                        "repo_url": repo_url,
+                        "file_path": pattern.get("file_path"),
+                    },
+                ))
+
+                relations.append(ExtractedRelation(
+                    source_name=repo_name,
+                    source_type="Repository",
+                    target_name=pattern_name,
+                    target_type="CodePattern",
+                    relation_type="contains_code",
+                    confidence=100,
+                ))
+
+            # Notable implementations
+            for impl in repo.get("notable_implementations", []):
+                impl_name = impl.get("title", "Notable Implementation")
+                entities.append(ExtractedEntity(
+                    entity_type="NotableImplementation",
+                    name=impl_name,
+                    properties={
+                        "description": impl.get("description"),
+                        "file_path": impl.get("file_path"),
+                        "line_start": impl.get("line_start"),
+                        "line_end": impl.get("line_end"),
+                        "code_snippet": impl.get("code_snippet", "")[:500],
+                        "why_notable": impl.get("why_notable"),
+                        "question_potential": impl.get("question_potential", 0),
+                    },
+                    provenance={
+                        **provenance_base,
+                        "repo_url": repo_url,
+                        "file_path": impl.get("file_path"),
+                    },
+                ))
+
+                relations.append(ExtractedRelation(
+                    source_name=repo_name,
+                    source_type="Repository",
+                    target_name=impl_name,
+                    target_type="NotableImplementation",
+                    relation_type="contains_code",
+                    confidence=100,
+                ))
+
+            # Candidate contribution metrics
+            contrib = repo.get("candidate_contribution", {})
+            if contrib:
+                relations.append(ExtractedRelation(
+                    source_name="Candidate",
+                    source_type="Candidate",
+                    target_name=repo_name,
+                    target_type="Repository",
+                    relation_type="contributed_to",
+                    confidence=100,
+                    properties={
+                        "total_commits": contrib.get("total_commits", 0),
+                        "total_additions": contrib.get("total_additions", 0),
+                        "total_deletions": contrib.get("total_deletions", 0),
+                        "avg_complexity": contrib.get("avg_complexity", 0),
+                    },
+                ))
+
+        # Combined tech stack (verified skills from code)
+        for tech in code_analysis.get("combined_tech_stack", []):
+            skill_exists = any(e.name == tech and e.entity_type == "Skill" for e in entities)
+            if not skill_exists:
+                entities.append(ExtractedEntity(
+                    entity_type="Skill",
+                    name=tech,
+                    properties={
+                        "source_type": "code",
+                        "verified": True,
+                    },
+                    provenance={
+                        **provenance_base,
+                        "field": "combined_tech_stack",
+                    },
+                ))
+
+        logger.info(f"Extracted {len(entities)} entities and {len(relations)} relations from code analysis")
+
+        return ExtractionResult(
+            entities=entities,
+            relations=relations,
+            metadata={
+                "total_repositories": len(code_analysis.get("repositories", [])),
+                "total_patterns": code_analysis.get("total_patterns", 0),
+                "total_notable_implementations": code_analysis.get("total_notable_implementations", 0),
+            },
+        )
+
+
+# ============================================
+# JD Analysis Extractor
+# ============================================
+
+class JDEntityExtractor:
+    """Extract KG entities from JD analysis results."""
+
+    def __init__(self, source: str = "jd_analysis"):
+        self.source = source
+
+    def extract(self, jd_analysis: dict[str, Any]) -> ExtractionResult:
+        """Extract entities and relations from JDAnalysis."""
+        entities: list[ExtractedEntity] = []
+        relations: list[ExtractedRelation] = []
+
+        provenance_base = {
+            "source": self.source,
+            "extraction_method": "jd_analysis",
+        }
+
+        job_title = jd_analysis.get("job_title", "Unknown Position")
+        company_name = jd_analysis.get("company_name", "Unknown Company")
+
+        # Company Info entity
+        if company_name != "Unknown Company":
+            entities.append(ExtractedEntity(
+                entity_type="CompanyInfo",
+                name=company_name,
+                properties={
+                    "culture": jd_analysis.get("company_culture", []),
+                },
+                provenance=provenance_base,
+            ))
+
+        # Requirements
+        for req in jd_analysis.get("requirements", []):
+            req_name = req.get("skill", "Unknown Requirement")
+            req_category = req.get("category", "필수")
+
+            entities.append(ExtractedEntity(
+                entity_type="Requirement",
+                name=req_name,
+                properties={
+                    "category": req_category,
+                    "detail": req.get("detail"),
+                    "experience_years": req.get("experience_years"),
+                    "priority": "required" if req_category == "필수" else "preferred",
+                },
+                provenance={
+                    **provenance_base,
+                    "field": "requirements",
+                },
+            ))
+
+            # Relation to job
+            relation_type = "requires_skill" if req_category == "필수" else "prefers_skill"
+            relations.append(ExtractedRelation(
+                source_name=job_title,
+                source_type="Job",
+                target_name=req_name,
+                target_type="Requirement",
+                relation_type=relation_type,
+                confidence=100,
+            ))
+
+        # Responsibilities
+        for i, resp in enumerate(jd_analysis.get("responsibilities", [])):
+            resp_name = f"Responsibility_{i+1}"
+            entities.append(ExtractedEntity(
+                entity_type="Responsibility",
+                name=resp_name,
+                properties={
+                    "description": resp,
+                },
+                provenance={
+                    **provenance_base,
+                    "field": "responsibilities",
+                },
+            ))
+
+        # Skill matches - create match relations
+        for match in jd_analysis.get("skill_matches", []):
+            if match.get("candidate_skill"):
+                relations.append(ExtractedRelation(
+                    source_name=match["candidate_skill"],
+                    source_type="Skill",
+                    target_name=match["required_skill"],
+                    target_type="Requirement",
+                    relation_type="matches_requirement",
+                    confidence=int(match.get("confidence", 0) * 100),
+                    properties={
+                        "match_type": match.get("match_type"),
+                        "evidence": match.get("evidence"),
+                    },
+                ))
+
+        logger.info(f"Extracted {len(entities)} entities and {len(relations)} relations from JD analysis")
+
+        return ExtractionResult(
+            entities=entities,
+            relations=relations,
+            metadata={
+                "job_title": job_title,
+                "company_name": company_name,
+                "overall_match_score": jd_analysis.get("overall_match_score", 0),
+                "gaps": jd_analysis.get("gaps", []),
+                "strengths": jd_analysis.get("strengths", []),
+            },
+        )
+
+
+# ============================================
+# Factory Functions
+# ============================================
+
+def get_candidate_extractor(source: str = "document_analysis") -> CandidateEntityExtractor:
+    return CandidateEntityExtractor(source)
+
+
+def get_code_extractor(source: str = "code_analysis") -> CodeEntityExtractor:
+    return CodeEntityExtractor(source)
+
+
+def get_jd_extractor(source: str = "jd_analysis") -> JDEntityExtractor:
+    return JDEntityExtractor(source)

--- a/backend/app/services/graph_queries.py
+++ b/backend/app/services/graph_queries.py
@@ -1,0 +1,362 @@
+"""
+backend/app/services/graph_queries.py
+Graph Query Service for Interview Question Generation
+Provides high-level query methods for extracting question candidates from the Knowledge Graph
+"""
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .knowledge_graph import KnowledgeGraphService, get_knowledge_graph
+from .conflict_detector import ConflictDetector, get_conflict_detector
+
+logger = logging.getLogger(__name__)
+
+
+class QuestionCandidate(BaseModel):
+    """A candidate topic for interview question generation."""
+    topic: str
+    category: str  # "skill_depth", "gap_probe", "conflict_probe", "implementation_review"
+    priority: float  # Higher = more important to ask
+    evidence_chain: list[dict[str, Any]] = Field(default_factory=list)
+    context: dict[str, Any] = Field(default_factory=dict)
+    recommended_probe: str | None = None
+    code_reference: dict[str, Any] | None = None
+
+
+class InterviewGraphQueries:
+    """High-level query interface for interview question generation.
+
+    Provides methods to extract question candidates from the Knowledge Graph,
+    combining skill analysis, gap detection, and conflict identification.
+    """
+
+    def __init__(self, job_id: str):
+        self.job_id = job_id
+        self.kg = get_knowledge_graph(job_id)
+        self.conflict_detector = get_conflict_detector(job_id)
+
+    async def get_all_question_candidates(self) -> list[QuestionCandidate]:
+        """Get all question candidates from the Knowledge Graph.
+
+        Combines:
+        1. Skill depth questions (verified skills with code evidence)
+        2. Gap questions (JD requirements not matched)
+        3. Conflict questions (claim-evidence discrepancies)
+        4. Implementation review questions (notable code patterns)
+
+        Returns sorted by priority.
+        """
+        logger.info(f"[{self.job_id}] Gathering question candidates from KG")
+
+        candidates: list[QuestionCandidate] = []
+
+        # 1. Skill depth questions
+        skill_questions = await self._get_skill_depth_candidates()
+        candidates.extend(skill_questions)
+
+        # 2. Gap questions
+        gap_questions = await self._get_gap_candidates()
+        candidates.extend(gap_questions)
+
+        # 3. Conflict questions
+        conflict_questions = await self._get_conflict_candidates()
+        candidates.extend(conflict_questions)
+
+        # 4. Implementation review questions
+        impl_questions = await self._get_implementation_candidates()
+        candidates.extend(impl_questions)
+
+        # Sort by priority
+        candidates.sort(key=lambda x: x.priority, reverse=True)
+
+        logger.info(f"[{self.job_id}] Found {len(candidates)} question candidates")
+        return candidates
+
+    async def _get_skill_depth_candidates(self) -> list[QuestionCandidate]:
+        """Get candidates for deep skill probing based on verified evidence."""
+        candidates = []
+        skill_questions = await self.kg.get_skill_depth_questions()
+
+        for sq in skill_questions:
+            # Build evidence chain
+            evidence_chain = []
+            for impl in sq.get("implementations", []):
+                evidence_chain.append({
+                    "type": "NotableImplementation",
+                    "name": impl["implementation"],
+                    "repository": impl["repository"],
+                    "file_path": impl.get("file_path"),
+                    "description": impl.get("description"),
+                })
+
+            code_reference = None
+            if sq.get("implementations"):
+                impl = sq["implementations"][0]
+                code_reference = {
+                    "file_path": impl.get("file_path"),
+                    "repository": impl.get("repository"),
+                    "code_snippet": impl.get("code_snippet"),
+                    "why_notable": impl.get("why_notable"),
+                }
+
+            candidates.append(QuestionCandidate(
+                topic=sq["skill"],
+                category="skill_depth",
+                priority=sq.get("priority", 50),
+                evidence_chain=evidence_chain,
+                context={
+                    "evidence_count": sq["evidence_count"],
+                    "question_potential": sum(i.get("question_potential", 0) for i in sq.get("implementations", [])),
+                },
+                code_reference=code_reference,
+            ))
+
+        return candidates
+
+    async def _get_gap_candidates(self) -> list[QuestionCandidate]:
+        """Get candidates for probing gaps between JD and candidate skills."""
+        candidates = []
+        gap_questions = await self.kg.get_gap_questions()
+
+        for gq in gap_questions:
+            priority = 80 if gq.get("priority") == "required" else 50
+
+            if gq["question_type"] == "gap_probe":
+                candidates.append(QuestionCandidate(
+                    topic=gq["requirement"],
+                    category="gap_probe",
+                    priority=priority,
+                    evidence_chain=[],
+                    context={
+                        "probe_reason": gq.get("probe_reason"),
+                        "requirement_priority": gq.get("priority"),
+                    },
+                    recommended_probe=f"The role requires {gq['requirement']}. Can you tell me about your experience with this?",
+                ))
+            elif gq["question_type"] == "partial_match_probe":
+                candidates.append(QuestionCandidate(
+                    topic=gq["requirement"],
+                    category="partial_match_probe",
+                    priority=priority * 0.8,  # Slightly lower than full gaps
+                    evidence_chain=[{"type": "SkillMatch", **m} for m in gq.get("matches", [])],
+                    context={
+                        "probe_reason": gq.get("probe_reason"),
+                        "partial_matches": gq.get("matches"),
+                    },
+                    recommended_probe=f"You have some experience with {gq['requirement']}, but can you elaborate on your depth of knowledge?",
+                ))
+
+        return candidates
+
+    async def _get_conflict_candidates(self) -> list[QuestionCandidate]:
+        """Get candidates for probing claim-evidence conflicts."""
+        candidates = []
+
+        # Run conflict detection
+        report = await self.conflict_detector.detect_all_conflicts()
+
+        for conflict in report.conflicts:
+            priority_map = {"high": 90, "medium": 70, "low": 40}
+            priority = priority_map.get(conflict.severity, 50)
+
+            candidates.append(QuestionCandidate(
+                topic=conflict.claim,
+                category="conflict_probe",
+                priority=priority,
+                evidence_chain=[{
+                    "type": "Conflict",
+                    "conflict_type": conflict.conflict_type,
+                    "expected": conflict.expected_evidence,
+                    "actual": conflict.actual_evidence,
+                }],
+                context={
+                    "claim_source": conflict.claim_source,
+                    "conflict_type": conflict.conflict_type,
+                    "severity": conflict.severity,
+                    "analysis": conflict.analysis,
+                },
+                recommended_probe=conflict.recommended_probe,
+            ))
+
+        return candidates
+
+    async def _get_implementation_candidates(self) -> list[QuestionCandidate]:
+        """Get candidates for implementation/code review questions."""
+        candidates = []
+
+        # Get notable implementations directly
+        from .graph_store import get_graph_store
+        store = get_graph_store(self.job_id)
+
+        implementations = await store.get_nodes_by_type("NotableImplementation")
+
+        for impl in implementations:
+            props = impl.get("properties", {})
+            question_potential = props.get("question_potential", 0)
+
+            if question_potential < 0.5:  # Skip low-potential implementations
+                continue
+
+            candidates.append(QuestionCandidate(
+                topic=impl["name"],
+                category="implementation_review",
+                priority=question_potential * 100,
+                evidence_chain=[],
+                context={
+                    "description": props.get("description"),
+                    "why_notable": props.get("why_notable"),
+                    "file_path": props.get("file_path"),
+                },
+                code_reference={
+                    "file_path": props.get("file_path"),
+                    "line_start": props.get("line_start"),
+                    "line_end": props.get("line_end"),
+                    "code_snippet": props.get("code_snippet"),
+                },
+                recommended_probe=f"I noticed an interesting implementation in {props.get('file_path', 'your code')}. Can you walk me through your thought process here?",
+            ))
+
+        return candidates
+
+    async def get_question_candidates_by_category(
+        self,
+        category: str,
+    ) -> list[QuestionCandidate]:
+        """Get question candidates filtered by category."""
+        all_candidates = await self.get_all_question_candidates()
+        return [c for c in all_candidates if c.category == category]
+
+    async def get_top_question_candidates(
+        self,
+        limit: int = 25,
+        balance_categories: bool = True,
+    ) -> list[QuestionCandidate]:
+        """Get top question candidates with optional category balancing.
+
+        Args:
+            limit: Maximum number of candidates to return
+            balance_categories: If True, ensure representation from all categories
+
+        Returns:
+            Sorted list of question candidates
+        """
+        all_candidates = await self.get_all_question_candidates()
+
+        if not balance_categories or len(all_candidates) <= limit:
+            return all_candidates[:limit]
+
+        # Balance across categories
+        categories = ["skill_depth", "gap_probe", "conflict_probe", "implementation_review"]
+        per_category = max(3, limit // len(categories))  # At least 3 per category
+
+        balanced = []
+        by_category = {cat: [] for cat in categories}
+
+        for c in all_candidates:
+            by_category.setdefault(c.category, []).append(c)
+
+        # Take top from each category
+        for cat in categories:
+            cat_candidates = by_category.get(cat, [])
+            balanced.extend(cat_candidates[:per_category])
+
+        # Fill remaining slots with highest priority overall
+        remaining = limit - len(balanced)
+        if remaining > 0:
+            used_topics = {c.topic for c in balanced}
+            extras = [c for c in all_candidates if c.topic not in used_topics]
+            balanced.extend(extras[:remaining])
+
+        # Final sort by priority
+        balanced.sort(key=lambda x: x.priority, reverse=True)
+
+        return balanced[:limit]
+
+    async def get_evidence_chain_for_topic(self, topic: str) -> list[dict[str, Any]]:
+        """Get the full evidence chain for a specific topic.
+
+        Traverses the graph to find all connected evidence for a skill/topic.
+        """
+        from .graph_store import get_graph_store
+        store = get_graph_store(self.job_id)
+
+        # Try to find the topic as a Skill first
+        skill = await store.find_node_by_name("Skill", topic)
+        if skill:
+            # Traverse from skill to find all evidence
+            paths = await store.traverse_from_node(
+                skill["id"],
+                relation_types=["demonstrated_by", "contains_code", "supported_by"],
+                direction="both",
+                max_depth=3,
+            )
+
+            evidence_chain = []
+            for path in paths:
+                for step in path:
+                    if "node" in step:
+                        node = step["node"]
+                        evidence_chain.append({
+                            "entity_type": node["entity_type"],
+                            "name": node["name"],
+                            "properties": node["properties"],
+                        })
+                    if "edge" in step:
+                        edge = step["edge"]
+                        evidence_chain.append({
+                            "relation": edge["relation_type"],
+                            "confidence": edge["confidence"],
+                        })
+
+            return evidence_chain
+
+        # Try as a Requirement
+        req = await store.find_node_by_name("Requirement", topic)
+        if req:
+            paths = await store.traverse_from_node(
+                req["id"],
+                relation_types=["matches_requirement", "requires_skill"],
+                direction="both",
+                max_depth=2,
+            )
+
+            evidence_chain = []
+            for path in paths:
+                for step in path:
+                    if "node" in step:
+                        node = step["node"]
+                        evidence_chain.append({
+                            "entity_type": node["entity_type"],
+                            "name": node["name"],
+                            "properties": node["properties"],
+                        })
+
+            return evidence_chain
+
+        return []
+
+    async def get_kg_summary_for_question_generation(self) -> dict[str, Any]:
+        """Get a summary of KG data relevant for question generation."""
+        summary = await self.kg.get_summary()
+
+        # Add question-specific stats
+        all_candidates = await self.get_all_question_candidates()
+        by_category = {}
+        for c in all_candidates:
+            by_category[c.category] = by_category.get(c.category, 0) + 1
+
+        return {
+            **summary,
+            "question_generation": {
+                "total_candidates": len(all_candidates),
+                "by_category": by_category,
+                "top_priority": all_candidates[0].priority if all_candidates else 0,
+            },
+        }
+
+
+def get_interview_graph_queries(job_id: str) -> InterviewGraphQueries:
+    """Factory function to create an InterviewGraphQueries instance."""
+    return InterviewGraphQueries(job_id)

--- a/backend/app/services/graph_store.py
+++ b/backend/app/services/graph_store.py
@@ -1,0 +1,509 @@
+"""
+backend/app/services/graph_store.py
+PostgreSQL-based Knowledge Graph Store for entity and relationship persistence
+"""
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from sqlalchemy import select, delete, and_, or_, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import async_session
+from app.models.database import KGNodeDB, KGEdgeDB, ClaimEvidenceDB
+
+logger = logging.getLogger(__name__)
+
+# Type aliases for entity and relation types
+EntityType = Literal[
+    # Candidate Domain
+    "Skill", "WorkExperience", "Education", "Project", "Certification",
+    # Code Domain
+    "Repository", "CodePattern", "NotableImplementation", "TechStack",
+    # JD Domain
+    "Requirement", "Responsibility", "CompanyInfo",
+]
+
+RelationType = Literal[
+    # Skill relationships
+    "has_skill", "demonstrated_by", "requires", "matches",
+    # Evidence relationships
+    "supported_by", "contradicted_by", "verified_by",
+    # Work relationships
+    "worked_at", "used_technology", "contributed_to",
+    # JD relationships
+    "requires_skill", "prefers_skill", "matches_requirement",
+    # Code relationships
+    "implements_pattern", "contains_code", "shows_proficiency",
+]
+
+EvidenceType = Literal["supporting", "contradicting", "neutral", "missing"]
+
+
+class GraphStore:
+    """PostgreSQL-based Knowledge Graph Store.
+
+    Provides CRUD operations for Knowledge Graph nodes and edges,
+    with support for relationship queries and claim-evidence tracking.
+    """
+
+    def __init__(self, job_id: str):
+        self.job_id = uuid.UUID(job_id) if isinstance(job_id, str) else job_id
+
+    # ==========================================
+    # Node Operations
+    # ==========================================
+
+    async def create_node(
+        self,
+        entity_type: str,
+        name: str,
+        properties: dict[str, Any] | None = None,
+        provenance: dict[str, Any] | None = None,
+        embedding: list[float] | None = None,
+    ) -> str:
+        """Create a new KG node and return its ID."""
+        node_id = uuid.uuid4()
+        async with async_session() as session:
+            node = KGNodeDB(
+                id=node_id,
+                job_id=self.job_id,
+                entity_type=entity_type,
+                name=name,
+                properties=properties or {},
+                provenance=provenance,
+                embedding=embedding,
+            )
+            session.add(node)
+            await session.commit()
+            logger.debug(f"[{self.job_id}] Created node: {entity_type}/{name}")
+        return str(node_id)
+
+    async def create_nodes_batch(
+        self,
+        nodes: list[dict[str, Any]],
+    ) -> list[str]:
+        """Batch create multiple nodes. Returns list of node IDs."""
+        node_ids = []
+        async with async_session() as session:
+            for node_data in nodes:
+                node_id = uuid.uuid4()
+                node = KGNodeDB(
+                    id=node_id,
+                    job_id=self.job_id,
+                    entity_type=node_data["entity_type"],
+                    name=node_data["name"],
+                    properties=node_data.get("properties", {}),
+                    provenance=node_data.get("provenance"),
+                    embedding=node_data.get("embedding"),
+                )
+                session.add(node)
+                node_ids.append(str(node_id))
+            await session.commit()
+        logger.info(f"[{self.job_id}] Batch created {len(node_ids)} nodes")
+        return node_ids
+
+    async def get_node(self, node_id: str) -> dict[str, Any] | None:
+        """Get a node by ID."""
+        async with async_session() as session:
+            stmt = select(KGNodeDB).where(KGNodeDB.id == uuid.UUID(node_id))
+            result = await session.execute(stmt)
+            node = result.scalar_one_or_none()
+            if node:
+                return self._node_to_dict(node)
+        return None
+
+    async def get_nodes_by_type(self, entity_type: str) -> list[dict[str, Any]]:
+        """Get all nodes of a specific type for this job."""
+        async with async_session() as session:
+            stmt = select(KGNodeDB).where(
+                and_(
+                    KGNodeDB.job_id == self.job_id,
+                    KGNodeDB.entity_type == entity_type,
+                )
+            )
+            result = await session.execute(stmt)
+            nodes = result.scalars().all()
+            return [self._node_to_dict(n) for n in nodes]
+
+    async def find_node_by_name(
+        self,
+        entity_type: str,
+        name: str,
+    ) -> dict[str, Any] | None:
+        """Find a node by entity type and name."""
+        async with async_session() as session:
+            stmt = select(KGNodeDB).where(
+                and_(
+                    KGNodeDB.job_id == self.job_id,
+                    KGNodeDB.entity_type == entity_type,
+                    KGNodeDB.name == name,
+                )
+            )
+            result = await session.execute(stmt)
+            node = result.scalar_one_or_none()
+            if node:
+                return self._node_to_dict(node)
+        return None
+
+    async def update_node(
+        self,
+        node_id: str,
+        properties: dict[str, Any] | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> bool:
+        """Update node properties and/or provenance."""
+        async with async_session() as session:
+            stmt = select(KGNodeDB).where(KGNodeDB.id == uuid.UUID(node_id))
+            result = await session.execute(stmt)
+            node = result.scalar_one_or_none()
+            if node:
+                if properties:
+                    node.properties = {**node.properties, **properties}
+                if provenance:
+                    node.provenance = {**(node.provenance or {}), **provenance}
+                await session.commit()
+                return True
+        return False
+
+    async def delete_node(self, node_id: str) -> bool:
+        """Delete a node and its associated edges."""
+        async with async_session() as session:
+            stmt = delete(KGNodeDB).where(KGNodeDB.id == uuid.UUID(node_id))
+            result = await session.execute(stmt)
+            await session.commit()
+            return result.rowcount > 0
+
+    # ==========================================
+    # Edge Operations
+    # ==========================================
+
+    async def create_edge(
+        self,
+        source_id: str,
+        target_id: str,
+        relation_type: str,
+        properties: dict[str, Any] | None = None,
+        confidence: int = 100,
+    ) -> str:
+        """Create an edge between two nodes."""
+        edge_id = uuid.uuid4()
+        async with async_session() as session:
+            edge = KGEdgeDB(
+                id=edge_id,
+                job_id=self.job_id,
+                source_id=uuid.UUID(source_id),
+                target_id=uuid.UUID(target_id),
+                relation_type=relation_type,
+                properties=properties or {},
+                confidence=confidence,
+            )
+            session.add(edge)
+            await session.commit()
+            logger.debug(f"[{self.job_id}] Created edge: {relation_type}")
+        return str(edge_id)
+
+    async def create_edges_batch(
+        self,
+        edges: list[dict[str, Any]],
+    ) -> list[str]:
+        """Batch create multiple edges."""
+        edge_ids = []
+        async with async_session() as session:
+            for edge_data in edges:
+                edge_id = uuid.uuid4()
+                edge = KGEdgeDB(
+                    id=edge_id,
+                    job_id=self.job_id,
+                    source_id=uuid.UUID(edge_data["source_id"]),
+                    target_id=uuid.UUID(edge_data["target_id"]),
+                    relation_type=edge_data["relation_type"],
+                    properties=edge_data.get("properties", {}),
+                    confidence=edge_data.get("confidence", 100),
+                )
+                session.add(edge)
+                edge_ids.append(str(edge_id))
+            await session.commit()
+        logger.info(f"[{self.job_id}] Batch created {len(edge_ids)} edges")
+        return edge_ids
+
+    async def get_edges_by_relation(self, relation_type: str) -> list[dict[str, Any]]:
+        """Get all edges of a specific relation type for this job."""
+        async with async_session() as session:
+            stmt = select(KGEdgeDB).where(
+                and_(
+                    KGEdgeDB.job_id == self.job_id,
+                    KGEdgeDB.relation_type == relation_type,
+                )
+            )
+            result = await session.execute(stmt)
+            edges = result.scalars().all()
+            return [self._edge_to_dict(e) for e in edges]
+
+    async def get_outgoing_edges(self, node_id: str) -> list[dict[str, Any]]:
+        """Get all outgoing edges from a node."""
+        async with async_session() as session:
+            stmt = select(KGEdgeDB).where(
+                KGEdgeDB.source_id == uuid.UUID(node_id)
+            )
+            result = await session.execute(stmt)
+            edges = result.scalars().all()
+            return [self._edge_to_dict(e) for e in edges]
+
+    async def get_incoming_edges(self, node_id: str) -> list[dict[str, Any]]:
+        """Get all incoming edges to a node."""
+        async with async_session() as session:
+            stmt = select(KGEdgeDB).where(
+                KGEdgeDB.target_id == uuid.UUID(node_id)
+            )
+            result = await session.execute(stmt)
+            edges = result.scalars().all()
+            return [self._edge_to_dict(e) for e in edges]
+
+    # ==========================================
+    # Claim-Evidence Operations
+    # ==========================================
+
+    async def create_claim_evidence(
+        self,
+        claim_node_id: str | None,
+        evidence_node_id: str | None,
+        evidence_type: str,
+        evidence_strength: int,
+        analysis: str | None = None,
+        recommended_probe: str | None = None,
+    ) -> str:
+        """Create a claim-evidence verification record."""
+        record_id = uuid.uuid4()
+        async with async_session() as session:
+            record = ClaimEvidenceDB(
+                id=record_id,
+                job_id=self.job_id,
+                claim_node_id=uuid.UUID(claim_node_id) if claim_node_id else None,
+                evidence_node_id=uuid.UUID(evidence_node_id) if evidence_node_id else None,
+                evidence_type=evidence_type,
+                evidence_strength=evidence_strength,
+                analysis=analysis,
+                recommended_probe=recommended_probe,
+            )
+            session.add(record)
+            await session.commit()
+            logger.debug(f"[{self.job_id}] Created claim-evidence: {evidence_type}")
+        return str(record_id)
+
+    async def get_claim_evidence_by_type(
+        self,
+        evidence_type: str,
+    ) -> list[dict[str, Any]]:
+        """Get all claim-evidence records of a specific type."""
+        async with async_session() as session:
+            stmt = select(ClaimEvidenceDB).where(
+                and_(
+                    ClaimEvidenceDB.job_id == self.job_id,
+                    ClaimEvidenceDB.evidence_type == evidence_type,
+                )
+            ).order_by(ClaimEvidenceDB.evidence_strength.desc())
+            result = await session.execute(stmt)
+            records = result.scalars().all()
+            return [self._claim_evidence_to_dict(r) for r in records]
+
+    async def get_all_claim_evidence(self) -> list[dict[str, Any]]:
+        """Get all claim-evidence records for this job."""
+        async with async_session() as session:
+            stmt = select(ClaimEvidenceDB).where(
+                ClaimEvidenceDB.job_id == self.job_id
+            ).order_by(ClaimEvidenceDB.evidence_strength.desc())
+            result = await session.execute(stmt)
+            records = result.scalars().all()
+            return [self._claim_evidence_to_dict(r) for r in records]
+
+    # ==========================================
+    # Graph Query Operations
+    # ==========================================
+
+    async def traverse_from_node(
+        self,
+        node_id: str,
+        relation_types: list[str] | None = None,
+        direction: Literal["outgoing", "incoming", "both"] = "outgoing",
+        max_depth: int = 2,
+    ) -> list[dict[str, Any]]:
+        """Traverse the graph from a starting node.
+
+        Returns a list of paths, where each path contains nodes and edges.
+        """
+        visited = set()
+        paths = []
+
+        async def _traverse(current_id: str, current_path: list, depth: int):
+            if depth > max_depth or current_id in visited:
+                return
+            visited.add(current_id)
+
+            edges = []
+            if direction in ("outgoing", "both"):
+                edges.extend(await self.get_outgoing_edges(current_id))
+            if direction in ("incoming", "both"):
+                edges.extend(await self.get_incoming_edges(current_id))
+
+            for edge in edges:
+                if relation_types and edge["relation_type"] not in relation_types:
+                    continue
+
+                next_id = edge["target_id"] if edge["source_id"] == current_id else edge["source_id"]
+                next_node = await self.get_node(next_id)
+                if next_node:
+                    new_path = current_path + [{"edge": edge, "node": next_node}]
+                    paths.append(new_path)
+                    await _traverse(next_id, new_path, depth + 1)
+
+        start_node = await self.get_node(node_id)
+        if start_node:
+            await _traverse(node_id, [{"node": start_node}], 0)
+
+        return paths
+
+    async def find_paths_between(
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: int = 3,
+    ) -> list[list[dict[str, Any]]]:
+        """Find all paths between two nodes up to max_depth."""
+        paths = []
+
+        async def _find_path(current_id: str, path: list, visited: set):
+            if len(path) > max_depth:
+                return
+            if current_id == target_id:
+                paths.append(path.copy())
+                return
+            if current_id in visited:
+                return
+
+            visited.add(current_id)
+            edges = await self.get_outgoing_edges(current_id)
+
+            for edge in edges:
+                next_node = await self.get_node(edge["target_id"])
+                if next_node:
+                    path.append({"edge": edge, "node": next_node})
+                    await _find_path(edge["target_id"], path, visited)
+                    path.pop()
+
+            visited.remove(current_id)
+
+        start_node = await self.get_node(source_id)
+        if start_node:
+            await _find_path(source_id, [{"node": start_node}], set())
+
+        return paths
+
+    async def get_graph_summary(self) -> dict[str, Any]:
+        """Get summary statistics of the knowledge graph for this job."""
+        async with async_session() as session:
+            # Count nodes by type
+            node_stmt = text("""
+                SELECT entity_type, COUNT(*) as count
+                FROM kg_nodes
+                WHERE job_id = :job_id
+                GROUP BY entity_type
+            """)
+            node_result = await session.execute(node_stmt, {"job_id": str(self.job_id)})
+            node_counts = {row[0]: row[1] for row in node_result.fetchall()}
+
+            # Count edges by type
+            edge_stmt = text("""
+                SELECT relation_type, COUNT(*) as count
+                FROM kg_edges
+                WHERE job_id = :job_id
+                GROUP BY relation_type
+            """)
+            edge_result = await session.execute(edge_stmt, {"job_id": str(self.job_id)})
+            edge_counts = {row[0]: row[1] for row in edge_result.fetchall()}
+
+            # Count claim-evidence by type
+            claim_stmt = text("""
+                SELECT evidence_type, COUNT(*) as count
+                FROM claim_evidence
+                WHERE job_id = :job_id
+                GROUP BY evidence_type
+            """)
+            claim_result = await session.execute(claim_stmt, {"job_id": str(self.job_id)})
+            claim_counts = {row[0]: row[1] for row in claim_result.fetchall()}
+
+        return {
+            "job_id": str(self.job_id),
+            "node_counts": node_counts,
+            "edge_counts": edge_counts,
+            "claim_evidence_counts": claim_counts,
+            "total_nodes": sum(node_counts.values()),
+            "total_edges": sum(edge_counts.values()),
+            "total_claim_evidence": sum(claim_counts.values()),
+        }
+
+    # ==========================================
+    # Cleanup Operations
+    # ==========================================
+
+    async def clear_all(self) -> None:
+        """Clear all KG data for this job."""
+        async with async_session() as session:
+            # Delete in order due to foreign keys
+            await session.execute(
+                delete(ClaimEvidenceDB).where(ClaimEvidenceDB.job_id == self.job_id)
+            )
+            await session.execute(
+                delete(KGEdgeDB).where(KGEdgeDB.job_id == self.job_id)
+            )
+            await session.execute(
+                delete(KGNodeDB).where(KGNodeDB.job_id == self.job_id)
+            )
+            await session.commit()
+        logger.info(f"[{self.job_id}] Cleared all KG data")
+
+    # ==========================================
+    # Helper Methods
+    # ==========================================
+
+    def _node_to_dict(self, node: KGNodeDB) -> dict[str, Any]:
+        return {
+            "id": str(node.id),
+            "job_id": str(node.job_id),
+            "entity_type": node.entity_type,
+            "name": node.name,
+            "properties": node.properties,
+            "provenance": node.provenance,
+            "created_at": node.created_at.isoformat() if node.created_at else None,
+        }
+
+    def _edge_to_dict(self, edge: KGEdgeDB) -> dict[str, Any]:
+        return {
+            "id": str(edge.id),
+            "job_id": str(edge.job_id),
+            "source_id": str(edge.source_id),
+            "target_id": str(edge.target_id),
+            "relation_type": edge.relation_type,
+            "properties": edge.properties,
+            "confidence": edge.confidence,
+            "created_at": edge.created_at.isoformat() if edge.created_at else None,
+        }
+
+    def _claim_evidence_to_dict(self, record: ClaimEvidenceDB) -> dict[str, Any]:
+        return {
+            "id": str(record.id),
+            "job_id": str(record.job_id),
+            "claim_node_id": str(record.claim_node_id) if record.claim_node_id else None,
+            "evidence_node_id": str(record.evidence_node_id) if record.evidence_node_id else None,
+            "evidence_type": record.evidence_type,
+            "evidence_strength": record.evidence_strength,
+            "analysis": record.analysis,
+            "recommended_probe": record.recommended_probe,
+            "created_at": record.created_at.isoformat() if record.created_at else None,
+        }
+
+
+def get_graph_store(job_id: str) -> GraphStore:
+    """Factory function to create a GraphStore instance."""
+    return GraphStore(job_id)

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -1,0 +1,400 @@
+"""
+backend/app/services/knowledge_graph.py
+Core Knowledge Graph Service for Vantict Sniper
+Orchestrates entity extraction, graph building, and claim-evidence verification
+"""
+import logging
+from typing import Any
+
+from .graph_store import GraphStore, get_graph_store
+from .entity_extractors import (
+    CandidateEntityExtractor,
+    CodeEntityExtractor,
+    JDEntityExtractor,
+    ExtractionResult,
+    ExtractedEntity,
+    ExtractedRelation,
+    get_candidate_extractor,
+    get_code_extractor,
+    get_jd_extractor,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeGraphService:
+    """Main orchestration service for Knowledge Graph operations.
+
+    Coordinates entity extraction, graph storage, relationship building,
+    and provides unified access to graph data for question generation.
+    """
+
+    def __init__(self, job_id: str):
+        self.job_id = job_id
+        self.store = get_graph_store(job_id)
+        self._node_cache: dict[str, str] = {}  # name:type -> node_id mapping
+
+    # ==========================================
+    # Entity Extraction from Analysis Results
+    # ==========================================
+
+    async def extract_and_store_candidate_entities(
+        self,
+        profile: dict[str, Any],
+    ) -> ExtractionResult:
+        """Extract and store entities from candidate profile."""
+        logger.info(f"[{self.job_id}] Extracting candidate entities")
+
+        extractor = get_candidate_extractor()
+        result = extractor.extract(profile)
+
+        await self._store_extraction_result(result)
+
+        logger.info(
+            f"[{self.job_id}] Stored {len(result.entities)} candidate entities, "
+            f"{len(result.relations)} relations"
+        )
+        return result
+
+    async def extract_and_store_code_entities(
+        self,
+        code_analysis: dict[str, Any],
+    ) -> ExtractionResult:
+        """Extract and store entities from code analysis."""
+        logger.info(f"[{self.job_id}] Extracting code entities")
+
+        extractor = get_code_extractor()
+        result = extractor.extract(code_analysis)
+
+        await self._store_extraction_result(result)
+
+        logger.info(
+            f"[{self.job_id}] Stored {len(result.entities)} code entities, "
+            f"{len(result.relations)} relations"
+        )
+        return result
+
+    async def extract_and_store_jd_entities(
+        self,
+        jd_analysis: dict[str, Any],
+    ) -> ExtractionResult:
+        """Extract and store entities from JD analysis."""
+        logger.info(f"[{self.job_id}] Extracting JD entities")
+
+        extractor = get_jd_extractor()
+        result = extractor.extract(jd_analysis)
+
+        await self._store_extraction_result(result)
+
+        logger.info(
+            f"[{self.job_id}] Stored {len(result.entities)} JD entities, "
+            f"{len(result.relations)} relations"
+        )
+        return result
+
+    async def _store_extraction_result(self, result: ExtractionResult) -> None:
+        """Store extraction result in the graph store."""
+        # First, create all entities
+        for entity in result.entities:
+            cache_key = f"{entity.name}:{entity.entity_type}"
+
+            # Check if entity already exists
+            existing = await self.store.find_node_by_name(entity.entity_type, entity.name)
+            if existing:
+                # Update existing node with new properties
+                merged_props = {**existing.get("properties", {}), **entity.properties}
+                await self.store.update_node(
+                    existing["id"],
+                    properties=merged_props,
+                    provenance=entity.provenance,
+                )
+                self._node_cache[cache_key] = existing["id"]
+            else:
+                # Create new node
+                node_id = await self.store.create_node(
+                    entity_type=entity.entity_type,
+                    name=entity.name,
+                    properties=entity.properties,
+                    provenance=entity.provenance,
+                )
+                self._node_cache[cache_key] = node_id
+
+        # Then, create all relations
+        for relation in result.relations:
+            source_key = f"{relation.source_name}:{relation.source_type}"
+            target_key = f"{relation.target_name}:{relation.target_type}"
+
+            source_id = self._node_cache.get(source_key)
+            target_id = self._node_cache.get(target_key)
+
+            # If source/target not in cache, try to find or create
+            if not source_id:
+                existing = await self.store.find_node_by_name(
+                    relation.source_type, relation.source_name
+                )
+                if existing:
+                    source_id = existing["id"]
+                    self._node_cache[source_key] = source_id
+                else:
+                    # Create placeholder node
+                    source_id = await self.store.create_node(
+                        entity_type=relation.source_type,
+                        name=relation.source_name,
+                        properties={"placeholder": True},
+                    )
+                    self._node_cache[source_key] = source_id
+
+            if not target_id:
+                existing = await self.store.find_node_by_name(
+                    relation.target_type, relation.target_name
+                )
+                if existing:
+                    target_id = existing["id"]
+                    self._node_cache[target_key] = target_id
+                else:
+                    # Create placeholder node
+                    target_id = await self.store.create_node(
+                        entity_type=relation.target_type,
+                        name=relation.target_name,
+                        properties={"placeholder": True},
+                    )
+                    self._node_cache[target_key] = target_id
+
+            await self.store.create_edge(
+                source_id=source_id,
+                target_id=target_id,
+                relation_type=relation.relation_type,
+                properties=relation.properties,
+                confidence=relation.confidence,
+            )
+
+    # ==========================================
+    # Graph Query Operations
+    # ==========================================
+
+    async def get_skills_with_evidence(self) -> list[dict[str, Any]]:
+        """Get all skills with their evidence chains.
+
+        Returns skills linked to their demonstration sources (code, projects, etc.)
+        """
+        skills = await self.store.get_nodes_by_type("Skill")
+        result = []
+
+        for skill in skills:
+            skill_id = skill["id"]
+
+            # Get incoming edges (demonstrated_by relations)
+            edges = await self.store.get_incoming_edges(skill_id)
+            evidence = []
+
+            for edge in edges:
+                if edge["relation_type"] == "demonstrated_by":
+                    evidence_node = await self.store.get_node(edge["source_id"])
+                    if evidence_node:
+                        evidence.append({
+                            "type": evidence_node["entity_type"],
+                            "name": evidence_node["name"],
+                            "properties": evidence_node["properties"],
+                            "confidence": edge["confidence"],
+                        })
+
+            # Check if skill is from resume (has_skill relation)
+            outgoing = await self.store.get_incoming_edges(skill_id)
+            is_claimed = any(e["relation_type"] == "has_skill" for e in outgoing)
+
+            result.append({
+                "skill": skill["name"],
+                "properties": skill["properties"],
+                "is_claimed": is_claimed,
+                "evidence_count": len(evidence),
+                "evidence": evidence,
+                "verified": len(evidence) > 0,
+            })
+
+        return result
+
+    async def get_unverified_claims(self) -> list[dict[str, Any]]:
+        """Get skills claimed in resume but not demonstrated in code."""
+        skills_with_evidence = await self.get_skills_with_evidence()
+        return [s for s in skills_with_evidence if s["is_claimed"] and not s["verified"]]
+
+    async def get_jd_requirement_matches(self) -> list[dict[str, Any]]:
+        """Get JD requirements with their match status."""
+        requirements = await self.store.get_nodes_by_type("Requirement")
+        result = []
+
+        for req in requirements:
+            req_id = req["id"]
+
+            # Get matches_requirement edges
+            edges = await self.store.get_incoming_edges(req_id)
+            matches = []
+
+            for edge in edges:
+                if edge["relation_type"] == "matches_requirement":
+                    skill_node = await self.store.get_node(edge["source_id"])
+                    if skill_node:
+                        matches.append({
+                            "skill": skill_node["name"],
+                            "confidence": edge["confidence"],
+                            "match_type": edge["properties"].get("match_type"),
+                            "evidence": edge["properties"].get("evidence"),
+                        })
+
+            result.append({
+                "requirement": req["name"],
+                "priority": req["properties"].get("priority", "required"),
+                "matches": matches,
+                "is_matched": len(matches) > 0,
+                "best_match_confidence": max((m["confidence"] for m in matches), default=0),
+            })
+
+        return result
+
+    async def get_notable_implementations_for_skill(
+        self,
+        skill_name: str,
+    ) -> list[dict[str, Any]]:
+        """Get notable implementations that demonstrate a specific skill."""
+        skill = await self.store.find_node_by_name("Skill", skill_name)
+        if not skill:
+            return []
+
+        # Traverse: Skill -[demonstrated_by]-> Repository -[contains_code]-> NotableImplementation
+        result = []
+        edges = await self.store.get_incoming_edges(skill["id"])
+
+        for edge in edges:
+            if edge["relation_type"] == "demonstrated_by":
+                repo_node = await self.store.get_node(edge["source_id"])
+                if repo_node and repo_node["entity_type"] == "Repository":
+                    # Get implementations in this repo
+                    repo_edges = await self.store.get_outgoing_edges(repo_node["id"])
+                    for repo_edge in repo_edges:
+                        if repo_edge["relation_type"] == "contains_code":
+                            impl = await self.store.get_node(repo_edge["target_id"])
+                            if impl and impl["entity_type"] == "NotableImplementation":
+                                result.append({
+                                    "implementation": impl["name"],
+                                    "repository": repo_node["name"],
+                                    "file_path": impl["properties"].get("file_path"),
+                                    "description": impl["properties"].get("description"),
+                                    "why_notable": impl["properties"].get("why_notable"),
+                                    "question_potential": impl["properties"].get("question_potential", 0),
+                                    "code_snippet": impl["properties"].get("code_snippet"),
+                                })
+
+        return sorted(result, key=lambda x: x["question_potential"], reverse=True)
+
+    async def get_skill_depth_questions(self) -> list[dict[str, Any]]:
+        """Get skills suitable for depth probing based on evidence strength.
+
+        Returns skills with high evidence for deep technical discussion.
+        """
+        skills = await self.get_skills_with_evidence()
+
+        # Filter to verified skills with substantial evidence
+        question_candidates = []
+        for skill in skills:
+            if skill["verified"] and skill["evidence_count"] >= 1:
+                implementations = await self.get_notable_implementations_for_skill(skill["skill"])
+                if implementations:
+                    question_candidates.append({
+                        "skill": skill["skill"],
+                        "evidence_count": skill["evidence_count"],
+                        "evidence": skill["evidence"],
+                        "implementations": implementations[:3],  # Top 3
+                        "question_type": "skill_depth",
+                        "priority": skill["evidence_count"] * 10 + (
+                            sum(i["question_potential"] for i in implementations[:3])
+                        ),
+                    })
+
+        return sorted(question_candidates, key=lambda x: x["priority"], reverse=True)
+
+    async def get_gap_questions(self) -> list[dict[str, Any]]:
+        """Get questions about gaps between JD requirements and candidate skills."""
+        requirements = await self.get_jd_requirement_matches()
+
+        gap_questions = []
+        for req in requirements:
+            if not req["is_matched"]:
+                gap_questions.append({
+                    "requirement": req["requirement"],
+                    "priority": req["priority"],
+                    "question_type": "gap_probe",
+                    "probe_reason": f"JD requires {req['requirement']} but no evidence found",
+                })
+            elif req["best_match_confidence"] < 70:
+                gap_questions.append({
+                    "requirement": req["requirement"],
+                    "priority": req["priority"],
+                    "question_type": "partial_match_probe",
+                    "probe_reason": f"Partial match for {req['requirement']} (confidence: {req['best_match_confidence']}%)",
+                    "matches": req["matches"],
+                })
+
+        return gap_questions
+
+    async def get_conflict_questions(self) -> list[dict[str, Any]]:
+        """Get questions about conflicts between claims and evidence."""
+        claim_evidence_records = await self.store.get_claim_evidence_by_type("contradicting")
+
+        conflict_questions = []
+        for record in claim_evidence_records:
+            claim_node = await self.store.get_node(record["claim_node_id"]) if record["claim_node_id"] else None
+            evidence_node = await self.store.get_node(record["evidence_node_id"]) if record["evidence_node_id"] else None
+
+            conflict_questions.append({
+                "claim": claim_node["name"] if claim_node else "Unknown claim",
+                "evidence": evidence_node["name"] if evidence_node else "No evidence",
+                "evidence_type": record["evidence_type"],
+                "evidence_strength": record["evidence_strength"],
+                "analysis": record["analysis"],
+                "recommended_probe": record["recommended_probe"],
+                "question_type": "conflict_probe",
+            })
+
+        return conflict_questions
+
+    # ==========================================
+    # Graph Summary and Statistics
+    # ==========================================
+
+    async def get_summary(self) -> dict[str, Any]:
+        """Get comprehensive summary of the knowledge graph."""
+        store_summary = await self.store.get_graph_summary()
+
+        # Add derived statistics
+        skills_with_evidence = await self.get_skills_with_evidence()
+        unverified_claims = await self.get_unverified_claims()
+        jd_matches = await self.get_jd_requirement_matches()
+
+        return {
+            **store_summary,
+            "skills_summary": {
+                "total_skills": len(skills_with_evidence),
+                "verified_skills": len([s for s in skills_with_evidence if s["verified"]]),
+                "unverified_claims": len(unverified_claims),
+            },
+            "jd_summary": {
+                "total_requirements": len(jd_matches),
+                "matched_requirements": len([r for r in jd_matches if r["is_matched"]]),
+                "unmatched_requirements": len([r for r in jd_matches if not r["is_matched"]]),
+            },
+        }
+
+    # ==========================================
+    # Cleanup
+    # ==========================================
+
+    async def clear(self) -> None:
+        """Clear all KG data for this job."""
+        await self.store.clear_all()
+        self._node_cache.clear()
+        logger.info(f"[{self.job_id}] Cleared knowledge graph")
+
+
+def get_knowledge_graph(job_id: str) -> KnowledgeGraphService:
+    """Factory function to create a KnowledgeGraphService instance."""
+    return KnowledgeGraphService(job_id)

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -39,6 +39,12 @@ from app.workflows.activities.observability_activities import (
     end_job_trace,
     log_phase_event,
 )
+from app.workflows.activities.knowledge_graph_activities import (
+    build_knowledge_graph,
+    get_kg_question_candidates,
+    get_evidence_chain,
+    clear_knowledge_graph,
+)
 
 ACTIVITIES = [
     enrich_input,
@@ -62,6 +68,11 @@ ACTIVITIES = [
     start_job_trace,
     end_job_trace,
     log_phase_event,
+    # Knowledge Graph activities
+    build_knowledge_graph,
+    get_kg_question_candidates,
+    get_evidence_chain,
+    clear_knowledge_graph,
 ]
 
 

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -99,9 +99,33 @@ async def analyze_code(
     for repo in repositories:
         all_notables.extend(repo.get("notable_implementations", []))
 
-    return {
+    # Build code analysis result
+    code_analysis_result = {
         "repositories": repositories,
+        "combined_tech_stack": list(set(tech for repo in repositories for tech in repo.get("analysis", {}).get("tech_stack", []))),
+        "total_patterns": sum(len(repo.get("analysis", {}).get("patterns", [])) for repo in repositories),
+        "total_notable_implementations": len(all_notables),
         "top_question_candidates": all_notables[:20],
+    }
+
+    # Extract and store KG entities (non-blocking)
+    job_id = input_data.get("job_id")
+    kg_entity_count = 0
+
+    if job_id:
+        activity.heartbeat("Extracting KG entities from code analysis...")
+        try:
+            from app.services.knowledge_graph import get_knowledge_graph
+            kg = get_knowledge_graph(job_id)
+            extraction_result = await kg.extract_and_store_code_entities(code_analysis_result)
+            kg_entity_count = len(extraction_result.entities)
+            logger.info(f"Extracted {kg_entity_count} KG entities from code analysis for job {job_id}")
+        except Exception as e:
+            logger.warning(f"KG extraction failed (non-fatal): {e}")
+
+    return {
+        **code_analysis_result,
+        "kg_entity_count": kg_entity_count,
     }
 
 

--- a/backend/app/workflows/activities/document_analysis.py
+++ b/backend/app/workflows/activities/document_analysis.py
@@ -56,6 +56,8 @@ async def analyze_documents(input_data: dict) -> dict:
 
     # 벡터 스토어에 프로필 저장 (job_id가 있을 경우)
     job_id = input_data.get("job_id")
+    kg_entity_count = 0
+
     if job_id and isinstance(profile, dict):
         activity.heartbeat("Storing profile embeddings...")
         try:
@@ -66,8 +68,20 @@ async def analyze_documents(input_data: dict) -> dict:
         except Exception as e:
             logger.warning(f"Vector store failed (non-fatal): {e}")
 
+        # Extract and store KG entities (non-blocking)
+        activity.heartbeat("Extracting KG entities from profile...")
+        try:
+            from app.services.knowledge_graph import get_knowledge_graph
+            kg = get_knowledge_graph(job_id)
+            extraction_result = await kg.extract_and_store_candidate_entities(profile)
+            kg_entity_count = len(extraction_result.entities)
+            logger.info(f"Extracted {kg_entity_count} KG entities for job {job_id}")
+        except Exception as e:
+            logger.warning(f"KG extraction failed (non-fatal): {e}")
+
     return {
         "profile": profile if isinstance(profile, dict) else {},
         "raw_texts": documents,
         "parse_info": parse_results,
+        "kg_entity_count": kg_entity_count,
     }

--- a/backend/app/workflows/activities/jd_analysis.py
+++ b/backend/app/workflows/activities/jd_analysis.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 @activity.defn
 @observe_activity(name="analyze_jd", phase="analysis")
-async def analyze_jd(jd_text: str) -> dict:
+async def analyze_jd(jd_text: str, job_id: str | None = None) -> dict:
     """
     채용공고(JD) 분석
 
@@ -30,8 +30,11 @@ async def analyze_jd(jd_text: str) -> dict:
 
     result = await llm.run(prompt)
 
+    jd_result = {}
+    kg_entity_count = 0
+
     if isinstance(result, dict):
-        return {
+        jd_result = {
             "job_title": result.get("job_title"),
             "company_name": result.get("company_name"),
             "requirements": result.get("requirements", []),
@@ -43,16 +46,33 @@ async def analyze_jd(jd_text: str) -> dict:
             "gaps": [],
             "strengths": [],
         }
+    else:
+        jd_result = {
+            "job_title": None,
+            "company_name": None,
+            "requirements": [],
+            "responsibilities": [],
+            "company_culture": [],
+            "tech_stack": [],
+            "skill_matches": [],
+            "overall_match_score": 0,
+            "gaps": [],
+            "strengths": [],
+        }
+
+    # Extract and store KG entities (non-blocking)
+    if job_id and jd_result.get("job_title"):
+        activity.heartbeat("Extracting KG entities from JD analysis...")
+        try:
+            from app.services.knowledge_graph import get_knowledge_graph
+            kg = get_knowledge_graph(job_id)
+            extraction_result = await kg.extract_and_store_jd_entities(jd_result)
+            kg_entity_count = len(extraction_result.entities)
+            logger.info(f"Extracted {kg_entity_count} KG entities from JD for job {job_id}")
+        except Exception as e:
+            logger.warning(f"KG extraction failed (non-fatal): {e}")
 
     return {
-        "job_title": None,
-        "company_name": None,
-        "requirements": [],
-        "responsibilities": [],
-        "company_culture": [],
-        "tech_stack": [],
-        "skill_matches": [],
-        "overall_match_score": 0,
-        "gaps": [],
-        "strengths": [],
+        **jd_result,
+        "kg_entity_count": kg_entity_count,
     }

--- a/backend/app/workflows/activities/knowledge_graph_activities.py
+++ b/backend/app/workflows/activities/knowledge_graph_activities.py
@@ -1,0 +1,236 @@
+"""
+backend/app/workflows/activities/knowledge_graph_activities.py
+Knowledge Graph Activities for Temporal Workflow
+"""
+import logging
+
+from temporalio import activity
+
+from app.core.observability import observe_activity
+
+logger = logging.getLogger(__name__)
+
+
+@activity.defn
+@observe_activity(name="build_knowledge_graph", phase="analysis")
+async def build_knowledge_graph(
+    job_id: str,
+    profile: dict | None = None,
+    code_analysis: dict | None = None,
+    jd_analysis: dict | None = None,
+) -> dict:
+    """
+    Build Knowledge Graph from analysis results.
+
+    1. Extract entities from each analysis domain
+    2. Store entities and relationships in graph store
+    3. Run conflict detection
+    4. Return summary for question generation
+
+    This activity should be called after document_analysis, code_analysis, and jd_analysis
+    are complete, typically in Phase 2 of the workflow.
+    """
+    from app.services.knowledge_graph import get_knowledge_graph
+    from app.services.conflict_detector import get_conflict_detector
+
+    activity.heartbeat("Initializing Knowledge Graph...")
+    kg = get_knowledge_graph(job_id)
+
+    entity_counts = {
+        "candidate": 0,
+        "code": 0,
+        "jd": 0,
+    }
+    relation_counts = {
+        "candidate": 0,
+        "code": 0,
+        "jd": 0,
+    }
+
+    # Extract and store candidate entities from profile
+    if profile:
+        activity.heartbeat("Extracting candidate entities...")
+        try:
+            result = await kg.extract_and_store_candidate_entities(profile)
+            entity_counts["candidate"] = len(result.entities)
+            relation_counts["candidate"] = len(result.relations)
+            logger.info(f"[{job_id}] Extracted {len(result.entities)} candidate entities")
+        except Exception as e:
+            logger.warning(f"[{job_id}] Failed to extract candidate entities: {e}")
+
+    # Extract and store code entities
+    if code_analysis:
+        activity.heartbeat("Extracting code entities...")
+        try:
+            result = await kg.extract_and_store_code_entities(code_analysis)
+            entity_counts["code"] = len(result.entities)
+            relation_counts["code"] = len(result.relations)
+            logger.info(f"[{job_id}] Extracted {len(result.entities)} code entities")
+        except Exception as e:
+            logger.warning(f"[{job_id}] Failed to extract code entities: {e}")
+
+    # Extract and store JD entities
+    if jd_analysis:
+        activity.heartbeat("Extracting JD entities...")
+        try:
+            result = await kg.extract_and_store_jd_entities(jd_analysis)
+            entity_counts["jd"] = len(result.entities)
+            relation_counts["jd"] = len(result.relations)
+            logger.info(f"[{job_id}] Extracted {len(result.entities)} JD entities")
+        except Exception as e:
+            logger.warning(f"[{job_id}] Failed to extract JD entities: {e}")
+
+    # Run conflict detection
+    activity.heartbeat("Running conflict detection...")
+    conflict_report = None
+    try:
+        detector = get_conflict_detector(job_id)
+        conflict_report = await detector.detect_all_conflicts()
+        logger.info(
+            f"[{job_id}] Conflict detection complete: "
+            f"{conflict_report.summary.get('total_conflicts', 0)} conflicts found"
+        )
+    except Exception as e:
+        logger.warning(f"[{job_id}] Conflict detection failed: {e}")
+
+    # Get KG summary
+    activity.heartbeat("Generating KG summary...")
+    summary = await kg.get_summary()
+
+    return {
+        "status": "success",
+        "entity_counts": entity_counts,
+        "relation_counts": relation_counts,
+        "total_entities": sum(entity_counts.values()),
+        "total_relations": sum(relation_counts.values()),
+        "conflict_summary": conflict_report.summary if conflict_report else {},
+        "kg_summary": summary,
+    }
+
+
+@activity.defn
+@observe_activity(name="get_kg_question_candidates", phase="generation")
+async def get_kg_question_candidates(
+    job_id: str,
+    limit: int = 25,
+    balance_categories: bool = True,
+) -> dict:
+    """
+    Get question candidates from Knowledge Graph.
+
+    This activity queries the KG for:
+    1. Skill depth questions (verified skills with evidence)
+    2. Gap questions (unmatched JD requirements)
+    3. Conflict questions (claim-evidence discrepancies)
+    4. Implementation review questions (notable code patterns)
+
+    Should be called before question generation to provide KG-based topics.
+    """
+    from app.services.graph_queries import get_interview_graph_queries
+
+    activity.heartbeat("Querying Knowledge Graph for question candidates...")
+
+    try:
+        queries = get_interview_graph_queries(job_id)
+        candidates = await queries.get_top_question_candidates(
+            limit=limit,
+            balance_categories=balance_categories,
+        )
+
+        # Convert to serializable format
+        candidates_list = []
+        for c in candidates:
+            candidates_list.append({
+                "topic": c.topic,
+                "category": c.category,
+                "priority": c.priority,
+                "evidence_chain": c.evidence_chain,
+                "context": c.context,
+                "recommended_probe": c.recommended_probe,
+                "code_reference": c.code_reference,
+            })
+
+        # Get summary for logging
+        summary = await queries.get_kg_summary_for_question_generation()
+
+        logger.info(
+            f"[{job_id}] Found {len(candidates_list)} KG question candidates "
+            f"(by_category: {summary.get('question_generation', {}).get('by_category', {})})"
+        )
+
+        return {
+            "status": "success",
+            "candidates": candidates_list,
+            "summary": summary.get("question_generation", {}),
+        }
+
+    except Exception as e:
+        logger.warning(f"[{job_id}] KG question query failed: {e}")
+        return {
+            "status": "fallback",
+            "candidates": [],
+            "summary": {},
+            "error": str(e),
+        }
+
+
+@activity.defn
+@observe_activity(name="get_evidence_chain", phase="generation")
+async def get_evidence_chain(job_id: str, topic: str) -> dict:
+    """
+    Get the full evidence chain for a specific topic.
+
+    Used during question generation to provide context and code references.
+    """
+    from app.services.graph_queries import get_interview_graph_queries
+
+    activity.heartbeat(f"Getting evidence chain for {topic}...")
+
+    try:
+        queries = get_interview_graph_queries(job_id)
+        evidence = await queries.get_evidence_chain_for_topic(topic)
+
+        return {
+            "status": "success",
+            "topic": topic,
+            "evidence_chain": evidence,
+        }
+
+    except Exception as e:
+        logger.warning(f"[{job_id}] Evidence chain query failed for {topic}: {e}")
+        return {
+            "status": "error",
+            "topic": topic,
+            "evidence_chain": [],
+            "error": str(e),
+        }
+
+
+@activity.defn
+@observe_activity(name="clear_knowledge_graph", phase="cleanup")
+async def clear_knowledge_graph(job_id: str) -> dict:
+    """
+    Clear all Knowledge Graph data for a job.
+
+    Used during cleanup or when reprocessing a job.
+    """
+    from app.services.knowledge_graph import get_knowledge_graph
+
+    activity.heartbeat("Clearing Knowledge Graph...")
+
+    try:
+        kg = get_knowledge_graph(job_id)
+        await kg.clear()
+
+        return {
+            "status": "success",
+            "job_id": job_id,
+        }
+
+    except Exception as e:
+        logger.warning(f"[{job_id}] KG clear failed: {e}")
+        return {
+            "status": "error",
+            "job_id": job_id,
+            "error": str(e),
+        }

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -13,14 +13,15 @@ logger = logging.getLogger(__name__)
 
 @activity.defn
 @observe_activity(name="select_topics", phase="question_generation")
-async def select_topics(analysis: dict, enriched_input: dict) -> list[dict]:
+async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None = None) -> list[dict]:
     """
     25개 질문 토픽 선정 (5카테고리 × 5)
 
     선정 기준:
-    1. 코드에서 발견된 주목할 만한 구현
-    2. JD 요구사항과의 매칭
-    3. 경험 레벨에 맞는 난이도
+    1. Knowledge Graph 기반 후보 (skill_depth, gap_probe, conflict_probe, implementation_review)
+    2. 코드에서 발견된 주목할 만한 구현
+    3. JD 요구사항과의 매칭
+    4. 경험 레벨에 맞는 난이도
     """
     from app.services.cached_llm import CachedLLMService
 
@@ -32,12 +33,54 @@ async def select_topics(analysis: dict, enriched_input: dict) -> list[dict]:
     # 질문 후보 수집
     candidates = []
 
+    # Knowledge Graph 기반 후보 (highest priority)
+    if job_id:
+        activity.heartbeat("Fetching KG-based question candidates...")
+        try:
+            from app.services.graph_queries import get_interview_graph_queries
+            queries = get_interview_graph_queries(job_id)
+            kg_candidates = await queries.get_top_question_candidates(
+                limit=30,
+                balance_categories=True,
+            )
+
+            for kgc in kg_candidates:
+                # Map KG category to interview category
+                category_map = {
+                    "skill_depth": "technical_depth",
+                    "gap_probe": "role_fit",
+                    "conflict_probe": "risk_flags",
+                    "implementation_review": "execution_ownership",
+                    "partial_match_probe": "technical_depth",
+                }
+
+                candidates.append({
+                    "source": f"kg_{kgc.category}",
+                    "topic": kgc.topic,
+                    "evidence": {
+                        "evidence_chain": kgc.evidence_chain,
+                        "code_reference": kgc.code_reference,
+                        "recommended_probe": kgc.recommended_probe,
+                    },
+                    "score": kgc.priority / 100,  # Normalize to 0-1
+                    "kg_category": kgc.category,
+                    "interview_category": category_map.get(kgc.category, "technical_depth"),
+                })
+
+            logger.info(f"[{job_id}] Added {len(kg_candidates)} KG-based candidates")
+        except Exception as e:
+            logger.warning(f"[{job_id}] KG query failed (using fallback): {e}")
+
     # 코드 기반 후보
     code_analysis = analysis.get("code_analysis", {})
     for impl in code_analysis.get("top_question_candidates", []):
+        # Skip if already added from KG
+        topic = impl.get("title", "unknown")
+        if any(c["topic"] == topic for c in candidates):
+            continue
         candidates.append({
             "source": "code",
-            "topic": impl.get("title", "unknown"),
+            "topic": topic,
             "evidence": impl,
             "score": impl.get("question_potential", 0.5),
         })
@@ -47,6 +90,9 @@ async def select_topics(analysis: dict, enriched_input: dict) -> list[dict]:
     for req in jd_analysis.get("requirements", []):
         skill = req.get("skill", "") if isinstance(req, dict) else str(req)
         category = req.get("category", "우대") if isinstance(req, dict) else "우대"
+        # Skip if already added from KG
+        if any(c["topic"] == skill for c in candidates):
+            continue
         candidates.append({
             "source": "jd_match",
             "topic": skill,
@@ -97,6 +143,7 @@ async def craft_question(
     topic: dict,
     analysis: dict,
     enriched_input: dict,
+    job_id: str | None = None,
 ) -> dict:
     """
     단일 질문 상세 생성
@@ -107,6 +154,7 @@ async def craft_question(
     - 평가 시나리오
     - 꼬리질문
     - 용어 설명
+    - Knowledge Graph evidence chain (if available)
     """
     from app.services.cached_llm import CachedLLMService
 
@@ -116,6 +164,42 @@ async def craft_question(
     output_language = language_config.get("output_language", "ko")
     experience_level = raw_input.get("experience_level", "미들")
 
+    # Extract KG evidence if available
+    evidence_context = ""
+    code_reference = None
+    recommended_probe = None
+
+    if topic.get("source", "").startswith("kg_"):
+        evidence = topic.get("evidence", {})
+        evidence_chain = evidence.get("evidence_chain", [])
+        code_reference = evidence.get("code_reference")
+        recommended_probe = evidence.get("recommended_probe")
+
+        if evidence_chain:
+            evidence_context = "\n\nEvidence chain:\n"
+            for item in evidence_chain[:5]:  # Limit to 5 items
+                evidence_context += f"- {item.get('type', 'Unknown')}: {item.get('name', 'N/A')}\n"
+
+        if code_reference:
+            evidence_context += f"\nCode reference: {code_reference.get('file_path', 'N/A')}\n"
+            if code_reference.get('code_snippet'):
+                snippet = code_reference['code_snippet'][:300]  # Truncate
+                evidence_context += f"```\n{snippet}\n```\n"
+
+    # Get additional evidence from KG if job_id is available
+    if job_id and not evidence_context:
+        try:
+            from app.services.graph_queries import get_interview_graph_queries
+            queries = get_interview_graph_queries(job_id)
+            kg_evidence = await queries.get_evidence_chain_for_topic(topic.get("topic", ""))
+            if kg_evidence:
+                evidence_context = "\n\nKG Evidence:\n"
+                for item in kg_evidence[:5]:
+                    if item.get("entity_type"):
+                        evidence_context += f"- {item['entity_type']}: {item.get('name', 'N/A')}\n"
+        except Exception as e:
+            logger.debug(f"KG evidence fetch failed for {topic.get('topic')}: {e}")
+
     from app.prompts import get_prompt
     prompt = get_prompt(
         "question_generation.yaml", "craft_question",
@@ -124,6 +208,8 @@ async def craft_question(
         topic=topic.get("topic"),
         category=topic.get("category"),
         difficulty=topic.get("difficulty"),
+        evidence_context=evidence_context if evidence_context else "",
+        recommended_probe=recommended_probe if recommended_probe else "",
     )
 
     result = await llm.run(prompt)
@@ -134,6 +220,25 @@ async def craft_question(
     question.setdefault("difficulty", topic.get("difficulty", "Medium"))
     question.setdefault("language", output_language)
     question.setdefault("topic", topic.get("topic"))
+
+    # Add KG provenance metadata
+    if topic.get("source", "").startswith("kg_"):
+        question["kg_source"] = topic.get("source")
+        question["kg_category"] = topic.get("kg_category")
+
+    # Add code reference if available
+    if code_reference:
+        question["code_reference"] = {
+            "file_path": code_reference.get("file_path"),
+            "line_start": code_reference.get("line_start"),
+            "line_end": code_reference.get("line_end"),
+            "repository": code_reference.get("repository"),
+        }
+
+    # Use recommended probe if available and question_text is generic
+    if recommended_probe and question.get("question_text", "").startswith("["):
+        question["alternative_phrasing"] = question.get("alternative_phrasing", [])
+        question["alternative_phrasing"].append(recommended_probe)
 
     return question
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "httpx>=0.27.0",
     # Utilities
     "python-dateutil>=2.9.0",
+    # Knowledge Graph
+    "spacy>=3.7.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_conflict_detector.py
+++ b/backend/tests/test_conflict_detector.py
@@ -1,0 +1,337 @@
+"""
+Unit tests for Conflict Detector service.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+# ============================================================
+# Conflict Analysis Model Tests
+# ============================================================
+
+class TestConflictAnalysisModel:
+    def test_conflict_analysis_creation(self):
+        from app.services.conflict_detector import ConflictAnalysis
+
+        conflict = ConflictAnalysis(
+            claim="Proficiency in Python",
+            claim_source="resume",
+            expected_evidence="Code demonstrating Python usage",
+            actual_evidence=None,
+            conflict_type="missing",
+            severity="high",
+            confidence=85,
+            analysis="Candidate claims Python but no evidence found",
+            recommended_probe="Can you describe your Python experience?",
+        )
+
+        assert conflict.claim == "Proficiency in Python"
+        assert conflict.conflict_type == "missing"
+        assert conflict.severity == "high"
+        assert conflict.confidence == 85
+
+    def test_conflict_analysis_all_types(self):
+        from app.services.conflict_detector import ConflictAnalysis
+
+        conflict_types = ["missing", "contradicting", "overstated", "understated"]
+        severities = ["high", "medium", "low"]
+
+        for ct in conflict_types:
+            for sev in severities:
+                conflict = ConflictAnalysis(
+                    claim="Test claim",
+                    claim_source="resume",
+                    expected_evidence="Expected",
+                    actual_evidence="Actual",
+                    conflict_type=ct,
+                    severity=sev,
+                    confidence=75,
+                    analysis="Analysis text",
+                    recommended_probe="Probe question",
+                )
+                assert conflict.conflict_type == ct
+                assert conflict.severity == sev
+
+
+class TestConflictReportModel:
+    def test_conflict_report_creation(self):
+        from app.services.conflict_detector import ConflictReport, ConflictAnalysis
+
+        conflict = ConflictAnalysis(
+            claim="Test",
+            claim_source="resume",
+            expected_evidence="Expected",
+            actual_evidence=None,
+            conflict_type="missing",
+            severity="medium",
+            confidence=80,
+            analysis="Analysis",
+            recommended_probe="Probe",
+        )
+
+        report = ConflictReport(
+            job_id="test-job-id",
+            total_claims_analyzed=10,
+            conflicts=[conflict],
+            verified_claims=[{"skill": "Verified Skill"}],
+            summary={"total_conflicts": 1},
+        )
+
+        assert report.job_id == "test-job-id"
+        assert report.total_claims_analyzed == 10
+        assert len(report.conflicts) == 1
+        assert len(report.verified_claims) == 1
+
+    def test_conflict_report_empty(self):
+        from app.services.conflict_detector import ConflictReport
+
+        report = ConflictReport(
+            job_id="test-job-id",
+            total_claims_analyzed=0,
+        )
+
+        assert report.conflicts == []
+        assert report.verified_claims == []
+        assert report.summary == {}
+
+
+# ============================================================
+# Conflict Detector Logic Tests
+# ============================================================
+
+class TestConflictDetectorLogic:
+    def test_determine_skill_severity_critical(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        critical_skills = ["Python", "Java", "JavaScript", "SQL", "Git"]
+        for skill in critical_skills:
+            assert detector._determine_skill_severity(skill) == "high", f"{skill} should be high severity"
+
+    def test_determine_skill_severity_important(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        important_skills = ["React", "Node.js", "Docker", "Kubernetes", "AWS"]
+        for skill in important_skills:
+            assert detector._determine_skill_severity(skill) == "medium", f"{skill} should be medium severity"
+
+    def test_determine_skill_severity_low(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        low_skills = ["ObscureFramework", "SomeLibrary", "RandomTool"]
+        for skill in low_skills:
+            assert detector._determine_skill_severity(skill) == "low", f"{skill} should be low severity"
+
+    def test_expected_complexity_senior(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        senior_roles = ["senior developer", "lead engineer", "principal architect", "staff engineer"]
+        for role in senior_roles:
+            assert detector._expected_complexity_for_role(role) == 15.0, f"{role} should expect 15.0 complexity"
+
+    def test_expected_complexity_mid(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        mid_roles = ["software engineer", "mid level developer", "regular developer"]
+        for role in mid_roles:
+            result = detector._expected_complexity_for_role(role)
+            assert result == 10.0, f"{role} should expect 10.0 complexity, got {result}"
+
+    def test_expected_complexity_junior(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        junior_roles = ["junior developer", "associate engineer", "entry level"]
+        for role in junior_roles:
+            result = detector._expected_complexity_for_role(role)
+            assert result == 5.0, f"{role} should expect 5.0 complexity, got {result}"
+
+    def test_find_related_tech_python(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        # Python-related techs
+        python_related = {"django", "flask", "fastapi"}
+        assert detector._find_related_tech("python", python_related) is True
+
+        # No Python-related techs
+        no_python_related = {"react", "vue", "angular"}
+        assert detector._find_related_tech("python", no_python_related) is False
+
+    def test_find_related_tech_javascript(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        # JS-related techs
+        js_related = {"react", "vue", "node.js"}
+        assert detector._find_related_tech("javascript", js_related) is True
+
+        # No JS-related techs
+        no_js_related = {"django", "flask", "postgresql"}
+        assert detector._find_related_tech("javascript", no_js_related) is False
+
+    def test_count_by_type(self):
+        from app.services.conflict_detector import ConflictDetector, ConflictAnalysis
+        detector = ConflictDetector("test")
+
+        conflicts = [
+            ConflictAnalysis(
+                claim="A", claim_source="resume", expected_evidence="E", actual_evidence=None,
+                conflict_type="missing", severity="high", confidence=80,
+                analysis="A", recommended_probe="P",
+            ),
+            ConflictAnalysis(
+                claim="B", claim_source="resume", expected_evidence="E", actual_evidence="X",
+                conflict_type="missing", severity="medium", confidence=70,
+                analysis="A", recommended_probe="P",
+            ),
+            ConflictAnalysis(
+                claim="C", claim_source="resume", expected_evidence="E", actual_evidence="Y",
+                conflict_type="overstated", severity="low", confidence=60,
+                analysis="A", recommended_probe="P",
+            ),
+        ]
+
+        counts = detector._count_by_type(conflicts)
+        assert counts["missing"] == 2
+        assert counts["overstated"] == 1
+
+
+# ============================================================
+# Probe Generation Tests
+# ============================================================
+
+class TestProbeGeneration:
+    def test_generate_skill_probe_python(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        probe = detector._generate_skill_probe("Python")
+        assert "Python" in probe or "structuring" in probe
+
+    def test_generate_skill_probe_react(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        probe = detector._generate_skill_probe("React")
+        assert "state" in probe.lower() or "react" in probe.lower()
+
+    def test_generate_skill_probe_docker(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        probe = detector._generate_skill_probe("Docker")
+        assert "docker" in probe.lower() or "container" in probe.lower()
+
+    def test_generate_skill_probe_unknown(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        probe = detector._generate_skill_probe("SomeUnknownTech")
+        assert "SomeUnknownTech" in probe
+        assert "describe" in probe.lower() or "project" in probe.lower()
+
+    def test_generate_skill_probe_all_major_techs(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        major_techs = ["python", "java", "javascript", "react", "docker",
+                       "kubernetes", "postgresql", "aws"]
+
+        for tech in major_techs:
+            probe = detector._generate_skill_probe(tech)
+            assert len(probe) > 20, f"Probe for {tech} should be meaningful"
+            assert "?" in probe or "walk" in probe.lower() or "describe" in probe.lower() or "explain" in probe.lower()
+
+
+# ============================================================
+# Integration Tests (Mocked)
+# ============================================================
+
+class TestConflictDetectorIntegration:
+    @pytest.fixture
+    def mock_kg_service(self):
+        """Mock knowledge graph service."""
+        with patch("app.services.conflict_detector.get_knowledge_graph") as mock:
+            kg_instance = AsyncMock()
+            kg_instance.get_skills_with_evidence = AsyncMock(return_value=[
+                {
+                    "skill": "Python",
+                    "is_claimed": True,
+                    "verified": True,
+                    "evidence_count": 3,
+                    "evidence": [{"name": "test-repo", "type": "Repository"}],
+                },
+                {
+                    "skill": "React",
+                    "is_claimed": True,
+                    "verified": False,
+                    "evidence_count": 0,
+                    "evidence": [],
+                },
+            ])
+            mock.return_value = kg_instance
+            yield kg_instance
+
+    @pytest.fixture
+    def mock_graph_store(self):
+        """Mock graph store."""
+        with patch("app.services.conflict_detector.get_graph_store") as mock:
+            store_instance = AsyncMock()
+            store_instance.get_nodes_by_type = AsyncMock(return_value=[])
+            store_instance.create_claim_evidence = AsyncMock(return_value="mock-id")
+            store_instance.find_node_by_name = AsyncMock(return_value=None)
+            mock.return_value = store_instance
+            yield store_instance
+
+    @pytest.mark.asyncio
+    async def test_detect_skill_conflicts(self, mock_kg_service, mock_graph_store):
+        from app.services.conflict_detector import ConflictDetector
+
+        detector = ConflictDetector("test-job-id")
+
+        # Mock _detect_experience_conflicts and _detect_technology_conflicts
+        detector._detect_experience_conflicts = AsyncMock(return_value=[])
+        detector._detect_technology_conflicts = AsyncMock(return_value=[])
+
+        report = await detector.detect_all_conflicts()
+
+        assert report.job_id == "test-job-id"
+        # Should find React as unverified
+        react_conflicts = [c for c in report.conflicts if "React" in c.claim]
+        # Note: This may vary based on mock setup
+        assert report.total_claims_analyzed >= 0
+
+
+class TestConflictDetectorWithMockedKG:
+    @pytest.mark.asyncio
+    async def test_detect_skill_conflicts_finds_unverified(self):
+        """Test that unverified skills are detected as conflicts."""
+        from app.services.conflict_detector import ConflictDetector
+
+        with patch.object(ConflictDetector, "__init__", lambda x, y: None):
+            detector = ConflictDetector.__new__(ConflictDetector)
+            detector.job_id = "test"
+            detector.kg = AsyncMock()
+            detector.store = AsyncMock()
+
+            detector.kg.get_skills_with_evidence = AsyncMock(return_value=[
+                {
+                    "skill": "Claimed But Not Found",
+                    "is_claimed": True,
+                    "verified": False,
+                    "evidence_count": 0,
+                    "evidence": [],
+                },
+            ])
+
+            result = await detector._detect_skill_conflicts()
+
+            assert "conflicts" in result
+            assert "verified" in result
+            assert len(result["conflicts"]) == 1
+            assert result["conflicts"][0].conflict_type == "missing"

--- a/backend/tests/test_knowledge_graph.py
+++ b/backend/tests/test_knowledge_graph.py
@@ -1,0 +1,443 @@
+"""
+Unit tests for Knowledge Graph services.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import uuid
+
+
+# ============================================================
+# Graph Store Tests
+# ============================================================
+
+class TestGraphStoreInit:
+    def test_get_graph_store(self):
+        from app.services.graph_store import get_graph_store
+        store = get_graph_store("test-job-id")
+        assert str(store.job_id) == "test-job-id"
+
+    def test_graph_store_class(self):
+        from app.services.graph_store import GraphStore
+        store = GraphStore("abc-123")
+        assert str(store.job_id) == "abc-123"
+
+
+class TestKGDatabaseModels:
+    def test_kg_node_db_importable(self):
+        from app.models.database import KGNodeDB
+        assert KGNodeDB.__tablename__ == "kg_nodes"
+
+    def test_kg_node_db_columns(self):
+        from app.models.database import KGNodeDB
+        columns = {c.name for c in KGNodeDB.__table__.columns}
+        assert "job_id" in columns
+        assert "entity_type" in columns
+        assert "name" in columns
+        assert "properties" in columns
+        assert "provenance" in columns
+        assert "embedding" in columns
+
+    def test_kg_edge_db_importable(self):
+        from app.models.database import KGEdgeDB
+        assert KGEdgeDB.__tablename__ == "kg_edges"
+
+    def test_kg_edge_db_columns(self):
+        from app.models.database import KGEdgeDB
+        columns = {c.name for c in KGEdgeDB.__table__.columns}
+        assert "job_id" in columns
+        assert "source_id" in columns
+        assert "target_id" in columns
+        assert "relation_type" in columns
+        assert "confidence" in columns
+        assert "properties" in columns
+
+    def test_claim_evidence_db_importable(self):
+        from app.models.database import ClaimEvidenceDB
+        assert ClaimEvidenceDB.__tablename__ == "claim_evidence"
+
+    def test_claim_evidence_db_columns(self):
+        from app.models.database import ClaimEvidenceDB
+        columns = {c.name for c in ClaimEvidenceDB.__table__.columns}
+        assert "job_id" in columns
+        assert "claim_node_id" in columns
+        assert "evidence_node_id" in columns
+        assert "evidence_type" in columns
+        assert "evidence_strength" in columns
+        assert "analysis" in columns
+        assert "recommended_probe" in columns
+
+
+# ============================================================
+# Entity Extractor Tests
+# ============================================================
+
+class TestCandidateEntityExtractor:
+    def test_extractor_init(self):
+        from app.services.entity_extractors import CandidateEntityExtractor
+        extractor = CandidateEntityExtractor()
+        assert extractor.source == "document_analysis"
+
+    def test_extract_skills_from_profile(self):
+        from app.services.entity_extractors import get_candidate_extractor
+        extractor = get_candidate_extractor()
+
+        profile = {
+            "name": "Test User",
+            "skills": ["Python", "React", "FastAPI"],
+            "work_history": [],
+            "education": [],
+            "projects": [],
+        }
+
+        result = extractor.extract(profile)
+
+        assert len(result.entities) >= 3  # At least 3 skills
+        skill_entities = [e for e in result.entities if e.entity_type == "Skill"]
+        skill_names = [e.name for e in skill_entities]
+        assert "Python" in skill_names
+        assert "React" in skill_names
+        assert "FastAPI" in skill_names
+
+    def test_extract_work_experience(self):
+        from app.services.entity_extractors import get_candidate_extractor
+        extractor = get_candidate_extractor()
+
+        profile = {
+            "name": "Test User",
+            "skills": [],
+            "work_history": [
+                {
+                    "company": "TechCorp",
+                    "position": "Senior Engineer",
+                    "period": "2020-2023",
+                    "description": "Built AI systems",
+                    "tech_stack": ["Python", "TensorFlow"],
+                }
+            ],
+            "education": [],
+            "projects": [],
+        }
+
+        result = extractor.extract(profile)
+
+        work_entities = [e for e in result.entities if e.entity_type == "WorkExperience"]
+        assert len(work_entities) == 1
+        assert "TechCorp" in work_entities[0].name
+
+        # Check for used_technology relations
+        tech_relations = [r for r in result.relations if r.relation_type == "used_technology"]
+        assert len(tech_relations) >= 2  # Python and TensorFlow
+
+    def test_categorize_skill(self):
+        from app.services.entity_extractors import CandidateEntityExtractor
+        extractor = CandidateEntityExtractor()
+
+        assert extractor._categorize_skill("Python") == "programming_language"
+        assert extractor._categorize_skill("React") == "frontend"
+        assert extractor._categorize_skill("FastAPI") == "backend"
+        assert extractor._categorize_skill("PostgreSQL") == "database"
+        assert extractor._categorize_skill("AWS") == "cloud"
+
+
+class TestCodeEntityExtractor:
+    def test_extractor_init(self):
+        from app.services.entity_extractors import CodeEntityExtractor
+        extractor = CodeEntityExtractor()
+        assert extractor.source == "code_analysis"
+
+    def test_extract_repositories(self):
+        from app.services.entity_extractors import get_code_extractor
+        extractor = get_code_extractor()
+
+        code_analysis = {
+            "repositories": [
+                {
+                    "repo_name": "test-repo",
+                    "repo_url": "https://github.com/user/test-repo",
+                    "language": "Python",
+                    "tech_stack": ["FastAPI", "SQLAlchemy"],
+                    "patterns": [],
+                    "notable_implementations": [],
+                }
+            ],
+            "combined_tech_stack": ["Python", "FastAPI"],
+        }
+
+        result = extractor.extract(code_analysis)
+
+        repo_entities = [e for e in result.entities if e.entity_type == "Repository"]
+        assert len(repo_entities) == 1
+        assert repo_entities[0].name == "test-repo"
+
+        # Check for demonstrated_by relations
+        demo_relations = [r for r in result.relations if r.relation_type == "demonstrated_by"]
+        assert len(demo_relations) >= 2  # FastAPI and SQLAlchemy
+
+    def test_extract_notable_implementations(self):
+        from app.services.entity_extractors import get_code_extractor
+        extractor = get_code_extractor()
+
+        code_analysis = {
+            "repositories": [
+                {
+                    "repo_name": "test-repo",
+                    "repo_url": "https://github.com/user/test-repo",
+                    "language": "Python",
+                    "tech_stack": [],
+                    "patterns": [],
+                    "notable_implementations": [
+                        {
+                            "title": "Async Workflow Engine",
+                            "description": "Custom workflow engine",
+                            "file_path": "workflow/engine.py",
+                            "line_start": 10,
+                            "line_end": 100,
+                            "code_snippet": "async def run_workflow():\n    ...",
+                            "why_notable": "Complex async patterns",
+                            "question_potential": 0.9,
+                        }
+                    ],
+                }
+            ],
+            "combined_tech_stack": [],
+        }
+
+        result = extractor.extract(code_analysis)
+
+        impl_entities = [e for e in result.entities if e.entity_type == "NotableImplementation"]
+        assert len(impl_entities) == 1
+        assert impl_entities[0].name == "Async Workflow Engine"
+        assert impl_entities[0].properties.get("question_potential") == 0.9
+
+
+class TestJDEntityExtractor:
+    def test_extractor_init(self):
+        from app.services.entity_extractors import JDEntityExtractor
+        extractor = JDEntityExtractor()
+        assert extractor.source == "jd_analysis"
+
+    def test_extract_requirements(self):
+        from app.services.entity_extractors import get_jd_extractor
+        extractor = get_jd_extractor()
+
+        jd_analysis = {
+            "job_title": "Senior Engineer",
+            "company_name": "TechCorp",
+            "requirements": [
+                {"skill": "Python", "category": "필수", "experience_years": 3},
+                {"skill": "LLM", "category": "우대"},
+            ],
+            "responsibilities": ["Build AI systems"],
+            "company_culture": [],
+        }
+
+        result = extractor.extract(jd_analysis)
+
+        req_entities = [e for e in result.entities if e.entity_type == "Requirement"]
+        assert len(req_entities) == 2
+
+        # Check priority mapping
+        python_req = next(e for e in req_entities if e.name == "Python")
+        assert python_req.properties.get("priority") == "required"
+
+        llm_req = next(e for e in req_entities if e.name == "LLM")
+        assert llm_req.properties.get("priority") == "preferred"
+
+
+# ============================================================
+# Knowledge Graph Service Tests
+# ============================================================
+
+class TestKnowledgeGraphService:
+    def test_service_init(self):
+        from app.services.knowledge_graph import KnowledgeGraphService
+        kg = KnowledgeGraphService("test-job-id")
+        assert kg.job_id == "test-job-id"
+        assert kg.store is not None
+        assert kg._node_cache == {}
+
+    def test_get_knowledge_graph_factory(self):
+        from app.services.knowledge_graph import get_knowledge_graph
+        kg = get_knowledge_graph("abc-123")
+        assert kg.job_id == "abc-123"
+
+
+# ============================================================
+# Conflict Detector Tests
+# ============================================================
+
+class TestConflictDetector:
+    def test_detector_init(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test-job-id")
+        assert detector.job_id == "test-job-id"
+
+    def test_get_conflict_detector_factory(self):
+        from app.services.conflict_detector import get_conflict_detector
+        detector = get_conflict_detector("abc-123")
+        assert detector.job_id == "abc-123"
+
+    def test_determine_skill_severity(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        assert detector._determine_skill_severity("Python") == "high"
+        assert detector._determine_skill_severity("React") == "medium"
+        assert detector._determine_skill_severity("Obscure Framework") == "low"
+
+    def test_expected_complexity_for_role(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        assert detector._expected_complexity_for_role("senior engineer") == 15.0
+        assert detector._expected_complexity_for_role("software engineer") == 10.0
+        assert detector._expected_complexity_for_role("junior developer") == 5.0
+        assert detector._expected_complexity_for_role("unknown role") is None
+
+    def test_find_related_tech(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        code_skills = {"django", "fastapi", "numpy"}
+
+        assert detector._find_related_tech("python", code_skills) is True
+        assert detector._find_related_tech("javascript", code_skills) is False
+
+    def test_generate_skill_probe(self):
+        from app.services.conflict_detector import ConflictDetector
+        detector = ConflictDetector("test")
+
+        python_probe = detector._generate_skill_probe("Python")
+        assert "Python" in python_probe or "structure" in python_probe
+
+        react_probe = detector._generate_skill_probe("React")
+        assert "state" in react_probe or "React" in react_probe
+
+        unknown_probe = detector._generate_skill_probe("UnknownTech")
+        assert "UnknownTech" in unknown_probe
+
+
+# ============================================================
+# Graph Queries Tests
+# ============================================================
+
+class TestInterviewGraphQueries:
+    def test_queries_init(self):
+        from app.services.graph_queries import InterviewGraphQueries
+        queries = InterviewGraphQueries("test-job-id")
+        assert queries.job_id == "test-job-id"
+
+    def test_get_interview_graph_queries_factory(self):
+        from app.services.graph_queries import get_interview_graph_queries
+        queries = get_interview_graph_queries("abc-123")
+        assert queries.job_id == "abc-123"
+
+
+class TestQuestionCandidateModel:
+    def test_question_candidate_creation(self):
+        from app.services.graph_queries import QuestionCandidate
+
+        candidate = QuestionCandidate(
+            topic="Python",
+            category="skill_depth",
+            priority=85.0,
+            evidence_chain=[{"type": "Repository", "name": "test-repo"}],
+            context={"evidence_count": 3},
+            recommended_probe="Tell me about your Python experience",
+        )
+
+        assert candidate.topic == "Python"
+        assert candidate.category == "skill_depth"
+        assert candidate.priority == 85.0
+        assert len(candidate.evidence_chain) == 1
+
+
+# ============================================================
+# KG Activity Tests
+# ============================================================
+
+class TestKGActivities:
+    def test_build_knowledge_graph_activity_exists(self):
+        from app.workflows.activities.knowledge_graph_activities import build_knowledge_graph
+        assert callable(build_knowledge_graph)
+
+    def test_get_kg_question_candidates_activity_exists(self):
+        from app.workflows.activities.knowledge_graph_activities import get_kg_question_candidates
+        assert callable(get_kg_question_candidates)
+
+    def test_get_evidence_chain_activity_exists(self):
+        from app.workflows.activities.knowledge_graph_activities import get_evidence_chain
+        assert callable(get_evidence_chain)
+
+    def test_clear_knowledge_graph_activity_exists(self):
+        from app.workflows.activities.knowledge_graph_activities import clear_knowledge_graph
+        assert callable(clear_knowledge_graph)
+
+
+# ============================================================
+# Worker Registration Tests
+# ============================================================
+
+class TestWorkerRegistration:
+    def test_kg_activities_in_worker(self):
+        from app.worker import ACTIVITIES
+
+        activity_names = [a.__name__ for a in ACTIVITIES]
+
+        assert "build_knowledge_graph" in activity_names
+        assert "get_kg_question_candidates" in activity_names
+        assert "get_evidence_chain" in activity_names
+        assert "clear_knowledge_graph" in activity_names
+
+
+# ============================================================
+# Integration Tests (Modified Activities)
+# ============================================================
+
+class TestModifiedActivities:
+    def test_document_analysis_returns_kg_count(self):
+        """Verify document_analysis activity returns kg_entity_count."""
+        # This is a structural test - actual DB integration would require mocking
+        from app.workflows.activities.document_analysis import analyze_documents
+
+        # Check the function signature and return type hint
+        import inspect
+        sig = inspect.signature(analyze_documents)
+        assert "input_data" in sig.parameters
+
+    def test_code_analysis_returns_kg_count(self):
+        """Verify code_analysis activity returns kg_entity_count."""
+        from app.workflows.activities.code_analysis import analyze_code
+
+        import inspect
+        sig = inspect.signature(analyze_code)
+        assert "github_urls" in sig.parameters
+        assert "input_data" in sig.parameters
+
+    def test_jd_analysis_accepts_job_id(self):
+        """Verify jd_analysis activity accepts job_id parameter."""
+        from app.workflows.activities.jd_analysis import analyze_jd
+
+        import inspect
+        sig = inspect.signature(analyze_jd)
+        assert "jd_text" in sig.parameters
+        assert "job_id" in sig.parameters
+
+    def test_select_topics_accepts_job_id(self):
+        """Verify select_topics activity accepts job_id parameter."""
+        from app.workflows.activities.question_generation import select_topics
+
+        import inspect
+        sig = inspect.signature(select_topics)
+        assert "analysis" in sig.parameters
+        assert "enriched_input" in sig.parameters
+        assert "job_id" in sig.parameters
+
+    def test_craft_question_accepts_job_id(self):
+        """Verify craft_question activity accepts job_id parameter."""
+        from app.workflows.activities.question_generation import craft_question
+
+        import inspect
+        sig = inspect.signature(craft_question)
+        assert "topic" in sig.parameters
+        assert "job_id" in sig.parameters

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -88,3 +88,77 @@ CREATE TABLE IF NOT EXISTS checkpoints (
 );
 
 CREATE INDEX IF NOT EXISTS idx_checkpoints_job ON checkpoints(job_id);
+
+-- ============================================
+-- Embeddings Table
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS embeddings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_id UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    kind VARCHAR(20) NOT NULL,
+    content_key VARCHAR(255) NOT NULL,
+    content_text TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}',
+    embedding VECTOR(1536) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_embeddings_job ON embeddings(job_id);
+CREATE INDEX IF NOT EXISTS idx_embeddings_kind ON embeddings(kind);
+
+-- ============================================
+-- Knowledge Graph Tables
+-- ============================================
+
+-- KG Nodes: Entity storage with optional embeddings for hybrid search
+CREATE TABLE IF NOT EXISTS kg_nodes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_id UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    entity_type VARCHAR(100) NOT NULL,
+    name VARCHAR(500) NOT NULL,
+    properties JSONB NOT NULL DEFAULT '{}',
+    embedding VECTOR(1536),
+    provenance JSONB,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kg_nodes_job ON kg_nodes(job_id);
+CREATE INDEX IF NOT EXISTS idx_kg_nodes_type ON kg_nodes(entity_type);
+CREATE INDEX IF NOT EXISTS idx_kg_nodes_job_type ON kg_nodes(job_id, entity_type);
+CREATE INDEX IF NOT EXISTS idx_kg_nodes_name ON kg_nodes(name);
+
+-- KG Edges: Relationship storage with confidence scores
+CREATE TABLE IF NOT EXISTS kg_edges (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_id UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    source_id UUID NOT NULL REFERENCES kg_nodes(id) ON DELETE CASCADE,
+    target_id UUID NOT NULL REFERENCES kg_nodes(id) ON DELETE CASCADE,
+    relation_type VARCHAR(100) NOT NULL,
+    properties JSONB DEFAULT '{}',
+    confidence INTEGER NOT NULL DEFAULT 100,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kg_edges_job ON kg_edges(job_id);
+CREATE INDEX IF NOT EXISTS idx_kg_edges_source ON kg_edges(source_id);
+CREATE INDEX IF NOT EXISTS idx_kg_edges_target ON kg_edges(target_id);
+CREATE INDEX IF NOT EXISTS idx_kg_edges_relation ON kg_edges(relation_type);
+CREATE INDEX IF NOT EXISTS idx_kg_edges_job_relation ON kg_edges(job_id, relation_type);
+
+-- Claim-Evidence: Verification records for interview probing
+CREATE TABLE IF NOT EXISTS claim_evidence (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_id UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    claim_node_id UUID REFERENCES kg_nodes(id) ON DELETE SET NULL,
+    evidence_node_id UUID REFERENCES kg_nodes(id) ON DELETE SET NULL,
+    evidence_type VARCHAR(50) NOT NULL,
+    evidence_strength INTEGER NOT NULL,
+    analysis TEXT,
+    recommended_probe TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_claim_evidence_job ON claim_evidence(job_id);
+CREATE INDEX IF NOT EXISTS idx_claim_evidence_type ON claim_evidence(evidence_type);
+CREATE INDEX IF NOT EXISTS idx_claim_evidence_strength ON claim_evidence(evidence_strength);


### PR DESCRIPTION
## 개요

Semantica Knowledge Graph를 Vantict Sniper v4.0 워크플로우에 통합하여 **Claim-Evidence 검증** 및 **그래프 기반 질문 생성** 기능을 구현합니다.

## 변경 전/후 비교

### Before (기존)
```
Resume → document_analysis → flat dict → vector store (similarity only)
GitHub → code_analysis → flat dict → vector store
JD → jd_analysis → flat dict
                          ↓
              LLM-based topic selection (no evidence chain)
                          ↓
              Question generation (no provenance)
```

### After (Knowledge Graph 통합)
```
Resume → document_analysis → Entity Extraction → KG Nodes
GitHub → code_analysis → Entity Extraction → KG Nodes
JD → jd_analysis → Entity Extraction → KG Nodes
                          ↓
              Knowledge Graph
              - Build relationships
              - Detect claim-evidence conflicts
              - Compute skill matches
                          ↓
              Graph-based topic selection
              - Evidence chains included
              - Conflict probing questions
              - Gap analysis questions
                          ↓
              Question generation with provenance
```

## 주요 변경사항

### 새로운 서비스 파일 (6개)
| 파일 | 용도 |
|------|------|
| `graph_store.py` | PostgreSQL 기반 KG 노드/엣지 저장소 |
| `entity_extractors.py` | 도메인별 엔티티 추출기 (후보자, 코드, JD) |
| `knowledge_graph.py` | KG 서비스 메인 오케스트레이터 |
| `conflict_detector.py` | Claim-Evidence 충돌 탐지 및 면접 질문 제안 |
| `graph_queries.py` | 질문 생성용 그래프 쿼리 인터페이스 |
| `knowledge_graph_activities.py` | Temporal KG Activity 4종 |

### 데이터베이스 스키마 추가
- `kg_nodes`: 엔티티 저장 (Skill, Repository, Requirement 등)
- `kg_edges`: 관계 저장 (has_skill, demonstrated_by, matches 등)
- `claim_evidence`: 충돌 분석 결과 및 면접 질문 제안

### Activity 수정 (4개)
- `document_analysis`: 후보자 프로필에서 KG 엔티티 추출 추가
- `code_analysis`: GitHub 분석 결과에서 KG 엔티티 추출 추가
- `jd_analysis`: JD 요구사항에서 KG 엔티티 추출 추가
- `question_generation`: KG 기반 질문 후보 우선순위 적용

### 테스트 추가 (2개)
- `test_knowledge_graph.py`: KG 서비스 및 추출기 단위 테스트 (444줄)
- `test_conflict_detector.py`: 충돌 탐지 로직 단위 테스트 (338줄)

## 기술 설계

### 핵심 엔티티 타입
```
Candidate Domain:
- Skill (name, category, proficiency, evidence_sources)
- WorkExperience (company, title, period, technologies)
- Education, Project

Code Domain:
- Repository (url, name, language, contributions)
- CodePattern (pattern_type, file_path, code_snippet)
- NotableImplementation (title, description, complexity)

JD Domain:
- Requirement (skill, category, experience_years, priority)
- Responsibility, TechnologyStack
```

### 핵심 관계 타입
```
Skill Relationships:
- Candidate --[has_skill]--> Skill
- Skill --[demonstrated_by]--> CodePattern | NotableImplementation
- Skill --[matches]--> Requirement (with confidence)

Evidence Relationships:
- Claim --[supported_by]--> Evidence
- Claim --[contradicted_by]--> Evidence
```

### Graceful Degradation
KG 작업 실패 시 기존 로직으로 폴백:
```python
try:
    kg = KnowledgeGraphService(job_id)
    graph_topics = await kg.query_question_candidates()
except Exception as e:
    logger.warning(f"Knowledge graph unavailable: {e}")
    graph_topics = []  # 기존 vector-only 모드로 진행
```

## 테스트 계획
- [x] Python 문법 검증 (모든 파일 통과)
- [ ] 단위 테스트 실행 (`pytest tests/test_knowledge_graph.py tests/test_conflict_detector.py`)
- [ ] 통합 테스트 (실제 Job 생성 후 KG 테이블 확인)
- [ ] E2E 테스트 (질문에 evidence_chain 포함 확인)

## 예상 성능 영향
| 항목 | 추가 시간 |
|------|----------|
| Entity extraction (per activity) | +2-5초 |
| Graph building | +1-2초 |
| Conflict detection | +0.5-1초 |
| **Phase 2 총 추가 시간** | **+5-10초** |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)