### PR TITLE
fix: Docker Compose 환경변수 파일 참조 추가

### DIFF
--- a/docker-compose.tunnel.yml
+++ b/docker-compose.tunnel.yml
@@ -27,6 +27,8 @@ services:
     container_name: cloudflared
     restart: unless-stopped
     command: tunnel --no-autoupdate run
+    env_file:
+      - .env
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       target: development
     ports:
       - "8000:8000"
+    env_file:
+      - .env
     environment:
       - ENV=local
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/vantict
@@ -53,6 +55,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       target: development
+    env_file:
+      - .env
     environment:
       - ENV=local
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/vantict


### PR DESCRIPTION
## 문제
- Docker Compose 실행 시 환경변수가 설정되지 않았다는 경고 메시지 발생
- `OPENAI_API_KEY`, `GOOGLE_CLIENT_ID` 등 필수 환경변수가 컨테이너에 전달되지 않음

## 해결
- `backend`, `worker`, `cloudflared` 서비스에 `env_file: .env` 추가
- 루트 디렉토리의 `.env` 파일에서 환경변수 자동 로드

## 변경 내용
- `docker-compose.yml`: backend, worker 서비스에 env_file 추가
- `docker-compose.tunnel.yml`: cloudflared 서비스에 env_file 추가

## 테스트
- [x] 컨테이너 재시작 후 환경변수 정상 로드 확인
- [x] Google OAuth 로그인 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)