### PR TITLE
feat: Langfuse Mustache 문법 통일 및 프롬프트 변수 동적 치환

### DIFF
--- a/backend/app/prompts/__init__.py
+++ b/backend/app/prompts/__init__.py
@@ -6,9 +6,14 @@ Langfuse Prompt Management Features:
 - 프롬프트 텍스트: Langfuse UI에서 버전 관리
 - 모델 설정: prompt.config에서 model, temperature 등 관리
 - Fallback: Langfuse 실패 시 로컬 YAML + llm_config.py 사용
+
+Template Syntax (Mustache-style):
+- {{variable}} = 변수 플레이스홀더
+- { } = 리터럴 중괄호 (JSON 등)
 """
 import logging
 import os
+import re
 from functools import lru_cache
 from typing import Any
 from dataclasses import dataclass
@@ -17,6 +22,19 @@ import yaml
 
 logger = logging.getLogger(__name__)
 PROMPTS_DIR = os.path.dirname(__file__)
+
+
+def mustache_format(template: str, **kwargs) -> str:
+    """Mustache 스타일 변수 치환 ({{variable}} → value).
+
+    Langfuse와 동일한 문법을 사용하여 YAML fallback에서도 일관성 유지.
+    """
+    result = template
+    for key, value in kwargs.items():
+        # {{key}} 패턴을 value로 치환
+        pattern = r'\{\{' + re.escape(key) + r'\}\}'
+        result = re.sub(pattern, str(value), result)
+    return result
 
 # Cache for Langfuse prompts (name -> prompt object)
 _langfuse_prompt_cache: dict[str, Any] = {}
@@ -140,7 +158,7 @@ def get_prompt(filename: str, key: str, **kwargs) -> str:
     # Fallback to local YAML
     data = _load_yaml(filename)
     template = data["prompts"][key]["template"]
-    result = template.format(**kwargs)
+    result = mustache_format(template, **kwargs)
 
     # Log YAML fallback usage
     _log_prompt_usage(langfuse_name, None, "yaml", kwargs.keys())
@@ -194,7 +212,7 @@ def get_prompt_with_metadata(filename: str, key: str, **kwargs) -> dict:
     # Fallback to YAML
     data = _load_yaml(filename)
     template = data["prompts"][key]["template"]
-    result = template.format(**kwargs)
+    result = mustache_format(template, **kwargs)
 
     _log_prompt_usage(langfuse_name, None, "yaml", kwargs.keys())
 
@@ -259,7 +277,7 @@ def get_prompt_with_config(filename: str, key: str, **kwargs) -> PromptWithConfi
     # Fallback to YAML + llm_config.py
     data = _load_yaml(filename)
     template = data["prompts"][key]["template"]
-    result = template.format(**kwargs)
+    result = mustache_format(template, **kwargs)
 
     # Get model from llm_config.py based on activity name
     from app.services.llm_config import get_model_for_activity

--- a/backend/app/prompts/document_analysis.yaml
+++ b/backend/app/prompts/document_analysis.yaml
@@ -24,77 +24,77 @@ prompts:
       - Note contradictions between documents with "[CONFLICT]"
 
       # CONTEXT DOCUMENTS
-      {documents}
+      {{documents}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
+      {
         "name": "string or null",
-        "contact": {{
+        "contact": {
           "email": "string or null",
           "phone": "string or null",
           "linkedin": "string or null",
           "github": "string or null"
-        }},
+        },
         "education": [
-          {{
+          {
             "institution": "학교명",
             "degree": "학위",
             "field": "전공",
             "graduation_year": "년도 or null",
             "gpa": "number or null",
             "source_quote": "원문에서 발췌"
-          }}
+          }
         ],
         "work_experience": [
-          {{
+          {
             "company": "회사명",
             "position": "직책",
             "period": "기간",
             "responsibilities": ["책임1", "책임2"],
             "achievements": ["성과1", "성과2"],
             "source_quote": "원문에서 발췌"
-          }}
+          }
         ],
-        "skills": {{
+        "skills": {
           "languages": ["명시된 프로그래밍 언어"],
           "frameworks": ["명시된 프레임워크"],
           "tools": ["명시된 도구"],
           "soft_skills": ["명시된 소프트 스킬"]
-        }},
+        },
         "projects": [
-          {{
+          {
             "name": "프로젝트명",
             "description": "설명",
             "technologies": ["사용 기술"],
             "role": "역할",
             "impact": "성과/영향",
             "source_quote": "원문에서 발췌"
-          }}
+          }
         ],
         "certifications": [
-          {{
+          {
             "name": "자격증명",
             "issuer": "발급기관",
             "date": "취득일 or null",
             "source_quote": "원문에서 발췌"
-          }}
+          }
         ],
         "awards": [
-          {{
+          {
             "name": "수상명",
             "issuer": "수여기관",
             "date": "수상일 or null",
             "description": "설명"
-          }}
+          }
         ],
-        "extraction_confidence": {{
+        "extraction_confidence": {
           "overall_score": 0.0-1.0,
           "missing_sections": ["section names with no data"],
           "unclear_sections": ["section names with unclear data"],
           "conflicts_found": ["description of any conflicts"]
-        }}
-      }}
+        }
+      }
       ```
 
       # SUCCESSFUL EXAMPLE
@@ -107,17 +107,17 @@ prompts:
 
       Output:
       ```json
-      {{
+      {
         "name": "홍길동",
-        "contact": {{"email": "hong@email.com", "github": "github.com/hong", "linkedin": null, "phone": null}},
-        "education": [{{"institution": "서울대학교", "degree": "학사", "field": "컴퓨터공학과", "graduation_year": "2020", "gpa": 4.2, "source_quote": "서울대학교 컴퓨터공학과 졸업 (2020, GPA 4.2/4.5)"}}],
-        "work_experience": [{{"company": "ABC Corp", "position": "백엔드 개발자", "period": "2020.03 - 현재", "responsibilities": ["FastAPI 기반 마이크로서비스 아키텍처 설계 및 구현"], "achievements": ["일일 100만 요청 처리 시스템 구축으로 응답시간 40% 개선"], "source_quote": "ABC Corp 백엔드 개발자..."}}],
-        "skills": {{"languages": ["Python"], "frameworks": ["FastAPI"], "tools": ["PostgreSQL", "Docker", "Kubernetes"], "soft_skills": []}},
+        "contact": {"email": "hong@email.com", "github": "github.com/hong", "linkedin": null, "phone": null},
+        "education": [{"institution": "서울대학교", "degree": "학사", "field": "컴퓨터공학과", "graduation_year": "2020", "gpa": 4.2, "source_quote": "서울대학교 컴퓨터공학과 졸업 (2020, GPA 4.2/4.5)"}],
+        "work_experience": [{"company": "ABC Corp", "position": "백엔드 개발자", "period": "2020.03 - 현재", "responsibilities": ["FastAPI 기반 마이크로서비스 아키텍처 설계 및 구현"], "achievements": ["일일 100만 요청 처리 시스템 구축으로 응답시간 40% 개선"], "source_quote": "ABC Corp 백엔드 개발자..."}],
+        "skills": {"languages": ["Python"], "frameworks": ["FastAPI"], "tools": ["PostgreSQL", "Docker", "Kubernetes"], "soft_skills": []},
         "projects": [],
         "certifications": [],
         "awards": [],
-        "extraction_confidence": {{"overall_score": 0.85, "missing_sections": ["projects", "certifications"], "unclear_sections": [], "conflicts_found": []}}
-      }}
+        "extraction_confidence": {"overall_score": 0.85, "missing_sections": ["projects", "certifications"], "unclear_sections": [], "conflicts_found": []}
+      }
       ```
 
       # UNSUCCESSFUL EXAMPLE (HALLUCINATION - DO NOT DO THIS)
@@ -125,19 +125,19 @@ prompts:
 
       BAD Output (hallucinated):
       ```json
-      {{
-        "skills": {{"languages": ["Python", "Java", "JavaScript"], "frameworks": ["Django", "FastAPI", "Spring"]}}
-      }}
+      {
+        "skills": {"languages": ["Python", "Java", "JavaScript"], "frameworks": ["Django", "FastAPI", "Spring"]}
+      }
       ```
       WHY BAD: Only "Python 백엔드 개발자" was mentioned. Java, JavaScript, Django, FastAPI, Spring were NOT in the document.
 
       CORRECT Output:
       ```json
-      {{
+      {
         "name": "김개발자",
-        "skills": {{"languages": ["Python"], "frameworks": [], "tools": [], "soft_skills": []}},
-        "extraction_confidence": {{"overall_score": 0.3, "missing_sections": ["education", "work_experience", "contact"], "unclear_sections": [], "conflicts_found": []}}
-      }}
+        "skills": {"languages": ["Python"], "frameworks": [], "tools": [], "soft_skills": []},
+        "extraction_confidence": {"overall_score": 0.3, "missing_sections": ["education", "work_experience", "contact"], "unclear_sections": [], "conflicts_found": []}
+      }
       ```
 
       # LIMITATIONS

--- a/backend/app/prompts/finalization.yaml
+++ b/backend/app/prompts/finalization.yaml
@@ -18,13 +18,13 @@ prompts:
       # ANALYZER INPUTS
 
       ## Analyzer 1: Document Analysis (Resume/Portfolio)
-      {document_analysis}
+      {{document_analysis}}
 
       ## Analyzer 2: Code Analysis (GitHub)
-      {code_analysis}
+      {{code_analysis}}
 
       ## Analyzer 3: LinkedIn Profile
-      {linkedin_profile}
+      {{linkedin_profile}}
 
       # SYNTHESIS RULES (CRITICAL)
 
@@ -53,80 +53,80 @@ prompts:
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
-        "candidate_overview": {{
+      {
+        "candidate_overview": {
           "name": "후보자 이름",
           "current_position": "현재 직책 (source)",
           "experience_years": "경력 년수 (calculated)",
           "primary_domain": "주요 분야",
           "confidence_level": "high|medium|low"
-        }},
+        },
         "key_strengths": [
-          {{
+          {
             "strength": "강점 설명",
-            "evidence": {{
+            "evidence": {
               "github": "GitHub 증거 또는 null",
               "resume": "이력서 증거 또는 null",
               "linkedin": "LinkedIn 증거 또는 null"
-            }},
+            },
             "confidence": 0.0-1.0,
             "corroboration": "3-source|2-source|1-source"
-          }}
+          }
         ],
         "notable_achievements": [
-          {{
+          {
             "achievement": "성과 설명",
             "source": "출처",
             "verification_status": "verified|unverified|conflicting",
             "details": "추가 세부사항"
-          }}
+          }
         ],
-        "technical_expertise": {{
+        "technical_expertise": {
           "languages": [
-            {{
+            {
               "skill": "Python",
               "proficiency": "expert|advanced|intermediate|beginner",
-              "evidence": {{"github": "commits/repos", "resume": "stated", "linkedin": "endorsed"}},
+              "evidence": {"github": "commits/repos", "resume": "stated", "linkedin": "endorsed"},
               "confidence": 0.0-1.0
-            }}
+            }
           ],
           "frameworks": [...],
           "tools": [...],
           "domains": [...]
-        }},
+        },
         "interview_discussion_topics": [
-          {{
+          {
             "topic": "토픽",
             "angle": "접근 방향",
             "evidence_base": "근거",
             "priority": "high|medium|low"
-          }}
+          }
         ],
         "risk_flags": [
-          {{
+          {
             "concern": "우려 사항",
             "evidence": "근거",
             "severity": "high|medium|low",
             "mitigation_question": "확인 질문"
-          }}
+          }
         ],
         "source_conflicts": [
-          {{
+          {
             "topic": "충돌 주제",
-            "source_a": {{"source": "github", "claim": "claim A"}},
-            "source_b": {{"source": "resume", "claim": "claim B"}},
+            "source_a": {"source": "github", "claim": "claim A"},
+            "source_b": {"source": "resume", "claim": "claim B"},
             "resolution": "recommended interpretation"
-          }}
+          }
         ],
-        "data_quality_assessment": {{
+        "data_quality_assessment": {
           "document_quality": 0.0-1.0,
           "github_quality": 0.0-1.0,
           "linkedin_quality": 0.0-1.0,
           "overall_confidence": 0.0-1.0,
           "missing_data": ["list of missing information"],
           "recommendations": ["suggestions for improving data"]
-        }}
-      }}
+        }
+      }
       ```
 
       # SUCCESSFUL SYNTHESIS EXAMPLE
@@ -138,61 +138,61 @@ prompts:
 
       Good Synthesis:
       ```json
-      {{
-        "candidate_overview": {{
+      {
+        "candidate_overview": {
           "name": "홍길동",
           "current_position": "Backend Engineer at ABC Corp (LinkedIn confirmed)",
           "experience_years": "3 years (Resume)",
           "primary_domain": "Backend Development (3-source corroboration)",
           "confidence_level": "high"
-        }},
+        },
         "key_strengths": [
-          {{
+          {
             "strength": "Python/FastAPI 전문성",
-            "evidence": {{
+            "evidence": {
               "github": "50 Python repos, FastAPI 주력, 2000+ commits",
               "resume": "Python/FastAPI 3년 경력 명시",
               "linkedin": "Python endorsed by 15 people"
-            }},
+            },
             "confidence": 0.95,
             "corroboration": "3-source"
-          }}
+          }
         ],
-        "data_quality_assessment": {{
+        "data_quality_assessment": {
           "overall_confidence": 0.9,
           "missing_data": ["specific project impact metrics", "team size details"]
-        }}
-      }}
+        }
+      }
       ```
 
       # UNSUCCESSFUL SYNTHESIS EXAMPLE (DO NOT DO THIS)
 
       BAD Synthesis (hallucinated):
       ```json
-      {{
+      {
         "key_strengths": [
-          {{
+          {
             "strength": "Kubernetes 및 클라우드 인프라 전문성",
-            "evidence": {{"github": "assumed from DevOps interest", "resume": null, "linkedin": null}},
+            "evidence": {"github": "assumed from DevOps interest", "resume": null, "linkedin": null},
             "confidence": 0.8
-          }}
+          }
         ]
-      }}
+      }
       ```
       WHY BAD: Kubernetes was NEVER mentioned in any source. High confidence is unjustified.
 
       CORRECT Synthesis:
       ```json
-      {{
+      {
         "risk_flags": [
-          {{
+          {
             "concern": "인프라/DevOps 경험 미확인",
             "evidence": "No infrastructure or Kubernetes evidence in any source",
             "severity": "medium",
             "mitigation_question": "배포 및 인프라 경험이 있으시다면 설명해주세요"
-          }}
+          }
         ]
-      }}
+      }
       ```
 
       # LIMITATIONS
@@ -216,50 +216,50 @@ prompts:
       Generate a comprehensive interviewer guide for conducting the interview.
 
       # CONTEXT
-      Experience Level: {experience_level}
-      Total Questions: {total_questions}
-      Categories: {categories}
+      Experience Level: {{experience_level}}
+      Total Questions: {{total_questions}}
+      Categories: {{categories}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
-        "interview_overview": {{
+      {
+        "interview_overview": {
           "total_duration_minutes": number,
           "question_count": number,
           "experience_level": "level",
           "interview_style": "conversational|structured|mixed"
-        }},
+        },
         "category_breakdown": [
-          {{
+          {
             "category": "category_name",
             "question_count": number,
             "time_allocation_minutes": number,
             "focus_areas": ["area1", "area2"],
             "evaluation_priority": "high|medium|low"
-          }}
+          }
         ],
-        "interview_flow": {{
-          "opening": {{
+        "interview_flow": {
+          "opening": {
             "script": "Opening remarks script",
             "duration_minutes": 3,
             "tips": ["tip1", "tip2"]
-          }},
-          "main_body": {{
+          },
+          "main_body": {
             "recommended_order": ["category1", "category2"],
             "transition_phrases": ["phrase1", "phrase2"]
-          }},
-          "closing": {{
+          },
+          "closing": {
             "script": "Closing remarks script",
             "duration_minutes": 3,
             "candidate_questions_time": 5
-          }}
-        }},
-        "evaluation_matrix": {{
+          }
+        },
+        "evaluation_matrix": {
           "scoring_scale": "1-5 or 1-10",
-          "category_weights": {{"category": weight}},
+          "category_weights": {"category": weight},
           "passing_threshold": number,
           "strong_hire_threshold": number
-        }},
+        },
         "red_flags_summary": [
           "Global red flag to watch for"
         ],
@@ -267,15 +267,15 @@ prompts:
           "Global positive indicator"
         ],
         "interviewer_tips": [
-          {{
+          {
             "tip": "Advice text",
             "context": "When this applies"
-          }}
+          }
         ],
         "post_interview_checklist": [
           "Item to complete after interview"
         ]
-      }}
+      }
       ```
 
       Return ONLY the JSON object, no additional text.
@@ -304,38 +304,38 @@ prompts:
       **Threshold**: If score < 70%, flag package for review
 
       # INPUT DATA
-      Candidate Summary: {candidate_summary}
-      Questions: {questions_json}
-      Evaluation Scenarios: {scenarios_json}
-      Interviewer Guide: {guide_json}
+      Candidate Summary: {{candidate_summary}}
+      Questions: {{questions_json}}
+      Evaluation Scenarios: {{scenarios_json}}
+      Interviewer Guide: {{guide_json}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
-        "final_validation": {{
+      {
+        "final_validation": {
           "total_questions": number,
           "grounded_questions": number,
           "evidence_grounding_score": 0-100,
           "passed_threshold": true|false,
           "flagged_items": [
-            {{
+            {
               "item_type": "question|claim|scenario",
               "item_index": number,
               "issue": "description of grounding issue",
               "recommendation": "how to fix"
-            }}
+            }
           ]
-        }},
-        "package_quality": {{
+        },
+        "package_quality": {
           "overall_score": 0-100,
-          "category_coverage": {{"category": "complete|partial|missing"}},
+          "category_coverage": {"category": "complete|partial|missing"},
           "difficulty_balance": "balanced|skewed_easy|skewed_hard",
           "evidence_quality": "strong|moderate|weak"
-        }},
+        },
         "ready_for_delivery": true|false,
         "delivery_blockers": ["list of issues preventing delivery"],
         "improvement_suggestions": ["optional improvements"]
-      }}
+      }
       ```
 
       # VALIDATION RULES

--- a/backend/app/prompts/jd_analysis.yaml
+++ b/backend/app/prompts/jd_analysis.yaml
@@ -24,48 +24,48 @@ prompts:
       - If unclear, default to "우대"
 
       # JOB DESCRIPTION
-      {jd_text}
+      {{jd_text}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
+      {
         "job_title": "직책명 or null",
         "company_name": "회사명 or null",
         "department": "부서명 or null",
         "experience_level": "Junior|Mid|Senior|Lead|Principal or null",
         "requirements": [
-          {{
+          {
             "skill": "기술/역량명",
             "category": "필수|우대",
             "level": "years of experience or proficiency level if stated",
             "source_quote": "JD에서 발췌한 원문"
-          }}
+          }
         ],
         "responsibilities": [
-          {{
+          {
             "description": "업무 설명",
             "source_quote": "JD에서 발췌한 원문"
-          }}
+          }
         ],
         "company_culture": [
           "문화/가치 키워드"
         ],
         "tech_stack": [
-          {{
+          {
             "technology": "기술명",
             "category": "language|framework|database|cloud|tool|other",
             "required": true|false
-          }}
+          }
         ],
         "benefits": [
           "복리후생 항목"
         ],
-        "extraction_confidence": {{
+        "extraction_confidence": {
           "overall_score": 0.0-1.0,
           "ambiguous_requirements": ["unclear requirement descriptions"],
           "inferred_items": ["items where category was inferred, not explicit"]
-        }}
-      }}
+        }
+      }
       ```
 
       # SUCCESSFUL EXAMPLE
@@ -89,33 +89,33 @@ prompts:
 
       Output:
       ```json
-      {{
+      {
         "job_title": "AI 엔지니어",
         "company_name": "TechCorp",
         "department": null,
         "experience_level": "Mid",
         "requirements": [
-          {{"skill": "Python", "category": "필수", "level": "3년 이상", "source_quote": "Python 3년 이상 경력"}},
-          {{"skill": "LLM/RAG 시스템 개발", "category": "필수", "level": null, "source_quote": "LLM/RAG 시스템 개발 경험"}},
-          {{"skill": "컴퓨터공학 학사", "category": "필수", "level": "학사 이상", "source_quote": "컴퓨터공학 또는 관련 학과 학사 이상"}},
-          {{"skill": "TypeScript", "category": "우대", "level": null, "source_quote": "TypeScript 경험자"}},
-          {{"skill": "AWS", "category": "우대", "level": null, "source_quote": "AWS 클라우드 경험"}}
+          {"skill": "Python", "category": "필수", "level": "3년 이상", "source_quote": "Python 3년 이상 경력"},
+          {"skill": "LLM/RAG 시스템 개발", "category": "필수", "level": null, "source_quote": "LLM/RAG 시스템 개발 경험"},
+          {"skill": "컴퓨터공학 학사", "category": "필수", "level": "학사 이상", "source_quote": "컴퓨터공학 또는 관련 학과 학사 이상"},
+          {"skill": "TypeScript", "category": "우대", "level": null, "source_quote": "TypeScript 경험자"},
+          {"skill": "AWS", "category": "우대", "level": null, "source_quote": "AWS 클라우드 경험"}
         ],
         "responsibilities": [
-          {{"description": "AI 서비스 백엔드 개발", "source_quote": "AI 서비스 백엔드 개발"}},
-          {{"description": "프롬프트 엔지니어링 및 최적화", "source_quote": "프롬프트 엔지니어링 및 최적화"}}
+          {"description": "AI 서비스 백엔드 개발", "source_quote": "AI 서비스 백엔드 개발"},
+          {"description": "프롬프트 엔지니어링 및 최적화", "source_quote": "프롬프트 엔지니어링 및 최적화"}
         ],
         "company_culture": [],
         "tech_stack": [
-          {{"technology": "Python", "category": "language", "required": true}},
-          {{"technology": "FastAPI", "category": "framework", "required": true}},
-          {{"technology": "PostgreSQL", "category": "database", "required": true}},
-          {{"technology": "Redis", "category": "database", "required": true}},
-          {{"technology": "AWS", "category": "cloud", "required": false}}
+          {"technology": "Python", "category": "language", "required": true},
+          {"technology": "FastAPI", "category": "framework", "required": true},
+          {"technology": "PostgreSQL", "category": "database", "required": true},
+          {"technology": "Redis", "category": "database", "required": true},
+          {"technology": "AWS", "category": "cloud", "required": false}
         ],
         "benefits": [],
-        "extraction_confidence": {{"overall_score": 0.95, "ambiguous_requirements": [], "inferred_items": ["experience_level inferred from '3년 이상'"]}}
-      }}
+        "extraction_confidence": {"overall_score": 0.95, "ambiguous_requirements": [], "inferred_items": ["experience_level inferred from '3년 이상'"]}
+      }
       ```
 
       # UNSUCCESSFUL EXAMPLE (HALLUCINATION - DO NOT DO THIS)
@@ -123,13 +123,13 @@ prompts:
 
       BAD Output:
       ```json
-      {{
+      {
         "requirements": [
-          {{"skill": "Python", "category": "필수", "level": "5년 이상"}},
-          {{"skill": "Java", "category": "필수", "level": "3년 이상"}},
-          {{"skill": "Spring Boot", "category": "필수", "level": null}}
+          {"skill": "Python", "category": "필수", "level": "5년 이상"},
+          {"skill": "Java", "category": "필수", "level": "3년 이상"},
+          {"skill": "Spring Boot", "category": "필수", "level": null}
         ]
-      }}
+      }
       ```
       WHY BAD:
       1. Python was "우대" not "필수" in the JD
@@ -138,14 +138,14 @@ prompts:
 
       CORRECT Output:
       ```json
-      {{
+      {
         "job_title": "백엔드 개발자",
         "company_name": null,
         "requirements": [
-          {{"skill": "Python", "category": "우대", "level": null, "source_quote": "Python 경험자 우대"}}
+          {"skill": "Python", "category": "우대", "level": null, "source_quote": "Python 경험자 우대"}
         ],
-        "extraction_confidence": {{"overall_score": 0.4, "ambiguous_requirements": [], "inferred_items": []}}
-      }}
+        "extraction_confidence": {"overall_score": 0.4, "ambiguous_requirements": [], "inferred_items": []}
+      }
       ```
 
       # LIMITATIONS

--- a/backend/app/prompts/quality_review.yaml
+++ b/backend/app/prompts/quality_review.yaml
@@ -34,23 +34,23 @@ prompts:
       **RULE: If Evidence Score < 70%, flag for revision**
 
       # INTERVIEW QUESTIONS TO REVIEW
-      {questions}
+      {{questions}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
+      {
         "overall_quality_score": 0-10,
         "total_questions": number,
         "questions_flagged": number,
         "duplicates": [
-          {{
+          {
             "indices": [index1, index2],
             "similarity_reason": "why these are duplicates",
             "recommendation": "keep|merge|remove"
-          }}
+          }
         ],
         "question_reviews": [
-          {{
+          {
             "question_index": 0,
             "question_preview": "first 50 chars of question...",
             "relevance_score": 0-10,
@@ -63,40 +63,40 @@ prompts:
             "issues": ["list of specific issues"],
             "improvements": ["suggested improvements"],
             "verdict": "pass|revise|reject"
-          }}
+          }
         ],
-        "category_distribution": {{
-          "role_fit": {{"count": n, "quality_avg": x}},
-          "technical_depth": {{"count": n, "quality_avg": x}},
-          "execution_ownership": {{"count": n, "quality_avg": x}},
-          "communication": {{"count": n, "quality_avg": x}},
-          "risk_flags": {{"count": n, "quality_avg": x}}
-        }},
-        "difficulty_distribution": {{
+        "category_distribution": {
+          "role_fit": {"count": n, "quality_avg": x},
+          "technical_depth": {"count": n, "quality_avg": x},
+          "execution_ownership": {"count": n, "quality_avg": x},
+          "communication": {"count": n, "quality_avg": x},
+          "risk_flags": {"count": n, "quality_avg": x}
+        },
+        "difficulty_distribution": {
           "Easy": n,
           "Medium": n,
           "Hard": n
-        }},
+        },
         "overall_verdict": "APPROVED|NEEDS_REVISION",
         "summary": "overall assessment paragraph"
-      }}
+      }
       ```
 
       # SUCCESSFUL REVIEW EXAMPLE
       Input Question:
       ```json
-      {{
+      {
         "question_text": "이력서에 FastAPI 프로젝트에서 일일 100만 요청을 처리했다고 하셨는데, 이 성능을 달성하기 위해 어떤 최적화 기법을 적용하셨나요?",
         "category": "technical_depth",
         "difficulty": "Hard",
         "source": "resume",
         "evidence_summary": "Resume states: '일일 100만 요청 처리 시스템 구축'"
-      }}
+      }
       ```
 
       Good Review:
       ```json
-      {{
+      {
         "question_index": 0,
         "relevance_score": 10,
         "clarity_score": 9,
@@ -108,35 +108,35 @@ prompts:
         "issues": [],
         "improvements": ["Could specify which optimization types to discuss"],
         "verdict": "pass"
-      }}
+      }
       ```
 
       # UNSUCCESSFUL REVIEW EXAMPLE (Missed Hallucination)
       Input Question:
       ```json
-      {{
+      {
         "question_text": "Kubernetes 클러스터에서 HPA를 어떻게 설정하셨나요?",
         "category": "technical_depth",
         "difficulty": "Hard",
         "source": "inferred",
         "evidence_summary": "Resume mentions Docker experience"
-      }}
+      }
       ```
 
       BAD Review (missed the hallucination):
       ```json
-      {{
+      {
         "evidence_score": 80,
         "hallucination_risk": "low",
         "verdict": "pass"
-      }}
+      }
       ```
 
       WHY BAD: Resume only mentions Docker, NOT Kubernetes or HPA. This is hallucination.
 
       CORRECT Review:
       ```json
-      {{
+      {
         "question_index": 1,
         "relevance_score": 3,
         "clarity_score": 8,
@@ -148,7 +148,7 @@ prompts:
         "issues": ["Question assumes Kubernetes experience not documented", "HPA knowledge cannot be verified"],
         "improvements": ["Replace with Docker-specific question based on actual evidence"],
         "verdict": "reject"
-      }}
+      }
       ```
 
       # EVALUATION CRITERIA FOR VERDICT
@@ -177,7 +177,7 @@ prompts:
       You are a semantic similarity analyzer. Identify duplicate or semantically similar interview questions.
 
       # QUESTIONS TO ANALYZE
-      {questions}
+      {{questions}}
 
       # DUPLICATE CRITERIA
       - **Exact duplicate**: Same question, different wording
@@ -186,19 +186,19 @@ prompts:
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
+      {
         "duplicates": [
-          {{
+          {
             "indices": [i, j],
             "type": "exact|semantic|partial",
             "similarity_score": 0.0-1.0,
             "reason": "explanation of similarity",
             "recommendation": "remove_first|remove_second|merge|keep_both"
-          }}
+          }
         ],
         "unique_questions": number,
         "duplicate_groups": number
-      }}
+      }
       ```
 
       Return ONLY the JSON object, no additional text.

--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -3,8 +3,8 @@ prompts:
     description: "면접 질문 토픽 25개 선정 - 다중 소스 기반 (Few-shot Enhanced)"
     template: |
       # ROLE & GOAL
-      You are an expert interview strategist. Your task is to select {max_questions} interview topics
-      for a {experience_level} level candidate based on multiple analyzed sources.
+      You are an expert interview strategist. Your task is to select {{max_questions}} interview topics
+      for a {{experience_level}} level candidate based on multiple analyzed sources.
 
       # WHAT YOU WILL SEE
       You will receive pre-analyzed data from multiple sources:
@@ -37,7 +37,7 @@ prompts:
       Every topic MUST have clear source attribution with evidence_summary
 
       # AVAILABLE TOPIC CANDIDATES
-      {candidates}
+      {{candidates}}
 
       # CATEGORY REQUIREMENTS
       Distribute exactly 5 topics per category:
@@ -55,20 +55,20 @@ prompts:
       # OUTPUT FORMAT (JSON)
       ```json
       [
-        {{
+        {
           "category": "role_fit|technical_depth|execution_ownership|communication|risk_flags",
           "topic": "Specific topic title",
           "difficulty": "Easy|Medium|Hard",
           "source": "github|resume|linkedin|multi-source",
-          "source_details": {{
+          "source_details": {
             "github": "specific evidence from GitHub analysis or null",
             "resume": "specific evidence from resume or null",
             "linkedin": "specific evidence from LinkedIn or null"
-          }},
+          },
           "evidence_summary": "Concise evidence supporting this topic",
           "confidence_score": 0.0-1.0,
           "question_angle": "Suggested approach for the question"
-        }}
+        }
       ]
       ```
 
@@ -80,20 +80,20 @@ prompts:
 
       Good Topic Selection:
       ```json
-      {{
+      {
         "category": "technical_depth",
         "topic": "FastAPI 비동기 처리 및 성능 최적화",
         "difficulty": "Hard",
         "source": "multi-source",
-        "source_details": {{
+        "source_details": {
           "github": "FastAPI project with async patterns in 50+ commits",
           "resume": "일일 100만 요청 처리 시스템 구축",
           "linkedin": null
-        }},
+        },
         "evidence_summary": "Both GitHub commits AND resume confirm FastAPI expertise with performance optimization experience",
         "confidence_score": 0.95,
         "question_angle": "Ask about specific async patterns used to achieve 100M request handling"
-      }}
+      }
       ```
 
       # UNSUCCESSFUL EXAMPLE (Hallucinated Topic - DO NOT DO THIS)
@@ -104,32 +104,32 @@ prompts:
 
       BAD Topic Selection:
       ```json
-      {{
+      {
         "category": "technical_depth",
         "topic": "Kubernetes 클러스터 오케스트레이션 경험",
         "difficulty": "Hard",
         "source": "inferred",
         "evidence_summary": "Likely uses Kubernetes for deployment"
-      }}
+      }
       ```
       WHY BAD: Kubernetes was NEVER mentioned in any source. This is hallucination.
 
       CORRECT Topic Selection:
       ```json
-      {{
+      {
         "category": "technical_depth",
         "topic": "Python 데이터 분석 프로젝트 경험",
         "difficulty": "Medium",
         "source": "multi-source",
-        "source_details": {{
+        "source_details": {
           "github": "Python scripts for data analysis",
           "resume": "Python 개발자",
           "linkedin": "Data Analyst"
-        }},
+        },
         "evidence_summary": "All sources confirm Python data analysis focus",
         "confidence_score": 0.85,
         "question_angle": "Explore specific data analysis workflows and tools used"
-      }}
+      }
       ```
 
       # LIMITATIONS
@@ -151,17 +151,17 @@ prompts:
     template: |
       # ROLE & GOAL
       You are an expert interview question crafter. Generate a detailed interview question
-      in {output_language} that is GROUNDED in documented evidence.
+      in {{output_language}} that is GROUNDED in documented evidence.
 
       # WHAT YOU WILL SEE
       - Topic with source attribution
       - Category and difficulty level
-      - Candidate experience level: {experience_level}
+      - Candidate experience level: {{experience_level}}
 
       # TOPIC DETAILS
-      Topic: {topic}
-      Category: {category}
-      Difficulty: {difficulty}
+      Topic: {{topic}}
+      Category: {{category}}
+      Difficulty: {{difficulty}}
 
       # DETAILED GOAL
       Create a question that:
@@ -172,51 +172,51 @@ prompts:
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
-        "question_text": "Main question in {output_language}",
+      {
+        "question_text": "Main question in {{output_language}}",
         "question_rationale": "Why this question based on evidence",
         "evidence_reference": "Specific evidence this question is based on",
         "alternative_phrasings": [
           "Alternative way to ask 1",
           "Alternative way to ask 2"
         ],
-        "expected_answer": {{
-          "expert": {{
+        "expected_answer": {
+          "expert": {
             "description": "What an expert-level answer looks like",
             "key_indicators": ["specific technical terms", "depth of understanding"],
             "example_response": "Brief example of expert answer"
-          }},
-          "mid_level": {{
+          },
+          "mid_level": {
             "description": "What an adequate answer looks like",
             "key_indicators": ["basic understanding", "practical experience"],
             "example_response": "Brief example of mid-level answer"
-          }},
-          "low_level": {{
+          },
+          "low_level": {
             "description": "What an insufficient answer looks like",
             "key_indicators": ["vague responses", "lack of specifics"],
             "example_response": "Brief example of weak answer"
-          }}
-        }},
+          }
+        },
         "follow_up_questions": [
-          {{
+          {
             "trigger": "expert|mid|low",
             "question": "Follow-up question text",
             "purpose": "What this follow-up aims to uncover"
-          }}
+          }
         ],
-        "evaluation_criteria": {{
+        "evaluation_criteria": {
           "technical_accuracy": "How to assess technical correctness",
           "depth_of_experience": "How to assess real-world experience",
           "communication_clarity": "How to assess explanation ability"
-        }},
-        "interviewer_note": {{
+        },
+        "interviewer_note": {
           "what_to_listen_for": "Key phrases or concepts",
           "red_flags": ["Warning signs in answer"],
           "green_flags": ["Positive indicators in answer"],
           "time_allocation_minutes": 5
-        }},
+        },
         "confidence_score": 0.0-1.0
-      }}
+      }
       ```
 
       # SUCCESSFUL EXAMPLE
@@ -226,7 +226,7 @@ prompts:
 
       Good Question:
       ```json
-      {{
+      {
         "question_text": "이력서에 FastAPI 기반 API 개발 경험이 있으시다고 하셨는데, 비동기 처리가 필요한 상황에서 어떻게 구현하셨나요?",
         "question_rationale": "Resume explicitly mentions FastAPI; probing async understanding is appropriate for Mid level",
         "evidence_reference": "Resume: 'FastAPI 기반 API 개발'",
@@ -234,42 +234,42 @@ prompts:
           "FastAPI에서 async/await를 사용한 구체적인 사례를 설명해주세요",
           "FastAPI 프로젝트에서 동시성 처리를 어떻게 다루셨나요?"
         ],
-        "expected_answer": {{
-          "expert": {{
+        "expected_answer": {
+          "expert": {
             "description": "async/await 패턴, 이벤트 루프, 동시성 제어 설명",
             "key_indicators": ["asyncio", "await", "concurrent.futures", "background tasks"],
             "example_response": "저는 외부 API 호출이 많은 서비스에서 httpx의 AsyncClient를 사용해..."
-          }},
-          "mid_level": {{
+          },
+          "mid_level": {
             "description": "기본적인 async 함수 사용 경험",
             "key_indicators": ["async def", "await", "비동기 함수"],
             "example_response": "async def로 함수를 정의하고 await로 호출했습니다"
-          }},
-          "low_level": {{
+          },
+          "low_level": {
             "description": "비동기 개념 이해 부족",
             "key_indicators": ["잘 모르겠다", "동기적으로 처리"],
             "example_response": "그냥 함수로 작성했는데 특별히 비동기는..."
-          }}
-        }},
+          }
+        },
         "follow_up_questions": [
-          {{
+          {
             "trigger": "expert",
             "question": "동시에 여러 외부 API를 호출할 때 에러 처리는 어떻게 하셨나요?",
             "purpose": "Advanced error handling in async contexts"
-          }},
-          {{
+          },
+          {
             "trigger": "mid",
             "question": "비동기 처리의 장점이 무엇이라고 생각하시나요?",
             "purpose": "Verify conceptual understanding"
-          }},
-          {{
+          },
+          {
             "trigger": "low",
             "question": "동기와 비동기의 차이점을 설명해주실 수 있나요?",
             "purpose": "Assess baseline knowledge"
-          }}
+          }
         ],
         "confidence_score": 0.9
-      }}
+      }
       ```
 
       # UNSUCCESSFUL EXAMPLE (Hallucinated Question - DO NOT DO THIS)
@@ -279,21 +279,21 @@ prompts:
 
       BAD Question:
       ```json
-      {{
+      {
         "question_text": "Django ORM에서 N+1 쿼리 문제를 어떻게 해결하셨나요?",
         "evidence_reference": "Inferred from Python experience"
-      }}
+      }
       ```
       WHY BAD: Resume says "Python 개발자" but NEVER mentions Django. This assumes Django knowledge.
 
       CORRECT Question:
       ```json
-      {{
+      {
         "question_text": "Python 개발자로서 가장 복잡한 문제를 해결한 경험을 설명해주세요",
         "question_rationale": "Resume only mentions 'Python 개발자' without specifics; open-ended question appropriate",
         "evidence_reference": "Resume: 'Python 개발자'",
         "confidence_score": 0.6
-      }}
+      }
       ```
 
       # LIMITATIONS
@@ -320,32 +320,32 @@ prompts:
       Interview questions containing technical terminology that HR managers or hiring managers may not understand.
 
       # QUESTIONS TO ENHANCE
-      Language: {output_language}
-      {questions_json}
+      Language: {{output_language}}
+      {{questions_json}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
+      {
         "question_id": [
-          {{
+          {
             "term": "Technical term",
             "plain_language_explanation": "Everyday analogy or simple description",
             "business_relevance": "Why this matters for business outcomes",
             "pronunciation_guide": "How to say it (if non-obvious)"
-          }}
+          }
         ]
-      }}
+      }
       ```
 
       # EXAMPLE
       Term: "마이크로서비스 아키텍처"
       ```json
-      {{
+      {
         "term": "마이크로서비스 아키텍처",
         "plain_language_explanation": "레고 블록처럼 작은 서비스들을 조립해서 큰 시스템을 만드는 방식. 하나가 고장나도 전체가 멈추지 않음",
         "business_relevance": "시스템 일부만 업데이트할 수 있어 배포 속도가 빠르고, 장애 영향 범위가 작아 서비스 안정성이 높음",
         "pronunciation_guide": "마이크로-서비스 아키텍처"
-      }}
+      }
       ```
 
       Return ONLY the JSON object, no additional text.
@@ -357,35 +357,35 @@ prompts:
       You create detailed evaluation scenarios for interviewers to assess candidate responses.
 
       # QUESTIONS TO CREATE SCENARIOS FOR
-      Language: {output_language}
-      Experience Level: {experience_level}
-      {questions_json}
+      Language: {{output_language}}
+      Experience Level: {{experience_level}}
+      {{questions_json}}
 
       # OUTPUT FORMAT (JSON)
       For each question, create scenarios at three levels:
       ```json
-      {{
-        "question_id": {{
-          "expert": {{
+      {
+        "question_id": {
+          "expert": {
             "description": "What expert-level response looks like",
             "trigger_keywords": ["specific terms that indicate expertise"],
             "behavioral_indicators": ["what candidate does/says"],
             "follow_up_direction": "Where to probe deeper"
-          }},
-          "mid_level": {{
+          },
+          "mid_level": {
             "description": "What adequate response looks like",
             "trigger_keywords": ["basic understanding indicators"],
             "behavioral_indicators": ["typical mid-level responses"],
             "coaching_tip": "How to help them elaborate"
-          }},
-          "low_level": {{
+          },
+          "low_level": {
             "description": "What insufficient response looks like",
             "trigger_keywords": ["red flag phrases"],
             "behavioral_indicators": ["concerning responses"],
             "recovery_question": "Question to give them another chance"
-          }}
-        }}
-      }}
+          }
+        }
+      }
       ```
 
       Return ONLY the JSON object, no additional text.
@@ -397,22 +397,22 @@ prompts:
       Design follow-up question branches based on candidate response quality.
 
       # QUESTIONS TO DESIGN FOLLOW-UPS FOR
-      Language: {output_language}
-      Experience Level: {experience_level}
-      {questions_json}
+      Language: {{output_language}}
+      Experience Level: {{experience_level}}
+      {{questions_json}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
+      {
         "question_id": [
-          {{
+          {
             "trigger": "expert|mid|low",
             "question_text": "Follow-up question",
             "purpose": "What this reveals about candidate",
             "expected_insight": "What good answer would show"
-          }}
+          }
         ]
-      }}
+      }
       ```
 
       Return ONLY the JSON object, no additional text.
@@ -424,13 +424,13 @@ prompts:
       Generate guidance notes for non-technical interviewers conducting technical interviews.
 
       # QUESTIONS TO GENERATE NOTES FOR
-      Language: {output_language}
-      {questions_json}
+      Language: {{output_language}}
+      {{questions_json}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
-        "question_id": {{
+      {
+        "question_id": {
           "business_interpretation": "What this question reveals in business terms",
           "daily_analogy": "Everyday situation that parallels this technical concept",
           "what_to_listen_for": "Key phrases or concepts that indicate competence",
@@ -438,8 +438,8 @@ prompts:
           "green_flags": ["Positive indicators in candidate's answer"],
           "time_guidance": "How long to spend, when to move on",
           "note_to_self": "Quick reminder for interviewer"
-        }}
-      }}
+        }
+      }
       ```
 
       Return ONLY the JSON object, no additional text.
@@ -451,40 +451,40 @@ prompts:
       Generate a decision guide for the hiring committee based on interview results.
 
       # CONTEXT
-      Language: {output_language}
-      Experience Level: {experience_level}
-      Analysis Summary: {analysis_summary}
-      Category Summary: {category_summary}
+      Language: {{output_language}}
+      Experience Level: {{experience_level}}
+      Analysis Summary: {{analysis_summary}}
+      Category Summary: {{category_summary}}
 
       # OUTPUT FORMAT (JSON)
       ```json
-      {{
-        "scoring_weights": {{
+      {
+        "scoring_weights": {
           "role_fit": 0.20,
           "technical_depth": 0.30,
           "execution_ownership": 0.25,
           "communication": 0.15,
           "risk_flags": 0.10
-        }},
-        "decision_thresholds": {{
-          "strong_hire": {{"score": 85, "description": "Exceeds expectations in most areas"}},
-          "hire": {{"score": 65, "description": "Meets expectations with growth potential"}},
-          "maybe": {{"score": 50, "description": "Mixed signals, needs additional evaluation"}},
-          "no_hire": {{"score": 35, "description": "Below expectations in critical areas"}}
-        }},
-        "category_insights": {{
+        },
+        "decision_thresholds": {
+          "strong_hire": {"score": 85, "description": "Exceeds expectations in most areas"},
+          "hire": {"score": 65, "description": "Meets expectations with growth potential"},
+          "maybe": {"score": 50, "description": "Mixed signals, needs additional evaluation"},
+          "no_hire": {"score": 35, "description": "Below expectations in critical areas"}
+        },
+        "category_insights": {
           "role_fit": "Key evaluation focus for this category",
           "technical_depth": "Key evaluation focus for this category",
           "execution_ownership": "Key evaluation focus for this category",
           "communication": "Key evaluation focus for this category",
           "risk_flags": "Key evaluation focus for this category"
-        }},
-        "risk_assessment": {{
+        },
+        "risk_assessment": {
           "identified_risks": ["Risk 1", "Risk 2"],
           "mitigation_questions": ["Question to address Risk 1", "Question to address Risk 2"]
-        }},
-        "experience_level_calibration": "Guidance on adjusting expectations for {experience_level}"
-      }}
+        },
+        "experience_level_calibration": "Guidance on adjusting expectations for {{experience_level}}"
+      }
       ```
 
       Return ONLY the JSON object, no additional text.
@@ -501,11 +501,11 @@ prompts:
       - Evidence scores and hallucination risks
 
       # QUESTIONS TO REVISE
-      Language: {output_language}
-      {questions_json}
+      Language: {{output_language}}
+      {{questions_json}}
 
       # REVIEW FEEDBACK
-      {review_feedback}
+      {{review_feedback}}
 
       # REVISION RULES
       1. **Hallucination detected**: Replace with question based on documented evidence only
@@ -518,7 +518,7 @@ prompts:
       Return revised questions as array:
       ```json
       [
-        {{
+        {
           "original_index": 0,
           "revision_type": "hallucination_fix|evidence_improvement|clarity_fix|bias_removal|duplicate_merge",
           "original_question": "Original question text",
@@ -526,20 +526,20 @@ prompts:
           "revision_rationale": "Why this change was made",
           "new_evidence_reference": "Updated evidence this is based on",
           "new_confidence_score": 0.0-1.0
-        }}
+        }
       ]
       ```
 
       # EXAMPLE REVISION
       Original (hallucinated):
       ```json
-      {{"question_text": "Kubernetes에서 HPA 설정 경험을 말씀해주세요"}}
+      {"question_text": "Kubernetes에서 HPA 설정 경험을 말씀해주세요"}
       ```
       Review feedback: "HALLUCINATION: No Kubernetes evidence. Only Docker mentioned."
 
       Revised:
       ```json
-      {{
+      {
         "original_index": 3,
         "revision_type": "hallucination_fix",
         "original_question": "Kubernetes에서 HPA 설정 경험을 말씀해주세요",
@@ -547,7 +547,7 @@ prompts:
         "revision_rationale": "Changed from assumed Kubernetes to documented Docker experience",
         "new_evidence_reference": "Resume: 'Docker 기반 배포 경험'",
         "new_confidence_score": 0.85
-      }}
+      }
       ```
 
       Return ONLY the JSON array, no additional text.

--- a/backend/scripts/upload_prompts_to_langfuse.py
+++ b/backend/scripts/upload_prompts_to_langfuse.py
@@ -18,6 +18,7 @@ scripts/upload_prompts_to_langfuse.py
 """
 import argparse
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -25,6 +26,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import yaml
+
+
+# Note: YAML 템플릿이 이제 Mustache 문법 ({{variable}})을 직접 사용하므로
+# 별도의 변환이 필요 없습니다. Langfuse와 YAML fallback 모두 동일한 문법 사용.
 
 
 # Activity별 최적 모델 설정 (llm_config.py와 동기화)
@@ -105,6 +110,7 @@ def load_yaml_prompts(prompts_dir: Path, filename: str | None = None) -> dict:
                 "temperature": 0.5,
             })
 
+            # YAML 템플릿이 이미 Mustache 문법 사용 - 변환 불필요
             prompts[langfuse_name] = {
                 "name": langfuse_name,
                 "template": prompt_data["template"],
@@ -135,6 +141,11 @@ def upload_to_langfuse(
             print(f"  Model: {data['config'].get('model')}")
             print(f"  Temperature: {data['config'].get('temperature')}")
             print(f"  Template length: {len(data['template'])} chars")
+
+            # Show detected Langfuse variables
+            variables = re.findall(r'\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}', data['template'])
+            if variables:
+                print(f"  Variables: {', '.join(sorted(set(variables)))}")
             print()
         return
 

--- a/backend/tests/test_prompts.py
+++ b/backend/tests/test_prompts.py
@@ -60,9 +60,11 @@ class TestPromptLoader:
         with pytest.raises(FileNotFoundError):
             get_prompt("nonexistent.yaml", "key")
 
-    def test_missing_variable_raises(self):
-        with pytest.raises(KeyError):
-            get_prompt("jd_analysis.yaml", "analyze")  # missing jd_text
+    def test_missing_variable_keeps_placeholder(self):
+        """Mustache 스타일: 누락된 변수는 플레이스홀더 유지 (에러 아님)."""
+        result = get_prompt("jd_analysis.yaml", "analyze")  # missing jd_text
+        # 누락된 변수 {{jd_text}}가 그대로 남아있어야 함
+        assert "{{jd_text}}" in result
 
 
 class TestYamlStructure:


### PR DESCRIPTION
## 요약
- YAML 프롬프트 템플릿을 Python `{variable}` 문법에서 Mustache `{{variable}}` 문법으로 변환
- Langfuse와 YAML fallback 모두 동일한 문법 사용으로 일관성 확보
- 프롬프트 변수(output_language, experience_level 등)가 실제 값으로 치환되지 않던 문제 해결

## 변경 내용
- **backend/app/prompts/__init__.py**: `mustache_format()` 함수 추가, 모든 `.format()` 호출을 Mustache 치환으로 교체
- **backend/app/prompts/*.yaml** (5개 파일): 모든 `{variable}` → `{{variable}}` 변환
- **backend/scripts/upload_prompts_to_langfuse.py**: 불필요한 변환 로직 제거 (YAML이 이미 Mustache 문법)
- **backend/tests/test_prompts.py**: 누락된 변수가 KeyError 대신 플레이스홀더 유지 확인 테스트

## 테스트
```bash
docker compose exec backend pytest tests/test_prompts.py -v  # 모든 테스트 통과
```

## 관련 이슈
- Langfuse 프롬프트 변수가 `{{output_language}}` 그대로 출력되던 문제 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)