### PR TITLE
feat: Frontend UI/UX 전면 개선 및 폼 필드 간소화

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route element={<Layout user={user} onLogout={logout} />}>
-          <Route path="/login" element={<LoginPage />} />
+          <Route path="/login" element={isAuthenticated ? <Navigate to="/jobs" /> : <LoginPage />} />
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
           <Route
             path="/jobs"

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 interface NavbarProps {
@@ -8,34 +8,127 @@ interface NavbarProps {
 
 export function Navbar({ user, onLogout }: NavbarProps) {
   const { t, i18n } = useTranslation()
+  const location = useLocation()
 
   const toggleLang = () => {
     i18n.changeLanguage(i18n.language === 'ko' ? 'en' : 'ko')
   }
 
+  const isActive = (path: string) => {
+    if (path === '/jobs') {
+      return location.pathname === '/jobs' || location.pathname.startsWith('/jobs/')
+    }
+    return location.pathname === path
+  }
+
   return (
-    <nav className="bg-gray-900 text-white px-6 py-3 flex items-center justify-between" aria-label={t('nav_label')}>
-      <Link to="/" className="text-xl font-bold">{t('app_title')}</Link>
-      <div className="flex items-center gap-4">
-        <button
-          onClick={toggleLang}
-          className="text-sm px-2 py-1 border border-gray-600 rounded"
-          aria-label={t('switch_language')}
-        >
-          {i18n.language === 'ko' ? 'EN' : 'KO'}
-        </button>
-        {user ? (
-          <>
-            <Link to="/jobs" className="hover:text-gray-300">{t('jobs')}</Link>
-            <Link to="/jobs/new" className="hover:text-gray-300">{t('create_job')}</Link>
-            <span className="text-sm text-gray-400" aria-label={t('logged_in_as')}>{user.display_name}</span>
-            <button onClick={onLogout} className="text-sm text-red-400 hover:text-red-300">
-              {t('logout')}
+    <nav
+      className="sticky top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur-lg"
+      aria-label={t('nav_label')}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          {/* Logo */}
+          <Link to="/" className="flex items-center gap-2.5 group">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 shadow-md transition-transform group-hover:scale-105">
+              <svg className="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+              </svg>
+            </div>
+            <span className="text-lg font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
+              {t('app_title')}
+            </span>
+          </Link>
+
+          {/* Navigation Links & Actions */}
+          <div className="flex items-center gap-1 sm:gap-2">
+            {/* Language Toggle */}
+            <button
+              onClick={toggleLang}
+              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900"
+              aria-label={t('switch_language')}
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+              </svg>
+              <span className="hidden sm:inline">{i18n.language === 'ko' ? 'EN' : '한국어'}</span>
+              <span className="sm:hidden">{i18n.language === 'ko' ? 'EN' : 'KO'}</span>
             </button>
-          </>
-        ) : (
-          <Link to="/login" className="hover:text-gray-300">{t('login')}</Link>
-        )}
+
+            {user ? (
+              <>
+                {/* My Scripts Link */}
+                <Link
+                  to="/jobs"
+                  className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                    isActive('/jobs')
+                      ? 'bg-indigo-50 text-indigo-700'
+                      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                  }`}
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  <span className="hidden sm:inline">{t('jobs')}</span>
+                </Link>
+
+                {/* New Script Button */}
+                <Link
+                  to="/jobs/new"
+                  className="flex items-center gap-1.5 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-md"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                  </svg>
+                  <span className="hidden sm:inline">{t('create_job')}</span>
+                </Link>
+
+                {/* User Menu */}
+                <div className="ml-2 flex items-center gap-2 border-l border-gray-200 pl-3">
+                  <div className="flex items-center gap-2">
+                    {user.avatar_url ? (
+                      <img
+                        src={user.avatar_url}
+                        alt={user.display_name || 'User'}
+                        className="h-8 w-8 rounded-full ring-2 ring-gray-100"
+                      />
+                    ) : (
+                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-indigo-400 to-purple-500 text-sm font-medium text-white">
+                        {(user.display_name || 'U').charAt(0).toUpperCase()}
+                      </div>
+                    )}
+                    <span
+                      className="hidden text-sm font-medium text-gray-700 md:inline"
+                      aria-label={t('logged_in_as')}
+                    >
+                      {user.display_name || 'User'}
+                    </span>
+                  </div>
+                  <button
+                    onClick={onLogout}
+                    className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm font-medium text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600"
+                    title={t('logout')}
+                  >
+                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                    </svg>
+                    <span className="hidden sm:inline">{t('logout')}</span>
+                  </button>
+                </div>
+              </>
+            ) : (
+              <Link
+                to="/login"
+                className="flex items-center gap-1.5 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-md"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
+                </svg>
+                {t('login')}
+              </Link>
+            )}
+          </div>
+        </div>
       </div>
     </nav>
   )

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -7,16 +7,25 @@ const resources = {
       app_title: 'Vantict Sniper',
       login: '로그인',
       logout: '로그아웃',
-      jobs: 'Job 목록',
-      create_job: 'Job 생성',
+      // Navigation - "Job" → "면접 스크립트" 변경
+      jobs: '내 면접 스크립트',
+      create_job: '새 스크립트 생성',
       status: '상태',
       loading: '로딩 중...',
-      login_with_google: 'Google로 로그인',
-      login_with_github: 'GitHub으로 로그인',
+      // Login page
+      login_with_google: 'Google 계정으로 로그인',
+      login_with_github: 'GitHub 계정으로 로그인',
+      login_subtitle: 'AI 기반 기술면접 스크립트 생성 서비스',
+      login_secure_note: '안전하게 로그인됩니다',
+      login_feature_1: 'GitHub 코드 분석으로 맞춤형 질문 생성',
+      login_feature_2: 'LinkedIn 프로필 기반 경력 분석',
+      login_feature_3: '25개 구조화된 면접 질문과 평가 가이드',
+      login_terms: '로그인 시 서비스 이용약관에 동의하게 됩니다.',
+      // Job description
       jd_placeholder: '채용공고(JD)를 입력하세요...',
       submit: '제출',
-      no_jobs: 'Job이 없습니다.',
-      // Job list
+      // Job list - "Job" → "면접 스크립트" 변경
+      no_jobs: '생성된 면접 스크립트가 없습니다.',
       delete: '삭제',
       delete_confirm: '정말 삭제하시겠습니까?',
       prev: '이전',
@@ -65,7 +74,7 @@ const resources = {
       go_home: '홈으로 돌아가기',
       // Error states
       fetch_error: '데이터를 불러오는 데 실패했습니다.',
-      // Create job
+      // Create job - "Job" → "면접 스크립트" 변경
       jd_label: '채용공고 (JD)',
       experience_level: '경험 레벨',
       level_entry: '신입',
@@ -79,14 +88,11 @@ const resources = {
       candidate_info: '후보자 정보',
       linkedin_url: 'LinkedIn 프로필 URL',
       linkedin_hint: 'LinkedIn 프로필에서 경력, 스킬, GitHub URL을 자동 추출합니다',
-      github_repos: 'GitHub 레포지토리',
-      add_repo: '레포 추가',
+      git_url: 'Git URL',
+      git_url_hint: '후보자의 GitHub 프로필 또는 레포지토리 URL을 입력하세요 (레포는 자동 추출됩니다)',
       remove: '삭제',
-      github_repos_hint: '분석할 GitHub 레포지토리 URL을 입력하세요 (최대 5개)',
       options: '옵션',
       max_questions: '생성할 질문 수',
-      focus_areas: '집중 기술 영역',
-      focus_areas_hint: '쉼표로 구분하여 입력 (선택사항)',
       cancel: '취소',
       create_interview_script: '면접 스크립트 생성',
       // File upload
@@ -102,6 +108,11 @@ const resources = {
       nav_label: '메인 네비게이션',
       switch_language: '언어 전환',
       logged_in_as: '로그인 사용자',
+      // Job list page - 추가 번역
+      script_list_title: '내 면접 스크립트',
+      script_list_empty_title: '아직 생성된 스크립트가 없습니다',
+      script_list_empty_desc: '새 면접 스크립트를 생성하여 시작하세요',
+      new_script: '새 스크립트 생성',
     },
   },
   en: {
@@ -109,19 +120,30 @@ const resources = {
       app_title: 'Vantict Sniper',
       login: 'Login',
       logout: 'Logout',
-      jobs: 'Jobs',
-      create_job: 'Create Job',
+      // Navigation - "Jobs" → "Interview Scripts" change
+      jobs: 'My Scripts',
+      create_job: 'New Script',
       status: 'Status',
       loading: 'Loading...',
-      login_with_google: 'Login with Google',
-      login_with_github: 'Login with GitHub',
+      // Login page
+      login_with_google: 'Continue with Google',
+      login_with_github: 'Continue with GitHub',
+      login_subtitle: 'AI-Powered Technical Interview Script Generator',
+      login_secure_note: 'Secure authentication',
+      login_feature_1: 'Custom questions from GitHub code analysis',
+      login_feature_2: 'LinkedIn profile-based career analysis',
+      login_feature_3: '25 structured interview questions with evaluation guide',
+      login_terms: 'By signing in, you agree to our Terms of Service.',
+      // Job description
       jd_placeholder: 'Enter job description...',
       submit: 'Submit',
-      no_jobs: 'No jobs found.',
+      // Job list - "Jobs" → "Scripts" change
+      no_jobs: 'No interview scripts found.',
       delete: 'Delete',
       delete_confirm: 'Are you sure you want to delete?',
       prev: 'Prev',
       next: 'Next',
+      // Job status phases
       phase_pending: 'Pending',
       phase_enriching: 'Phase 0: Input Analysis',
       phase_planning: 'Phase 1: Planning',
@@ -135,6 +157,7 @@ const resources = {
       view_result: 'View Result',
       generation_failed: 'Generation failed',
       unknown_error: 'Unknown error',
+      // Result page
       interview_script: 'Interview Script',
       score_label: 'Score',
       candidate_summary: 'Candidate Summary',
@@ -142,23 +165,29 @@ const resources = {
       print_pdf: 'Print PDF',
       glossary: 'Glossary',
       result_error: 'Failed to load result.',
+      // Categories
       cat_all: 'All',
       cat_role_fit: 'Role Fit',
       cat_technical_depth: 'Technical Depth',
       cat_execution_ownership: 'Execution/Ownership',
       cat_communication: 'Communication',
       cat_risk_flags: 'Risk Flags',
+      // Question card
       expected_answer: 'Expected Answer',
       follow_up: 'Follow-up Questions',
       terminology: 'Terminology',
       interviewer_note: 'Interviewer Note',
       scoring: 'Score',
       minutes: 'min',
+      // Error boundary
       error_occurred: 'An error occurred',
       retry: 'Retry',
+      // 404
       page_not_found: 'Page not found.',
       go_home: 'Go Home',
+      // Error states
       fetch_error: 'Failed to load data.',
+      // Create job
       jd_label: 'Job Description (JD)',
       experience_level: 'Experience Level',
       level_entry: 'Entry',
@@ -172,14 +201,11 @@ const resources = {
       candidate_info: 'Candidate Info',
       linkedin_url: 'LinkedIn Profile URL',
       linkedin_hint: 'Auto-extracts career, skills, and GitHub URL from LinkedIn profile',
-      github_repos: 'GitHub Repositories',
-      add_repo: 'Add Repo',
+      git_url: 'Git URL',
+      git_url_hint: 'Enter the candidate\'s GitHub profile or repository URL (repos will be auto-extracted)',
       remove: 'Remove',
-      github_repos_hint: 'Enter GitHub repository URLs to analyze (max 5)',
       options: 'Options',
       max_questions: 'Number of Questions',
-      focus_areas: 'Focus Areas',
-      focus_areas_hint: 'Comma-separated (optional)',
       cancel: 'Cancel',
       create_interview_script: 'Generate Interview Script',
       // File upload
@@ -190,10 +216,16 @@ const resources = {
       cover_letter: 'Cover Letter',
       uploading: 'Uploading...',
       output_language: 'Output Language',
+      // Accessibility
       skip_to_content: 'Skip to content',
       nav_label: 'Main navigation',
       switch_language: 'Switch language',
       logged_in_as: 'Logged in as',
+      // Job list page - additional translations
+      script_list_title: 'My Interview Scripts',
+      script_list_empty_title: 'No scripts yet',
+      script_list_empty_desc: 'Create your first interview script to get started',
+      new_script: 'Create New Script',
     },
   },
 }

--- a/frontend/src/pages/CreateJobPage.tsx
+++ b/frontend/src/pages/CreateJobPage.tsx
@@ -29,6 +29,98 @@ interface FileUpload {
   error: string | null
 }
 
+// Section Card Component
+function SectionCard({
+  title,
+  description,
+  required,
+  children,
+}: {
+  title: string
+  description?: string
+  required?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">
+          {title}
+          {required && <span className="ml-1 text-red-500">*</span>}
+        </h2>
+        {description && <p className="mt-1 text-sm text-gray-500">{description}</p>}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+// File Upload Field Component
+function FileUploadField({
+  label,
+  accept,
+  fileState,
+  onFileChange,
+  onRemove,
+  t,
+}: {
+  label: string
+  accept: string
+  fileState: FileUpload
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onRemove: () => void
+  t: (key: string) => string
+}) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-sm font-medium text-gray-700">{label}</label>
+      {fileState.path ? (
+        <div className="flex items-center gap-3 rounded-lg border border-green-200 bg-green-50 p-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-100">
+            <svg className="h-5 w-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <span className="flex-1 truncate text-sm font-medium text-green-700">{fileState.file?.name}</span>
+          <button
+            type="button"
+            onClick={onRemove}
+            className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <label className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 p-4 transition-colors hover:border-indigo-400 hover:bg-indigo-50/50">
+          <svg className="mb-2 h-8 w-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+          </svg>
+          <span className="text-sm text-gray-600">{accept} 파일을 선택하세요</span>
+          <input
+            type="file"
+            accept={accept}
+            onChange={onFileChange}
+            disabled={fileState.uploading}
+            className="hidden"
+          />
+        </label>
+      )}
+      {fileState.uploading && (
+        <div className="mt-2 flex items-center gap-2 text-sm text-indigo-600">
+          <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          {t('uploading')}
+        </div>
+      )}
+      {fileState.error && <p className="mt-2 text-sm text-red-600">{fileState.error}</p>}
+    </div>
+  )
+}
+
 export function CreateJobPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -46,9 +138,8 @@ export function CreateJobPage() {
 
   // 선택 필드
   const [linkedinUrl, setLinkedinUrl] = useState('')
-  const [githubUrls, setGithubUrls] = useState<string[]>([''])
+  const [gitUrl, setGitUrl] = useState('')
   const [maxQuestions, setMaxQuestions] = useState(25)
-  const [focusAreas, setFocusAreas] = useState('')
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -105,23 +196,6 @@ export function CreateJobPage() {
     setFileState({ file: null, path: null, uploading: false, error: null })
   }
 
-  // GitHub URL 핸들러
-  const addGithubUrl = () => {
-    if (githubUrls.length < 5) {
-      setGithubUrls([...githubUrls, ''])
-    }
-  }
-
-  const removeGithubUrl = (index: number) => {
-    setGithubUrls(githubUrls.filter((_, i) => i !== index))
-  }
-
-  const updateGithubUrl = (index: number, value: string) => {
-    const updated = [...githubUrls]
-    updated[index] = value
-    setGithubUrls(updated)
-  }
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!jdText.trim()) return
@@ -157,13 +231,8 @@ export function CreateJobPage() {
         inputData.linkedin_url = linkedinUrl.trim()
       }
 
-      const validGithubUrls = githubUrls.filter(url => url.trim())
-      if (validGithubUrls.length > 0) {
-        inputData.github_urls = validGithubUrls
-      }
-
-      if (focusAreas.trim()) {
-        inputData.focus_areas = focusAreas.split(',').map(s => s.trim()).filter(Boolean)
+      if (gitUrl.trim()) {
+        inputData.git_url = gitUrl.trim()
       }
 
       const job = await createJob(inputData)
@@ -176,143 +245,101 @@ export function CreateJobPage() {
   }
 
   const isUploading = resume.uploading || portfolio.uploading || coverLetter.uploading
+  const canSubmit = jdText.length >= 50 && !submitting && !isUploading
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">{t('create_job')}</h1>
+    <div className="mx-auto max-w-3xl">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600">
+            <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">{t('create_interview_script')}</h1>
+            <p className="mt-0.5 text-sm text-gray-500">채용공고와 후보자 정보를 입력하여 맞춤형 면접 스크립트를 생성하세요</p>
+          </div>
+        </div>
+      </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
-        {/* JD Text - Required */}
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h2 className="text-lg font-semibold text-gray-900 mb-3">
-            {t('jd_section_title')} <span className="text-red-500">*</span>
-          </h2>
+        {/* JD Text */}
+        <SectionCard
+          title={t('jd_section_title')}
+          description="채용 포지션에 대한 상세한 직무 설명을 입력해주세요"
+          required
+        >
           <textarea
             value={jdText}
             onChange={(e) => setJdText(e.target.value)}
             placeholder={t('jd_placeholder')}
             rows={8}
-            className="w-full border border-gray-300 rounded-lg p-3 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            className="w-full rounded-lg border border-gray-300 p-4 text-gray-900 placeholder-gray-400 transition-colors focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
             required
             minLength={50}
           />
-          <p className="text-sm text-gray-500 mt-1">
-            {jdText.length}/50 {t('min_chars')}
-          </p>
-        </div>
+          <div className="mt-2 flex items-center justify-between text-sm">
+            <span className={`${jdText.length >= 50 ? 'text-green-600' : 'text-gray-500'}`}>
+              {jdText.length >= 50 ? (
+                <span className="flex items-center gap-1">
+                  <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                  충분한 길이입니다
+                </span>
+              ) : (
+                `${jdText.length}/50 ${t('min_chars')}`
+              )}
+            </span>
+          </div>
+        </SectionCard>
 
         {/* 파일 업로드 섹션 */}
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h2 className="text-lg font-semibold text-gray-900 mb-3">
-            {t('document_upload')}
-          </h2>
-          <p className="text-sm text-gray-500 mb-4">{t('document_upload_hint')}</p>
-
-          <div className="space-y-4">
-            {/* 이력서 */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                {t('resume')} (PDF)
-              </label>
-              {resume.path ? (
-                <div className="flex items-center gap-2 p-2 bg-green-50 border border-green-200 rounded-lg">
-                  <span className="text-green-700 text-sm flex-1 truncate">{resume.file?.name}</span>
-                  <button
-                    type="button"
-                    onClick={() => removeFile(setResume)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {t('remove')}
-                  </button>
-                </div>
-              ) : (
-                <input
-                  type="file"
-                  accept=".pdf"
-                  onChange={(e) => handleFileChange(e, 'resume', setResume)}
-                  disabled={resume.uploading}
-                  className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-                />
-              )}
-              {resume.uploading && <p className="text-sm text-blue-600 mt-1">{t('uploading')}</p>}
-              {resume.error && <p className="text-sm text-red-600 mt-1">{resume.error}</p>}
-            </div>
-
-            {/* 포트폴리오 */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                {t('portfolio')} (PDF, DOCX)
-              </label>
-              {portfolio.path ? (
-                <div className="flex items-center gap-2 p-2 bg-green-50 border border-green-200 rounded-lg">
-                  <span className="text-green-700 text-sm flex-1 truncate">{portfolio.file?.name}</span>
-                  <button
-                    type="button"
-                    onClick={() => removeFile(setPortfolio)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {t('remove')}
-                  </button>
-                </div>
-              ) : (
-                <input
-                  type="file"
-                  accept=".pdf,.docx"
-                  onChange={(e) => handleFileChange(e, 'portfolio', setPortfolio)}
-                  disabled={portfolio.uploading}
-                  className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-                />
-              )}
-              {portfolio.uploading && <p className="text-sm text-blue-600 mt-1">{t('uploading')}</p>}
-              {portfolio.error && <p className="text-sm text-red-600 mt-1">{portfolio.error}</p>}
-            </div>
-
-            {/* 커버레터 */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                {t('cover_letter')} (PDF, DOCX)
-              </label>
-              {coverLetter.path ? (
-                <div className="flex items-center gap-2 p-2 bg-green-50 border border-green-200 rounded-lg">
-                  <span className="text-green-700 text-sm flex-1 truncate">{coverLetter.file?.name}</span>
-                  <button
-                    type="button"
-                    onClick={() => removeFile(setCoverLetter)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {t('remove')}
-                  </button>
-                </div>
-              ) : (
-                <input
-                  type="file"
-                  accept=".pdf,.docx"
-                  onChange={(e) => handleFileChange(e, 'cover_letter', setCoverLetter)}
-                  disabled={coverLetter.uploading}
-                  className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-                />
-              )}
-              {coverLetter.uploading && <p className="text-sm text-blue-600 mt-1">{t('uploading')}</p>}
-              {coverLetter.error && <p className="text-sm text-red-600 mt-1">{coverLetter.error}</p>}
-            </div>
+        <SectionCard
+          title={t('document_upload')}
+          description={t('document_upload_hint')}
+        >
+          <div className="grid gap-4 sm:grid-cols-3">
+            <FileUploadField
+              label={`${t('resume')} (PDF)`}
+              accept=".pdf"
+              fileState={resume}
+              onFileChange={(e) => handleFileChange(e, 'resume', setResume)}
+              onRemove={() => removeFile(setResume)}
+              t={t}
+            />
+            <FileUploadField
+              label={`${t('portfolio')} (PDF, DOCX)`}
+              accept=".pdf,.docx"
+              fileState={portfolio}
+              onFileChange={(e) => handleFileChange(e, 'portfolio', setPortfolio)}
+              onRemove={() => removeFile(setPortfolio)}
+              t={t}
+            />
+            <FileUploadField
+              label={`${t('cover_letter')} (PDF, DOCX)`}
+              accept=".pdf,.docx"
+              fileState={coverLetter}
+              onFileChange={(e) => handleFileChange(e, 'cover_letter', setCoverLetter)}
+              onRemove={() => removeFile(setCoverLetter)}
+              t={t}
+            />
           </div>
-        </div>
+        </SectionCard>
 
         {/* 후보자 정보 섹션 */}
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h2 className="text-lg font-semibold text-gray-900 mb-3">
-            {t('candidate_info')}
-          </h2>
-
-          <div className="grid grid-cols-2 gap-4">
+        <SectionCard title={t('candidate_info')}>
+          <div className="grid gap-4 sm:grid-cols-2">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">
                 {t('experience_level')} <span className="text-red-500">*</span>
               </label>
               <select
                 value={experienceLevel}
                 onChange={(e) => setExperienceLevel(e.target.value)}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-gray-900 transition-colors focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
               >
                 <option value="신입">{t('level_entry')}</option>
                 <option value="주니어">{t('level_junior')}</option>
@@ -323,13 +350,13 @@ export function CreateJobPage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">
                 {t('output_language')} <span className="text-red-500">*</span>
               </label>
               <select
                 value={outputLanguage}
                 onChange={(e) => setOutputLanguage(e.target.value)}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-gray-900 transition-colors focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
               >
                 {SUPPORTED_LANGUAGES.map((lang) => (
                   <option key={lang.code} value={lang.code}>
@@ -342,133 +369,110 @@ export function CreateJobPage() {
 
           {/* LinkedIn URL */}
           <div className="mt-4">
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="mb-1.5 block text-sm font-medium text-gray-700">
               {t('linkedin_url')}
             </label>
+            <div className="relative">
+              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                <svg className="h-5 w-5 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
+                </svg>
+              </div>
+              <input
+                type="url"
+                value={linkedinUrl}
+                onChange={(e) => setLinkedinUrl(e.target.value)}
+                placeholder="https://linkedin.com/in/username"
+                className="w-full rounded-lg border border-gray-300 py-2.5 pl-10 pr-3 text-gray-900 transition-colors focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
+              />
+            </div>
+            <p className="mt-1.5 text-sm text-gray-500">{t('linkedin_hint')}</p>
+          </div>
+        </SectionCard>
+
+        {/* Git URL */}
+        <SectionCard title={t('git_url')} description={t('git_url_hint')}>
+          <div className="relative">
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+              <svg className="h-5 w-5 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+                <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd"/>
+              </svg>
+            </div>
             <input
               type="url"
-              value={linkedinUrl}
-              onChange={(e) => setLinkedinUrl(e.target.value)}
-              placeholder="https://linkedin.com/in/username"
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500"
+              value={gitUrl}
+              onChange={(e) => setGitUrl(e.target.value)}
+              placeholder="https://github.com/username"
+              className="w-full rounded-lg border border-gray-300 py-2.5 pl-10 pr-3 text-gray-900 transition-colors focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
             />
-            <p className="text-sm text-gray-500 mt-1">{t('linkedin_hint')}</p>
           </div>
-        </div>
-
-        {/* GitHub Repos */}
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <div className="flex justify-between items-center mb-3">
-            <h2 className="text-lg font-semibold text-gray-900">
-              {t('github_repos')}
-            </h2>
-            {githubUrls.length < 5 && (
-              <button
-                type="button"
-                onClick={addGithubUrl}
-                className="text-sm text-blue-600 hover:text-blue-800"
-              >
-                + {t('add_repo')}
-              </button>
-            )}
-          </div>
-
-          <div className="space-y-2">
-            {githubUrls.map((url, index) => (
-              <div key={index} className="flex gap-2">
-                <input
-                  type="url"
-                  value={url}
-                  onChange={(e) => updateGithubUrl(index, e.target.value)}
-                  placeholder="https://github.com/user/repo"
-                  className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500"
-                />
-                {githubUrls.length > 1 && (
-                  <button
-                    type="button"
-                    onClick={() => removeGithubUrl(index)}
-                    className="px-3 py-2 text-red-600 hover:text-red-800"
-                    aria-label={t('remove')}
-                  >
-                    ✕
-                  </button>
-                )}
-              </div>
-            ))}
-          </div>
-          <p className="text-sm text-gray-500 mt-2">
-            {t('github_repos_hint')}
-          </p>
-        </div>
+        </SectionCard>
 
         {/* Options */}
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h2 className="text-lg font-semibold text-gray-900 mb-3">
-            {t('options')}
-          </h2>
-
-          <div className="space-y-4">
-            {/* Max Questions */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                {t('max_questions')}: <span className="font-semibold">{maxQuestions}</span>
-              </label>
-              <input
-                type="range"
-                min={5}
-                max={25}
-                value={maxQuestions}
-                onChange={(e) => setMaxQuestions(Number(e.target.value))}
-                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-              />
-              <div className="flex justify-between text-xs text-gray-500">
-                <span>5</span>
-                <span>15</span>
-                <span>25</span>
-              </div>
+        <SectionCard title={t('options')}>
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <label className="text-sm font-medium text-gray-700">{t('max_questions')}</label>
+              <span className="rounded-full bg-indigo-100 px-2.5 py-0.5 text-sm font-semibold text-indigo-700">
+                {maxQuestions}개
+              </span>
             </div>
-
-            {/* Focus Areas */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                {t('focus_areas')}
-              </label>
-              <input
-                type="text"
-                value={focusAreas}
-                onChange={(e) => setFocusAreas(e.target.value)}
-                placeholder="e.g. React, TypeScript, System Design"
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:ring-2 focus:ring-blue-500"
-              />
-              <p className="text-sm text-gray-500 mt-1">
-                {t('focus_areas_hint')}
-              </p>
+            <input
+              type="range"
+              min={5}
+              max={25}
+              value={maxQuestions}
+              onChange={(e) => setMaxQuestions(Number(e.target.value))}
+              className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-indigo-600"
+            />
+            <div className="mt-1 flex justify-between text-xs text-gray-400">
+              <span>5</span>
+              <span>15</span>
+              <span>25</span>
             </div>
           </div>
-        </div>
+        </SectionCard>
 
         {/* Error Display */}
         {error && (
-          <div className="p-4 bg-red-50 border border-red-200 text-red-700 rounded-lg text-sm">
-            {error}
+          <div className="flex items-center gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
+            <svg className="h-5 w-5 flex-shrink-0 text-red-500" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+            </svg>
+            <span className="text-sm font-medium text-red-700">{error}</span>
           </div>
         )}
 
-        {/* Submit Button */}
-        <div className="flex justify-end gap-3">
+        {/* Submit Buttons */}
+        <div className="flex items-center justify-end gap-3 border-t border-gray-200 pt-6">
           <button
             type="button"
             onClick={() => navigate('/jobs')}
-            className="px-6 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+            className="rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
           >
             {t('cancel')}
           </button>
           <button
             type="submit"
-            disabled={submitting || jdText.length < 50 || isUploading}
-            className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={!canSubmit}
+            className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-6 py-2.5 text-sm font-medium text-white shadow-sm transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-md disabled:cursor-not-allowed disabled:from-gray-400 disabled:to-gray-400 disabled:shadow-none"
           >
-            {submitting ? t('loading') : t('create_interview_script')}
+            {submitting ? (
+              <>
+                <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                {t('loading')}
+              </>
+            ) : (
+              <>
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                {t('create_interview_script')}
+              </>
+            )}
           </button>
         </div>
       </form>

--- a/frontend/src/pages/JobListPage.tsx
+++ b/frontend/src/pages/JobListPage.tsx
@@ -5,6 +5,85 @@ import { useJob } from '../hooks/useJob'
 
 const PAGE_SIZE = 10
 
+// Status badge component
+function StatusBadge({ status }: { status: string }) {
+  const { t } = useTranslation()
+
+  const statusConfig: Record<string, { bg: string; text: string; label: string }> = {
+    pending: { bg: 'bg-gray-100', text: 'text-gray-700', label: t('phase_pending') },
+    enriching: { bg: 'bg-blue-100', text: 'text-blue-700', label: t('phase_enriching') },
+    planning: { bg: 'bg-purple-100', text: 'text-purple-700', label: t('phase_planning') },
+    analyzing: { bg: 'bg-indigo-100', text: 'text-indigo-700', label: t('phase_analyzing') },
+    generating: { bg: 'bg-amber-100', text: 'text-amber-700', label: t('phase_generating') },
+    reviewing: { bg: 'bg-cyan-100', text: 'text-cyan-700', label: t('phase_reviewing') },
+    completed: { bg: 'bg-green-100', text: 'text-green-700', label: t('phase_completed') },
+    failed: { bg: 'bg-red-100', text: 'text-red-700', label: t('phase_failed') },
+  }
+
+  const config = statusConfig[status] || { bg: 'bg-gray-100', text: 'text-gray-700', label: status }
+
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${config.bg} ${config.text}`}>
+      {config.label}
+    </span>
+  )
+}
+
+// Empty state component
+function EmptyState() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-gray-200 bg-gray-50/50 px-6 py-16">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-purple-600">
+        <svg
+          className="h-8 w-8 text-white"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+      </div>
+      <h3 className="mt-4 text-lg font-semibold text-gray-900">{t('script_list_empty_title')}</h3>
+      <p className="mt-1 text-sm text-gray-500">{t('script_list_empty_desc')}</p>
+      <Link
+        to="/jobs/new"
+        className="mt-6 inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-md"
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+        {t('new_script')}
+      </Link>
+    </div>
+  )
+}
+
+// Loading skeleton
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-3">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="animate-pulse rounded-xl border border-gray-200 bg-white p-5">
+          <div className="flex items-center justify-between">
+            <div className="space-y-2">
+              <div className="h-4 w-32 rounded bg-gray-200"></div>
+              <div className="h-3 w-48 rounded bg-gray-100"></div>
+            </div>
+            <div className="h-6 w-16 rounded-full bg-gray-200"></div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function JobListPage() {
   const { t } = useTranslation()
   const { jobs, loading, error, fetchJobs, deleteJob } = useJob()
@@ -14,8 +93,33 @@ export function JobListPage() {
     fetchJobs()
   }, [fetchJobs])
 
-  if (loading) return <p>{t('loading')}</p>
-  if (error) return <p className="text-red-600">{t('fetch_error')}</p>
+  if (loading) {
+    return (
+      <div>
+        <div className="mb-8 flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-gray-900">{t('script_list_title')}</h1>
+        </div>
+        <LoadingSkeleton />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-xl border border-red-200 bg-red-50 px-6 py-12">
+        <svg className="h-12 w-12 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <p className="mt-3 text-sm font-medium text-red-800">{t('fetch_error')}</p>
+        <button
+          onClick={() => fetchJobs()}
+          className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+        >
+          {t('retry')}
+        </button>
+      </div>
+    )
+  }
 
   const totalPages = Math.max(1, Math.ceil(jobs.length / PAGE_SIZE))
   const paginated = jobs.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
@@ -28,60 +132,115 @@ export function JobListPage() {
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t('jobs')}</h1>
-        <Link
-          to="/jobs/new"
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
-        >
-          {t('create_job')}
-        </Link>
+      {/* Header */}
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{t('script_list_title')}</h1>
+          {jobs.length > 0 && (
+            <p className="mt-1 text-sm text-gray-500">
+              {jobs.length}개의 스크립트
+            </p>
+          )}
+        </div>
+        {jobs.length > 0 && (
+          <Link
+            to="/jobs/new"
+            className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-md"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            {t('new_script')}
+          </Link>
+        )}
       </div>
 
       {jobs.length === 0 ? (
-        <p className="text-gray-500">{t('no_jobs')}</p>
+        <EmptyState />
       ) : (
         <>
+          {/* Script List */}
           <div className="space-y-3">
             {paginated.map((job) => (
-              <div key={job.job_id} className="bg-white rounded-lg shadow p-4 flex items-center justify-between">
-                <div>
-                  <Link to={`/jobs/${job.job_id}`} className="text-blue-600 hover:underline font-medium">
-                    {job.job_id.slice(0, 8)}...
-                  </Link>
-                  <span className="ml-3 text-sm text-gray-500">{job.status}</span>
-                  <span className="ml-3 text-sm text-gray-400">
-                    {new Date(job.created_at).toLocaleString()}
-                  </span>
+              <div
+                key={job.job_id}
+                className="group rounded-xl border border-gray-200 bg-white p-5 transition-all hover:border-gray-300 hover:shadow-md"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3">
+                      <Link
+                        to={`/jobs/${job.job_id}`}
+                        className="text-base font-medium text-gray-900 hover:text-indigo-600"
+                      >
+                        #{job.job_id.slice(0, 8)}
+                      </Link>
+                      <StatusBadge status={job.status} />
+                    </div>
+                    <div className="mt-1.5 flex items-center gap-4 text-sm text-gray-500">
+                      <span className="flex items-center gap-1">
+                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                        {new Date(job.created_at).toLocaleDateString()}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        {new Date(job.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    {job.status === 'completed' && (
+                      <Link
+                        to={`/jobs/${job.job_id}/result`}
+                        className="rounded-lg bg-green-50 px-3 py-1.5 text-sm font-medium text-green-700 hover:bg-green-100"
+                      >
+                        {t('view_result')}
+                      </Link>
+                    )}
+                    <button
+                      onClick={() => handleDelete(job.job_id)}
+                      className="rounded-lg p-2 text-gray-400 opacity-0 transition-all hover:bg-red-50 hover:text-red-500 group-hover:opacity-100"
+                      aria-label={t('delete')}
+                    >
+                      <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-                <button
-                  onClick={() => handleDelete(job.job_id)}
-                  className="text-sm text-red-500 hover:text-red-700"
-                >
-                  {t('delete')}
-                </button>
               </div>
             ))}
           </div>
 
+          {/* Pagination */}
           {totalPages > 1 && (
-            <div className="flex justify-center items-center gap-2 mt-6">
+            <div className="mt-8 flex items-center justify-center gap-2">
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page === 1}
-                className="px-3 py-1 text-sm rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-100"
+                className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
               >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
                 {t('prev')}
               </button>
-              <span className="text-sm text-gray-600">
+              <span className="px-4 text-sm text-gray-600">
                 {page} / {totalPages}
               </span>
               <button
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page === totalPages}
-                className="px-3 py-1 text-sm rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-100"
+                className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {t('next')}
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
               </button>
             </div>
           )}

--- a/frontend/src/pages/JobStatusPage.tsx
+++ b/frontend/src/pages/JobStatusPage.tsx
@@ -15,6 +15,118 @@ const PHASE_KEYS: Record<string, string> = {
   failed: 'phase_failed',
 }
 
+// Phase configuration with colors and icons
+const PHASE_CONFIG: Record<string, { color: string; bgColor: string; icon: string }> = {
+  pending: { color: 'text-gray-600', bgColor: 'bg-gray-100', icon: 'clock' },
+  enriching: { color: 'text-blue-600', bgColor: 'bg-blue-100', icon: 'search' },
+  planning: { color: 'text-purple-600', bgColor: 'bg-purple-100', icon: 'clipboard' },
+  analyzing: { color: 'text-indigo-600', bgColor: 'bg-indigo-100', icon: 'chart' },
+  generating: { color: 'text-amber-600', bgColor: 'bg-amber-100', icon: 'sparkles' },
+  reviewing: { color: 'text-cyan-600', bgColor: 'bg-cyan-100', icon: 'check' },
+  completed: { color: 'text-green-600', bgColor: 'bg-green-100', icon: 'done' },
+  failed: { color: 'text-red-600', bgColor: 'bg-red-100', icon: 'error' },
+}
+
+// Phase icon component
+function PhaseIcon({ phase, className }: { phase: string; className?: string }) {
+  const icons: Record<string, React.ReactNode> = {
+    clock: (
+      <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+    search: (
+      <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+    ),
+    clipboard: (
+      <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+      </svg>
+    ),
+    chart: (
+      <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+      </svg>
+    ),
+    sparkles: (
+      <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+      </svg>
+    ),
+    check: (
+      <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+    done: (
+      <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+    error: (
+      <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  }
+  const config = PHASE_CONFIG[phase] || PHASE_CONFIG.pending
+  return <>{icons[config.icon]}</>
+}
+
+// Timeline step component
+function TimelineStep({
+  phase,
+  label,
+  isActive,
+  isCompleted,
+  isFailed,
+}: {
+  phase: string
+  label: string
+  isActive: boolean
+  isCompleted: boolean
+  isFailed: boolean
+}) {
+  const config = PHASE_CONFIG[phase] || PHASE_CONFIG.pending
+
+  return (
+    <div className={`flex items-center gap-3 ${isActive ? 'opacity-100' : isCompleted ? 'opacity-70' : 'opacity-40'}`}>
+      <div
+        className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ${
+          isActive
+            ? isFailed
+              ? 'bg-red-100 text-red-600'
+              : 'bg-indigo-100 text-indigo-600 ring-4 ring-indigo-50'
+            : isCompleted
+            ? 'bg-green-100 text-green-600'
+            : 'bg-gray-100 text-gray-400'
+        }`}
+      >
+        {isCompleted && !isActive ? (
+          <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        ) : (
+          <PhaseIcon phase={phase} className="h-5 w-5" />
+        )}
+      </div>
+      <span className={`text-sm font-medium ${isActive ? config.color : isCompleted ? 'text-green-600' : 'text-gray-400'}`}>
+        {label}
+      </span>
+      {isActive && !isFailed && phase !== 'completed' && (
+        <span className="ml-auto">
+          <svg className="h-4 w-4 animate-spin text-indigo-600" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+        </span>
+      )}
+    </div>
+  )
+}
+
 export function JobStatusPage() {
   const { t } = useTranslation()
   const { jobId } = useParams<{ jobId: string }>()
@@ -43,12 +155,37 @@ export function JobStatusPage() {
     }
   }, [jobId, getJob, connected])
 
-  if (error) return <p className="text-red-600 p-4">{error}</p>
+  if (error) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <div className="flex flex-col items-center justify-center rounded-xl border border-red-200 bg-red-50 px-6 py-12">
+          <svg className="h-12 w-12 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <p className="mt-3 text-sm font-medium text-red-800">{error}</p>
+          <Link
+            to="/jobs"
+            className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+          >
+            {t('go_home')}
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
   if (!job) {
     return (
-      <div className="max-w-2xl mx-auto flex items-center justify-center py-20">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
-        <span className="ml-3 text-gray-500">{t('loading')}</span>
+      <div className="mx-auto max-w-2xl">
+        <div className="flex flex-col items-center justify-center py-20">
+          <div className="relative">
+            <div className="h-16 w-16 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600"></div>
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="h-8 w-8 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600"></div>
+            </div>
+          </div>
+          <p className="mt-4 text-sm font-medium text-gray-500">{t('loading')}</p>
+        </div>
       </div>
     )
   }
@@ -60,58 +197,145 @@ export function JobStatusPage() {
   const phaseLabel = wsProgress?.phase || (phaseKey ? t(phaseKey) : status)
 
   const isTerminal = status === 'completed' || status === 'failed'
+  const config = PHASE_CONFIG[status] || PHASE_CONFIG.pending
+
+  // Define all phases for timeline
+  const phases = ['pending', 'enriching', 'planning', 'analyzing', 'generating', 'reviewing', 'completed']
+  const currentPhaseIndex = phases.indexOf(status)
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold text-gray-900 mb-4">Job: {jobId?.slice(0, 8)}...</h1>
-
-      <div className="bg-white rounded-lg shadow p-6 space-y-4">
-        <div className="flex justify-between items-center">
-          <span className="text-gray-600">{t('status')}</span>
-          <div className="flex items-center gap-2">
-            {!isTerminal && (
-              <span className={`inline-block h-2 w-2 rounded-full ${connected ? 'bg-green-500' : 'bg-yellow-500'} animate-pulse`} />
-            )}
-            <span className={`font-medium ${status === 'completed' ? 'text-green-600' : status === 'failed' ? 'text-red-600' : 'text-blue-600'}`}>
-              {phaseLabel}
-            </span>
+    <div className="mx-auto max-w-2xl">
+      {/* Header Card */}
+      <div className="mb-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-4">
+            <div className={`flex h-14 w-14 items-center justify-center rounded-xl ${config.bgColor}`}>
+              <PhaseIcon phase={status} className={`h-7 w-7 ${config.color}`} />
+            </div>
+            <div>
+              <h1 className="text-xl font-bold text-gray-900">면접 스크립트 #{jobId?.slice(0, 8)}</h1>
+              <div className="mt-1 flex items-center gap-2">
+                <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${config.bgColor} ${config.color}`}>
+                  {!isTerminal && (
+                    <span className={`h-1.5 w-1.5 rounded-full ${connected ? 'bg-green-500' : 'bg-yellow-500'} animate-pulse`} />
+                  )}
+                  {phaseLabel}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="text-right">
+            <p className="text-xs text-gray-400">{t('created_at')}</p>
+            <p className="text-sm font-medium text-gray-600">
+              {job.created_at ? new Date(String(job.created_at)).toLocaleDateString() : '-'}
+            </p>
+            <p className="text-xs text-gray-400">
+              {job.created_at ? new Date(String(job.created_at)).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : ''}
+            </p>
           </div>
         </div>
 
         {/* Progress bar */}
-        <div className="w-full bg-gray-200 rounded-full h-3">
-          <div
-            className={`h-3 rounded-full transition-all duration-500 ${status === 'failed' ? 'bg-red-500' : 'bg-blue-600'}`}
-            style={{ width: `${progressPercent}%` }}
-          />
+        <div className="mt-6">
+          <div className="mb-2 flex items-center justify-between text-sm">
+            <span className="font-medium text-gray-700">진행률</span>
+            <span className={`font-semibold ${config.color}`}>{progressPercent}%</span>
+          </div>
+          <div className="h-2.5 w-full overflow-hidden rounded-full bg-gray-200">
+            <div
+              className={`h-2.5 rounded-full transition-all duration-700 ease-out ${
+                status === 'failed' ? 'bg-red-500' : 'bg-gradient-to-r from-indigo-500 to-purple-600'
+              }`}
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
         </div>
-        <div className="text-right text-xs text-gray-400">{progressPercent}%</div>
+      </div>
 
-        <div className="text-sm text-gray-500">
-          {t('created_at')}: {job.created_at ? new Date(String(job.created_at)).toLocaleString() : '-'}
+      {/* Timeline */}
+      <div className="mb-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-sm font-semibold text-gray-900">처리 단계</h2>
+        <div className="space-y-4">
+          {phases.map((phase, index) => {
+            const isActive = phase === status
+            const isCompleted = index < currentPhaseIndex || status === 'completed'
+            const isFailed = status === 'failed' && index === currentPhaseIndex
+
+            return (
+              <div key={phase} className="relative">
+                {index < phases.length - 1 && (
+                  <div
+                    className={`absolute left-5 top-10 h-4 w-0.5 ${
+                      isCompleted ? 'bg-green-300' : 'bg-gray-200'
+                    }`}
+                  />
+                )}
+                <TimelineStep
+                  phase={phase}
+                  label={t(PHASE_KEYS[phase])}
+                  isActive={isActive}
+                  isCompleted={isCompleted}
+                  isFailed={isFailed}
+                />
+              </div>
+            )
+          })}
         </div>
+      </div>
 
-        {status === 'completed' && (
-          <div className="mt-4 p-4 bg-green-50 rounded-lg flex items-center justify-between">
-            <p className="text-green-800 font-medium">{t('script_complete')}</p>
+      {/* Success State */}
+      {status === 'completed' && (
+        <div className="rounded-xl border border-green-200 bg-gradient-to-br from-green-50 to-emerald-50 p-6">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <svg className="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <div className="flex-1">
+              <h3 className="text-lg font-semibold text-green-800">{t('script_complete')}</h3>
+              <p className="text-sm text-green-600">면접 스크립트가 성공적으로 생성되었습니다</p>
+            </div>
             <Link
               to={`/jobs/${jobId}/result`}
-              className="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700"
+              className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-medium text-white shadow-sm transition-all hover:bg-green-700 hover:shadow-md"
             >
               {t('view_result')}
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
             </Link>
           </div>
-        )}
+        </div>
+      )}
 
-        {status === 'failed' && (
-          <div className="mt-4 p-4 bg-red-50 rounded-lg">
-            <p className="text-red-800 font-medium">{t('generation_failed')}</p>
-            <p className="text-red-600 text-sm mt-1">
-              {String((job as Record<string, unknown>).error_message || t('unknown_error'))}
-            </p>
+      {/* Failed State */}
+      {status === 'failed' && (
+        <div className="rounded-xl border border-red-200 bg-gradient-to-br from-red-50 to-orange-50 p-6">
+          <div className="flex items-start gap-4">
+            <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100">
+              <svg className="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-red-800">{t('generation_failed')}</h3>
+              <p className="mt-1 text-sm text-red-600">
+                {String((job as Record<string, unknown>).error_message || t('unknown_error'))}
+              </p>
+              <Link
+                to="/jobs/new"
+                className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-red-700 hover:text-red-800"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                새 스크립트 생성하기
+              </Link>
+            </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,26 +2,143 @@ import { useTranslation } from 'react-i18next'
 
 const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000'
 
+// Google Icon SVG
+function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 533.5 544.3" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M533.5 278.4c0-17.4-1.6-34.1-4.6-50.2H272v95h146.9c-6.3 33.9-25 62.5-53.2 81.8v68.1h85.8c50.2-46.3 82-114.6 82-194.7z"
+        fill="#4285F4"
+      />
+      <path
+        d="M272 544.3c71.6 0 131.7-23.7 175.7-64.2l-85.8-68.1c-23.8 16-54.1 25.4-89.9 25.4-69.1 0-127.6-46.6-148.4-109.3h-89.6v68.9C77.7 480.5 168.5 544.3 272 544.3z"
+        fill="#34A853"
+      />
+      <path
+        d="M123.6 328.1c-10.8-32.1-10.8-66.9 0-99l-89.6-68.9c-39.1 77.6-39.1 168.3 0 245.9l89.6-68z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M272 107.7c37.4-.6 73.5 13.2 101.1 38.7l75.4-75.4C403.4 24.5 341.4 0 272 0 168.5 0 77.7 63.8 34 159.2l89.6 68.9C144.4 154.3 202.9 107.7 272 107.7z"
+        fill="#EA4335"
+      />
+    </svg>
+  )
+}
+
+// GitHub Icon SVG
+function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38v-1.48c-2.22.48-2.69-1.07-2.69-1.07-.36-.91-.88-1.15-.88-1.15-.72-.5.05-.49.05-.49.8.06 1.22.82 1.22.82.71 1.22 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.01.08-2.1 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.09.16 1.9.08 2.1.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.74.54 1.49v2.21c0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  )
+}
+
 export function LoginPage() {
   const { t } = useTranslation()
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6">
-      <h1 className="text-3xl font-bold text-gray-900">Vantict Sniper</h1>
-      <p className="text-gray-600">AI Technical Interview Script Generator</p>
-      <div className="flex flex-col gap-3 w-64">
-        <a
-          href={`${BACKEND}/auth/google/login`}
-          className="block text-center bg-white border border-gray-300 rounded-lg px-4 py-3 hover:bg-gray-50 text-gray-800 font-medium"
-        >
-          {t('login_with_google')}
-        </a>
-        <a
-          href={`${BACKEND}/auth/github/login`}
-          className="block text-center bg-gray-900 text-white rounded-lg px-4 py-3 hover:bg-gray-800 font-medium"
-        >
-          {t('login_with_github')}
-        </a>
+    <div className="flex min-h-[80vh] items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        {/* Card */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 shadow-lg">
+          {/* Header */}
+          <div className="mb-8 text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-purple-600">
+              <svg
+                className="h-8 w-8 text-white"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+                />
+              </svg>
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900">Vantict Sniper</h1>
+            <p className="mt-2 text-sm text-gray-600">{t('login_subtitle')}</p>
+          </div>
+
+          {/* OAuth Buttons */}
+          <div className="space-y-3">
+            <a
+              href={`${BACKEND}/auth/google/login`}
+              className="group flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition-all hover:border-gray-400 hover:bg-gray-50 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            >
+              <GoogleIcon className="h-5 w-5" />
+              <span>{t('login_with_google')}</span>
+            </a>
+
+            <a
+              href={`${BACKEND}/auth/github/login`}
+              className="group flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white transition-all hover:bg-gray-800 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2"
+            >
+              <GitHubIcon className="h-5 w-5" />
+              <span>{t('login_with_github')}</span>
+            </a>
+          </div>
+
+          {/* Divider */}
+          <div className="relative my-6">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200"></div>
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="bg-white px-4 text-gray-500">{t('login_secure_note')}</span>
+            </div>
+          </div>
+
+          {/* Features */}
+          <div className="space-y-3 text-sm text-gray-600">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-green-100">
+                <svg className="h-3 w-3 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+              <span>{t('login_feature_1')}</span>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-green-100">
+                <svg className="h-3 w-3 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+              <span>{t('login_feature_2')}</span>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-green-100">
+                <svg className="h-3 w-3 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+              <span>{t('login_feature_3')}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <p className="mt-6 text-center text-xs text-gray-500">
+          {t('login_terms')}
+        </p>
       </div>
     </div>
   )

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { apiFetch } from '../lib/api'
 import { QuestionCard, type Question } from '../components/QuestionCard'
@@ -15,12 +15,12 @@ function downloadJSON(data: unknown, filename: string) {
 }
 
 const CATEGORY_KEYS = [
-  { key: 'all', i18n: 'cat_all' },
-  { key: 'role_fit', i18n: 'cat_role_fit' },
-  { key: 'technical_depth', i18n: 'cat_technical_depth' },
-  { key: 'execution_ownership', i18n: 'cat_execution_ownership' },
-  { key: 'communication', i18n: 'cat_communication' },
-  { key: 'risk_flags', i18n: 'cat_risk_flags' },
+  { key: 'all', i18n: 'cat_all', color: 'bg-gray-100 text-gray-700 hover:bg-gray-200' },
+  { key: 'role_fit', i18n: 'cat_role_fit', color: 'bg-blue-100 text-blue-700 hover:bg-blue-200' },
+  { key: 'technical_depth', i18n: 'cat_technical_depth', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200' },
+  { key: 'execution_ownership', i18n: 'cat_execution_ownership', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200' },
+  { key: 'communication', i18n: 'cat_communication', color: 'bg-green-100 text-green-700 hover:bg-green-200' },
+  { key: 'risk_flags', i18n: 'cat_risk_flags', color: 'bg-red-100 text-red-700 hover:bg-red-200' },
 ]
 
 interface InterviewScript {
@@ -50,9 +50,47 @@ export function ResultPage() {
       .finally(() => setLoading(false))
   }, [jobId])
 
-  if (loading) return <p>{t('loading')}</p>
-  if (error) return <p className="text-red-600">{t('result_error')}: {error}</p>
-  if (!script) return <p className="text-red-600">{t('result_error')}</p>
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20">
+        <div className="relative">
+          <div className="h-16 w-16 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600"></div>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="h-8 w-8 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600"></div>
+          </div>
+        </div>
+        <p className="mt-4 text-sm font-medium text-gray-500">{t('loading')}</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-xl border border-red-200 bg-red-50 px-6 py-12">
+        <svg className="h-12 w-12 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <p className="mt-3 text-sm font-medium text-red-800">{t('result_error')}: {error}</p>
+        <Link
+          to="/jobs"
+          className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+        >
+          {t('go_home')}
+        </Link>
+      </div>
+    )
+  }
+
+  if (!script) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-gray-50 px-6 py-12">
+        <svg className="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        <p className="mt-3 text-sm font-medium text-gray-800">{t('result_error')}</p>
+      </div>
+    )
+  }
 
   const questions = script.questions || []
   const filtered = activeCategory === 'all'
@@ -65,38 +103,71 @@ export function ResultPage() {
 
   const totalScore = Object.values(scores).reduce((sum, s) => sum + s, 0)
   const maxScore = Object.keys(scores).length * 5
+  const scorePercent = maxScore > 0 ? Math.round((totalScore / maxScore) * 100) : 0
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
-        <h1 className="text-2xl font-bold text-gray-900">{t('interview_script')}</h1>
-        <div className="flex items-center gap-3">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600">
+            <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">{t('interview_script')}</h1>
+            <p className="text-sm text-gray-500">#{jobId?.slice(0, 8)} · {questions.length}개 질문</p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Score display */}
           {maxScore > 0 && (
-            <div className="text-lg font-semibold text-gray-700">
-              {t('score_label')}: {totalScore}/{maxScore} ({Math.round((totalScore / maxScore) * 100)}%)
+            <div className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2">
+              <svg className="h-5 w-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+              </svg>
+              <span className="text-sm font-semibold text-indigo-700">
+                {totalScore}/{maxScore} ({scorePercent}%)
+              </span>
             </div>
           )}
-          <button
-            onClick={() => downloadJSON(script, `interview-${jobId?.slice(0, 8)}.json`)}
-            className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 no-print"
-          >
-            {t('export_json')}
-          </button>
-          <button
-            onClick={() => window.print()}
-            className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 no-print"
-          >
-            {t('print_pdf')}
-          </button>
+
+          {/* Action buttons */}
+          <div className="flex gap-2 no-print">
+            <button
+              onClick={() => downloadJSON(script, `interview-${jobId?.slice(0, 8)}.json`)}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              {t('export_json')}
+            </button>
+            <button
+              onClick={() => window.print()}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+              </svg>
+              {t('print_pdf')}
+            </button>
+          </div>
         </div>
       </div>
 
       {/* Candidate Summary */}
       {script.candidate_summary && (
-        <div className="bg-white rounded-lg shadow p-4">
-          <h2 className="text-lg font-semibold text-gray-800 mb-2">{t('candidate_summary')}</h2>
-          <p className="text-sm text-gray-600">
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="mb-3 flex items-center gap-2">
+            <svg className="h-5 w-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+            <h2 className="text-lg font-semibold text-gray-900">{t('candidate_summary')}</h2>
+          </div>
+          <p className="text-sm leading-relaxed text-gray-600">
             {typeof script.candidate_summary === 'string'
               ? script.candidate_summary
               : JSON.stringify(script.candidate_summary, null, 2)}
@@ -105,53 +176,92 @@ export function ResultPage() {
       )}
 
       {/* Category tabs */}
-      <div className="flex gap-2 flex-wrap no-print">
-        {CATEGORY_KEYS.map((cat) => (
-          <button
-            key={cat.key}
-            onClick={() => setActiveCategory(cat.key)}
-            className={`px-3 py-1 rounded-full text-sm font-medium ${
-              activeCategory === cat.key
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-            }`}
-          >
-            {t(cat.i18n)}
-            <span className="ml-1 text-xs">
-              ({cat.key === 'all'
-                ? questions.length
-                : questions.filter((q) => q.category === cat.key).length})
-            </span>
-          </button>
-        ))}
+      <div className="flex flex-wrap gap-2 no-print">
+        {CATEGORY_KEYS.map((cat) => {
+          const count = cat.key === 'all'
+            ? questions.length
+            : questions.filter((q) => q.category === cat.key).length
+          const isActive = activeCategory === cat.key
+
+          return (
+            <button
+              key={cat.key}
+              onClick={() => setActiveCategory(cat.key)}
+              className={`inline-flex items-center gap-1.5 rounded-full px-4 py-2 text-sm font-medium transition-all ${
+                isActive
+                  ? 'bg-indigo-600 text-white shadow-md'
+                  : cat.color
+              }`}
+            >
+              {t(cat.i18n)}
+              <span className={`rounded-full px-1.5 py-0.5 text-xs ${
+                isActive ? 'bg-white/20' : 'bg-black/5'
+              }`}>
+                {count}
+              </span>
+            </button>
+          )
+        })}
       </div>
 
       {/* Questions */}
-      <div className="space-y-3">
-        {filtered.map((q, i) => (
-          <QuestionCard
-            key={i}
-            question={q}
-            index={i}
-            onScoreChange={handleScoreChange}
-          />
-        ))}
+      <div className="space-y-4">
+        {filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-gray-50 py-12">
+            <svg className="h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            <p className="mt-3 text-sm text-gray-500">이 카테고리에 해당하는 질문이 없습니다</p>
+          </div>
+        ) : (
+          filtered.map((q, i) => (
+            <QuestionCard
+              key={i}
+              question={q}
+              index={i}
+              onScoreChange={handleScoreChange}
+            />
+          ))
+        )}
       </div>
 
       {/* Glossary */}
       {script.full_glossary && script.full_glossary.length > 0 && (
-        <div className="bg-white rounded-lg shadow p-4">
-          <h2 className="text-lg font-semibold text-gray-800 mb-2">{t('glossary')}</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="mb-4 flex items-center gap-2">
+            <svg className="h-5 w-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+            </svg>
+            <h2 className="text-lg font-semibold text-gray-900">{t('glossary')}</h2>
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+              {script.full_glossary.length}개 용어
+            </span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
             {script.full_glossary.map((term, i) => (
-              <div key={i} className="text-sm">
-                <strong className="text-gray-800">{term.term}</strong>:{' '}
-                <span className="text-gray-600">{term.plain_language_explanation || term.definition}</span>
+              <div key={i} className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                <dt className="text-sm font-semibold text-gray-900">{term.term}</dt>
+                <dd className="mt-1 text-sm text-gray-600">
+                  {term.plain_language_explanation || term.definition}
+                </dd>
               </div>
             ))}
           </div>
         </div>
       )}
+
+      {/* Back to list link */}
+      <div className="flex justify-center pt-4 no-print">
+        <Link
+          to="/jobs"
+          className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 hover:text-gray-700"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          목록으로 돌아가기
+        </Link>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **UI/UX 전면 개선**: LoginPage, Navbar, JobListPage, JobStatusPage, ResultPage 모던 디자인 적용
- **폼 필드 간소화**: GitHub 복수 레포 → 단일 Git URL, focus_areas 필드 제거
- **라우팅 개선**: 로그인 상태에서 /login 접근 시 자동 리다이렉트

## Changes

### UI 개선
| 컴포넌트 | 변경사항 |
|---------|---------|
| LoginPage | 카드 기반 OAuth UI, Google/GitHub 아이콘, 기능 체크리스트 |
| Navbar | 그라데이션 로고, sticky backdrop-blur 헤더, 아바타 표시 |
| JobListPage | StatusBadge, EmptyState, LoadingSkeleton 컴포넌트 |
| JobStatusPage | PhaseIcon, TimelineStep 8단계 진행 시각화 |
| ResultPage | 카테고리별 컬러 탭, 용어집 카드 그리드 |

### 폼 필드 변경
- `github_urls[]` → `git_url` (단일 필드, 백엔드에서 레포 자동 추출)
- `focus_areas` 필드 제거 (JD 기반 자동 생성 예정)

### i18n
- "Job" → "면접 스크립트" 용어 전체 변경
- 새 번역 키: `login_subtitle`, `login_feature_*`, `git_url`, `git_url_hint`

## Test plan
- [x] 빌드 성공 확인
- [ ] 로그인 페이지 UI 확인
- [ ] 로그인 후 /jobs 리다이렉트 확인
- [ ] 새 스크립트 생성 폼 확인
- [ ] 반응형 레이아웃 확인

## Breaking Changes
- API 요청 시 `github_urls` 대신 `git_url` 사용 (백엔드 수정 필요)
- `focus_areas` 필드 미전송 (백엔드에서 자동 생성 로직 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)