### PR TITLE
feat: 파일 업로드 크기 제한 50MB로 증가

### DIFF
--- a/backend/app/api/routes/upload.py
+++ b/backend/app/api/routes/upload.py
@@ -23,7 +23,7 @@ ALLOWED_EXTENSIONS = {
     "cover_letter": [".pdf", ".docx"],
 }
 
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50MB
 
 
 class UploadResponse(BaseModel):

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # 파일 업로드 크기 제한 (50MB × 3파일 = 150MB)
+    client_max_body_size 150m;
+
     # SPA 라우팅: 모든 요청을 index.html로 리다이렉트
     location / {
         try_files $uri $uri/ /index.html;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,6 +10,9 @@ server {
     listen 80;
     server_name test.mystery-place.com;
 
+    # 파일 업로드 크기 제한 (50MB × 3파일 = 150MB)
+    client_max_body_size 150m;
+
     # Frontend OAuth callback (SPA route)
     location /auth/callback {
         proxy_pass http://frontend;


### PR DESCRIPTION
## 요약
- 이력서, 포트폴리오, 커버레터 파일 업로드 크기 제한을 50MB로 증가
- 기존 10MB 제한으로 인한 대용량 PDF 업로드 실패 문제 해결

## 변경 사항
| 파일 | 변경 내용 |
|------|----------|
| `backend/app/api/routes/upload.py` | `MAX_FILE_SIZE` 10MB → 50MB |
| `nginx/nginx.conf` | `client_max_body_size 150m` 추가 (게이트웨이) |
| `frontend/nginx.conf` | `client_max_body_size 150m` 추가 (SPA 서버) |

## 설정 값
- 단일 파일 최대: **50MB**
- Nginx 요청 최대: **150MB** (50MB × 3파일)

## 테스트 계획
- [ ] 50MB PDF 파일 업로드 테스트
- [ ] 여러 파일 동시 업로드 테스트
- [ ] 50MB 초과 파일 업로드 시 에러 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)