### PR TITLE
refactor: InputData github_urls → git_url 단일 필드로 변경

### DIFF
--- a/backend/app/models/input.py
+++ b/backend/app/models/input.py
@@ -31,7 +31,7 @@ class InputData(BaseModel):
     linkedin_url: str | None = Field(None, description="LinkedIn 프로필 URL")
 
     # GitHub
-    github_urls: list[HttpUrl] = Field(default_factory=list, description="GitHub 레포 URL 목록")
+    git_url: str | None = Field(None, description="GitHub 프로필 또는 레포지토리 URL (레포는 자동 추출)")
     candidate_github_username: str | None = Field(None, description="후보자 GitHub 사용자명")
 
     # JD

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -66,6 +66,58 @@ class GitHubService:
             logger.warning(f"Failed to get languages for {url}: {e}")
             return {}
 
+    async def get_user_repos(self, profile_url: str, max_repos: int = 10) -> list[str]:
+        """
+        GitHub 프로필 URL에서 사용자의 레포지토리 목록 가져오기
+
+        Args:
+            profile_url: GitHub 프로필 URL (e.g., https://github.com/username)
+            max_repos: 최대 가져올 레포 수 (기본 10개)
+
+        Returns:
+            레포지토리 URL 목록
+        """
+        import httpx
+
+        # 프로필 URL에서 username 추출
+        match = re.match(r'https?://github\.com/([\w\-]+)/?$', profile_url)
+        if not match:
+            logger.warning(f"Invalid GitHub profile URL: {profile_url}")
+            return []
+
+        username = match.group(1)
+
+        # 먼저 PyGithub 시도
+        try:
+            g = self._get_github()
+            user = g.get_user(username)
+            repos = []
+            for repo in user.get_repos(sort="pushed")[:max_repos]:
+                if not repo.fork:  # fork된 레포 제외
+                    repos.append(repo.html_url)
+            return repos
+        except Exception as e:
+            logger.warning(f"PyGithub failed for user repos {username}: {e}, trying unauthenticated...")
+
+        # Fallback: 인증 없이 공개 API 직접 호출
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"https://api.github.com/users/{username}/repos",
+                    headers={"Accept": "application/vnd.github.v3+json"},
+                    params={"sort": "pushed", "per_page": max_repos},
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    return [
+                        repo["html_url"] for repo in data
+                        if not repo.get("fork", False)
+                    ]
+        except Exception as e2:
+            logger.warning(f"Unauthenticated repos request also failed for {username}: {e2}")
+
+        return []
+
     async def filter_repos_by_language(
         self,
         github_urls: list[str],

--- a/backend/app/workflows/activities/input_enrichment.py
+++ b/backend/app/workflows/activities/input_enrichment.py
@@ -77,10 +77,31 @@ async def enrich_input(input_data: dict) -> dict:
             logger.warning(f"Cover letter 파싱 실패 (계속 진행): {e}")
             document_errors.append({"source": "cover_letter", "error": str(e)})
 
-    # 4. 직접 입력된 URL 병합
-    for url in input_data.get("github_urls", []):
-        extracted_urls["github"].add(str(url))
-        extraction_sources.setdefault("github_urls", []).append("user_input")
+    # 4. 직접 입력된 URL 병합 (git_url 필드 지원)
+    git_url = input_data.get("git_url")
+    if git_url:
+        git_url = str(git_url).strip()
+        # GitHub 프로필 URL인지 레포 URL인지 확인
+        if _is_github_profile_url(git_url):
+            # 프로필 URL이면 레포 목록을 가져옴
+            activity.heartbeat(f"Fetching repos from GitHub profile: {git_url}...")
+            try:
+                from app.services.github_service import GitHubService
+                github_svc = GitHubService()
+                profile_repos = await github_svc.get_user_repos(git_url)
+                for repo_url in profile_repos:
+                    extracted_urls["github"].add(repo_url)
+                    extraction_sources.setdefault("github_urls", []).append("git_url_profile")
+            except Exception as e:
+                logger.warning(f"Failed to fetch repos from profile {git_url}: {e}")
+                # 프로필 URL에서 username만 추출해서 저장
+                username = _extract_username_from_profile_url(git_url)
+                if username:
+                    input_data["candidate_github_username"] = username
+        elif _is_github_repo_url(git_url):
+            # 레포 URL이면 직접 추가
+            extracted_urls["github"].add(git_url)
+            extraction_sources.setdefault("github_urls", []).append("git_url_repo")
 
     linkedin_url = (
         input_data.get("linkedin_url")
@@ -173,4 +194,22 @@ def _extract_urls(text: str) -> dict[str, list[str]]:
 def _extract_github_username(github_url: str) -> str | None:
     """GitHub URL에서 username 추출"""
     match = re.match(r'https?://github\.com/([\w\-]+)/[\w\-\.]+', github_url)
+    return match.group(1) if match else None
+
+
+def _is_github_profile_url(url: str) -> bool:
+    """GitHub 프로필 URL인지 확인 (https://github.com/username)"""
+    pattern = r'^https?://github\.com/[\w\-]+/?$'
+    return bool(re.match(pattern, url))
+
+
+def _is_github_repo_url(url: str) -> bool:
+    """GitHub 레포지토리 URL인지 확인 (https://github.com/owner/repo)"""
+    pattern = r'^https?://github\.com/[\w\-]+/[\w\-\.]+/?$'
+    return bool(re.match(pattern, url))
+
+
+def _extract_username_from_profile_url(url: str) -> str | None:
+    """GitHub 프로필 URL에서 username 추출"""
+    match = re.match(r'https?://github\.com/([\w\-]+)/?$', url)
     return match.group(1) if match else None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -41,7 +41,7 @@ def sample_input_data(sample_jd_text):
         "resume_path": None,
         "portfolio_path": None,
         "linkedin_url": "https://www.linkedin.com/in/test-user",
-        "github_urls": [],
+        "git_url": None,
         "candidate_github_username": None,
         "jd_text": sample_jd_text,
         "experience_level": "시니어",

--- a/backend/tests/test_input_enrichment.py
+++ b/backend/tests/test_input_enrichment.py
@@ -353,7 +353,7 @@ class TestAvailableAnalysesDecision:
             "portfolio_path": None,
             "cover_letter_path": None,
             "linkedin_url": None,
-            "github_urls": [],
+            "git_url": None,
         }
 
         with patch("app.workflows.activities.input_enrichment.activity") as mock_activity:
@@ -377,7 +377,7 @@ class TestAvailableAnalysesDecision:
             "portfolio_path": None,
             "cover_letter_path": None,
             "linkedin_url": None,
-            "github_urls": ["https://github.com/user/repo"],  # GitHub 있음
+            "git_url": "https://github.com/user/repo",  # GitHub 있음 (단일 URL)
         }
 
         # Mock 설정
@@ -417,7 +417,7 @@ class TestAvailableAnalysesDecision:
 
         input_data = {
             "jd_text": "Test JD",
-            "github_urls": ["https://github.com/org/repo"],  # 조직 레포만
+            "git_url": "https://github.com/org/repo",  # 조직 레포만
         }
 
         async def mock_infer_username(github_urls, candidate_name=None):
@@ -513,6 +513,70 @@ class TestGracefulDocumentParsingFailure:
             assert len(result.get("document_errors", [])) == 3
             # JD 분석은 여전히 가능
             assert "jd_analysis" in result["available_analyses"]
+
+
+# ============================================================
+# P0-08: git_url 필드 처리
+# ============================================================
+
+class TestGitUrlFieldHandling:
+    """P0-08: git_url 필드 처리 테스트 (프로필 URL vs 레포 URL)"""
+
+    def test_is_github_profile_url(self):
+        """GitHub 프로필 URL 감지"""
+        from app.workflows.activities.input_enrichment import _is_github_profile_url
+
+        assert _is_github_profile_url("https://github.com/username")
+        assert _is_github_profile_url("https://github.com/username/")
+        assert not _is_github_profile_url("https://github.com/username/repo")
+        assert not _is_github_profile_url("https://github.com")
+
+    def test_is_github_repo_url(self):
+        """GitHub 레포 URL 감지"""
+        from app.workflows.activities.input_enrichment import _is_github_repo_url
+
+        assert _is_github_repo_url("https://github.com/username/repo")
+        assert _is_github_repo_url("https://github.com/username/repo/")
+        assert not _is_github_repo_url("https://github.com/username")
+        assert not _is_github_repo_url("https://github.com")
+
+    def test_extract_username_from_profile_url(self):
+        """프로필 URL에서 username 추출"""
+        from app.workflows.activities.input_enrichment import _extract_username_from_profile_url
+
+        assert _extract_username_from_profile_url("https://github.com/testuser") == "testuser"
+        assert _extract_username_from_profile_url("https://github.com/testuser/") == "testuser"
+        assert _extract_username_from_profile_url("https://github.com/test-user") == "test-user"
+        assert _extract_username_from_profile_url("https://github.com/user/repo") is None
+
+    @pytest.mark.asyncio
+    async def test_git_url_repo_adds_to_extracted(self):
+        """git_url이 레포 URL이면 extracted_urls에 추가"""
+        from app.workflows.activities.input_enrichment import enrich_input
+        from unittest.mock import patch, MagicMock
+
+        input_data = {
+            "jd_text": "Test JD",
+            "git_url": "https://github.com/user/project",
+        }
+
+        async def mock_infer_username(github_urls, candidate_name=None):
+            return {
+                "username": "user",
+                "confidence": "high",
+                "personal_repos": github_urls,
+                "skipped_org_repos": [],
+            }
+
+        with patch("app.workflows.activities.input_enrichment.activity") as mock_activity, \
+             patch("app.services.github_service.GitHubService.infer_candidate_username", side_effect=mock_infer_username):
+
+            mock_activity.heartbeat = MagicMock()
+
+            result = await enrich_input(input_data)
+
+            assert "https://github.com/user/project" in result["all_extracted_github_urls"]
+            assert "git_url_repo" in result["extraction_sources"].get("github_urls", [])
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
프론트엔드 폼 간소화(#51)에 맞춰 백엔드 입력 모델을 수정합니다.

- `InputData.github_urls` (list) → `git_url` (str|None)로 변경
- GitHub 프로필 URL과 레포 URL을 자동으로 감지하여 처리
- 프로필 URL 입력 시 사용자의 레포 목록을 자동으로 추출

## Changes
- **backend/app/models/input.py**: `github_urls` 필드 제거, `git_url` 필드 추가
- **backend/app/services/github_service.py**: `get_user_repos()` 메서드 추가
- **backend/app/workflows/activities/input_enrichment.py**: `git_url` 처리 로직 및 헬퍼 함수 추가
- **backend/tests/**: 관련 테스트 업데이트 및 P0-08 테스트 케이스 추가

## Test plan
- [x] InputData 모델 검증 (`git_url` 필드 정상 동작)
- [x] 헬퍼 함수 단위 테스트 (`_is_github_profile_url`, `_is_github_repo_url`, `_extract_username_from_profile_url`)
- [x] `GitHubService.get_user_repos()` 실제 API 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)