### PR TITLE
feat: WebSocket 지원 추가 및 ResultPage UI 전면 개선

### DIFF
--- a/frontend/src/components/QuestionCard.tsx
+++ b/frontend/src/components/QuestionCard.tsx
@@ -1,10 +1,21 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+// Backend returns this structure from finalization
 export interface Question {
-  question_text: string
-  category: string
-  difficulty: string
+  // New backend structure (finalization output)
+  revised_question?: string
+  original_question?: string
+  revision_type?: string
+  revision_rationale?: string
+  new_confidence_score?: number
+  new_evidence_reference?: string
+  original_index?: number
+
+  // Legacy fields (for backwards compatibility)
+  question_text?: string
+  category?: string
+  difficulty?: string
   alternative_phrasings?: string[]
   expected_answer?: Record<string, unknown>
   evaluation_scenarios?: Array<Record<string, unknown>>
@@ -21,11 +32,47 @@ interface QuestionCardProps {
   onScoreChange?: (index: number, score: number) => void
 }
 
+function getConfidenceColor(confidence?: number): string {
+  if (!confidence) return 'text-gray-600'
+  if (confidence >= 0.9) return 'text-green-600'
+  if (confidence >= 0.7) return 'text-blue-600'
+  if (confidence >= 0.5) return 'text-yellow-600'
+  return 'text-red-600'
+}
+
+function getConfidenceLabel(confidence?: number): string {
+  if (!confidence) return ''
+  if (confidence >= 0.9) return 'High'
+  if (confidence >= 0.7) return 'Medium'
+  if (confidence >= 0.5) return 'Low'
+  return 'Very Low'
+}
+
+function getRevisionTypeBadge(type?: string): { color: string; label: string } | null {
+  if (!type) return null
+  const badges: Record<string, { color: string; label: string }> = {
+    'duplicate_merge': { color: 'bg-purple-100 text-purple-700', label: '중복 병합' },
+    'clarity_fix': { color: 'bg-blue-100 text-blue-700', label: '명확성 개선' },
+    'hallucination_fix': { color: 'bg-red-100 text-red-700', label: '환각 수정' },
+    'evidence_improvement': { color: 'bg-green-100 text-green-700', label: '근거 강화' },
+    'scope_adjustment': { color: 'bg-amber-100 text-amber-700', label: '범위 조정' },
+  }
+  return badges[type] || { color: 'bg-gray-100 text-gray-700', label: type }
+}
+
 export function QuestionCard({ question, index, onScoreChange }: QuestionCardProps) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const [score, setScore] = useState<number | null>(null)
 
+  // Get question text from either new or legacy structure
+  const questionText = question.revised_question || question.question_text || ''
+  const confidence = question.new_confidence_score
+  const confidenceColor = getConfidenceColor(confidence)
+  const confidenceLabel = getConfidenceLabel(confidence)
+  const revisionBadge = getRevisionTypeBadge(question.revision_type)
+
+  // Legacy difficulty support
   const difficultyColor =
     question.difficulty === 'Hard' ? 'text-red-600' :
     question.difficulty === 'Medium' ? 'text-yellow-600' : 'text-green-600'
@@ -36,94 +83,163 @@ export function QuestionCard({ question, index, onScoreChange }: QuestionCardPro
   }
 
   return (
-    <div className="bg-white rounded-lg shadow border border-gray-200 overflow-hidden">
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-md transition-shadow">
       <button
         type="button"
-        className="w-full p-4 cursor-pointer flex items-center justify-between hover:bg-gray-50 text-left"
+        className="w-full p-5 cursor-pointer flex items-start justify-between hover:bg-gray-50 text-left gap-4"
         onClick={() => setExpanded(!expanded)}
         aria-expanded={expanded}
         aria-controls={`question-${index}-details`}
       >
-        <div className="flex-1">
-          <span className="text-sm text-gray-500 mr-2">Q{index + 1}</span>
-          <span className={`text-xs font-medium mr-2 ${difficultyColor}`}>
-            {question.difficulty}
-          </span>
-          <span className="text-gray-900">{question.question_text}</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2 flex-wrap">
+            <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-indigo-100 text-indigo-700 text-sm font-semibold">
+              {index + 1}
+            </span>
+
+            {/* Revision type badge */}
+            {revisionBadge && (
+              <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${revisionBadge.color}`}>
+                {revisionBadge.label}
+              </span>
+            )}
+
+            {/* Confidence score */}
+            {confidence !== undefined && (
+              <span className={`text-xs font-medium ${confidenceColor}`}>
+                {confidenceLabel} ({Math.round(confidence * 100)}%)
+              </span>
+            )}
+
+            {/* Legacy difficulty */}
+            {question.difficulty && (
+              <span className={`text-xs font-medium ${difficultyColor}`}>
+                {question.difficulty}
+              </span>
+            )}
+          </div>
+
+          <p className="text-gray-900 leading-relaxed">{questionText}</p>
         </div>
-        <div className="flex items-center gap-2">
+
+        <div className="flex items-center gap-2 flex-shrink-0">
           {question.time_allocation_minutes && (
-            <span className="text-xs text-gray-400">{question.time_allocation_minutes}{t('minutes')}</span>
+            <span className="text-xs text-gray-400 whitespace-nowrap">
+              {question.time_allocation_minutes}{t('minutes')}
+            </span>
           )}
-          <span className="text-gray-400" aria-hidden="true">{expanded ? '▲' : '▼'}</span>
+          <span className={`text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`} aria-hidden="true">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </span>
         </div>
       </button>
 
       {expanded && (
-        <div id={`question-${index}-details`} className="px-4 pb-4 space-y-3 border-t border-gray-100" role="region" aria-label={`Q${index + 1} ${t('expected_answer')}`}>
+        <div id={`question-${index}-details`} className="px-5 pb-5 space-y-4 border-t border-gray-100" role="region" aria-label={`Q${index + 1} ${t('details')}`}>
+
+          {/* Original question (if revised) */}
+          {question.original_question && question.original_question !== questionText && (
+            <div className="mt-3 p-3 rounded-lg bg-gray-50 border border-gray-200">
+              <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">원본 질문</h4>
+              <p className="text-sm text-gray-600">{question.original_question}</p>
+            </div>
+          )}
+
+          {/* Revision rationale */}
+          {question.revision_rationale && (
+            <div className="p-3 rounded-lg bg-blue-50 border border-blue-200">
+              <h4 className="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1">수정 이유</h4>
+              <p className="text-sm text-blue-800">{question.revision_rationale}</p>
+            </div>
+          )}
+
+          {/* Evidence reference */}
+          {question.new_evidence_reference && (
+            <div className="p-3 rounded-lg bg-green-50 border border-green-200">
+              <h4 className="text-xs font-semibold text-green-700 uppercase tracking-wide mb-1">근거</h4>
+              <p className="text-sm text-green-800">{question.new_evidence_reference}</p>
+            </div>
+          )}
+
+          {/* Legacy: Expected answer */}
           {question.expected_answer && (
-            <div className="mt-3">
-              <h4 className="text-sm font-semibold text-gray-700 mb-1">{t('expected_answer')}</h4>
+            <div>
+              <h4 className="text-sm font-semibold text-gray-700 mb-2">{t('expected_answer')}</h4>
               {Object.entries(question.expected_answer).map(([level, answer]) => (
-                <div key={level} className={`text-sm p-2 rounded mb-1 ${
-                  level === 'expert' ? 'bg-green-50 text-green-800' :
-                  level === 'mid_level' ? 'bg-yellow-50 text-yellow-800' :
-                  'bg-red-50 text-red-800'
+                <div key={level} className={`text-sm p-3 rounded-lg mb-2 ${
+                  level === 'expert' ? 'bg-green-50 text-green-800 border border-green-200' :
+                  level === 'mid_level' ? 'bg-yellow-50 text-yellow-800 border border-yellow-200' :
+                  'bg-red-50 text-red-800 border border-red-200'
                 }`}>
-                  <strong>{level}:</strong> {String(answer)}
+                  <strong className="capitalize">{level.replace('_', ' ')}:</strong> {String(answer)}
                 </div>
               ))}
             </div>
           )}
 
+          {/* Legacy: Follow-up questions */}
           {question.follow_up_questions && question.follow_up_questions.length > 0 && (
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-1">{t('follow_up')}</h4>
-              {question.follow_up_questions.map((fq, i) => (
-                <p key={i} className="text-sm text-gray-600 ml-2">
-                  → {typeof fq === 'string' ? fq : String((fq as Record<string, unknown>).question || JSON.stringify(fq))}
-                </p>
-              ))}
+              <h4 className="text-sm font-semibold text-gray-700 mb-2">{t('follow_up')}</h4>
+              <div className="space-y-1">
+                {question.follow_up_questions.map((fq, i) => (
+                  <p key={i} className="text-sm text-gray-600 pl-4 border-l-2 border-gray-200">
+                    {typeof fq === 'string' ? fq : String((fq as Record<string, unknown>).question || JSON.stringify(fq))}
+                  </p>
+                ))}
+              </div>
             </div>
           )}
 
+          {/* Legacy: Terminology */}
           {question.terminology && question.terminology.length > 0 && (
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-1">{t('terminology')}</h4>
-              {question.terminology.map((term, i) => (
-                <div key={i} className="text-sm text-gray-600 ml-2">
-                  <strong>{term.term}</strong>: {term.plain_language_explanation || term.definition}
-                </div>
+              <h4 className="text-sm font-semibold text-gray-700 mb-2">{t('terminology')}</h4>
+              <div className="grid gap-2">
+                {question.terminology.map((term, i) => (
+                  <div key={i} className="text-sm p-2 rounded bg-amber-50 border border-amber-200">
+                    <strong className="text-amber-800">{term.term}</strong>
+                    <span className="text-amber-700">: {term.plain_language_explanation || term.definition}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Legacy: Interviewer note */}
+          {question.interviewer_note && (
+            <div className="p-3 rounded-lg bg-indigo-50 border border-indigo-200">
+              <h4 className="text-xs font-semibold text-indigo-700 uppercase tracking-wide mb-1">{t('interviewer_note')}</h4>
+              <p className="text-sm text-indigo-800">
+                {typeof question.interviewer_note === 'string'
+                  ? question.interviewer_note
+                  : JSON.stringify(question.interviewer_note)}
+              </p>
+            </div>
+          )}
+
+          {/* Scoring */}
+          <div className="flex items-center gap-3 pt-3 border-t border-gray-100 no-print">
+            <span className="text-sm font-medium text-gray-600">{t('scoring')}:</span>
+            <div className="flex gap-1">
+              {[1, 2, 3, 4, 5].map((s) => (
+                <button
+                  key={s}
+                  onClick={() => handleScore(s)}
+                  aria-label={`${t('scoring')} ${s}/5`}
+                  aria-pressed={score === s}
+                  className={`w-9 h-9 rounded-lg text-sm font-semibold border-2 transition-all ${
+                    score === s
+                      ? 'bg-indigo-600 text-white border-indigo-600 shadow-md'
+                      : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-400 hover:text-indigo-600'
+                  }`}
+                >
+                  {s}
+                </button>
               ))}
             </div>
-          )}
-
-          {question.interviewer_note && (
-            <div className="bg-blue-50 p-2 rounded text-sm text-blue-800">
-              <strong>{t('interviewer_note')}:</strong>{' '}
-              {typeof question.interviewer_note === 'string'
-                ? question.interviewer_note
-                : JSON.stringify(question.interviewer_note)}
-            </div>
-          )}
-
-          <div className="flex items-center gap-2 pt-2 no-print">
-            <span className="text-sm text-gray-600">{t('scoring')}:</span>
-            {[1, 2, 3, 4, 5].map((s) => (
-              <button
-                key={s}
-                onClick={() => handleScore(s)}
-                aria-label={`${t('scoring')} ${s}/5`}
-                aria-pressed={score === s}
-                className={`w-8 h-8 rounded-full text-sm font-medium border ${
-                  score === s
-                    ? 'bg-blue-600 text-white border-blue-600'
-                    : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
-                }`}
-              >
-                {s}
-              </button>
-            ))}
           </div>
         </div>
       )}

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -14,28 +14,101 @@ function downloadJSON(data: unknown, filename: string) {
   URL.revokeObjectURL(url)
 }
 
-const CATEGORY_KEYS = [
-  { key: 'all', i18n: 'cat_all', color: 'bg-gray-100 text-gray-700 hover:bg-gray-200' },
-  { key: 'role_fit', i18n: 'cat_role_fit', color: 'bg-blue-100 text-blue-700 hover:bg-blue-200' },
-  { key: 'technical_depth', i18n: 'cat_technical_depth', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200' },
-  { key: 'execution_ownership', i18n: 'cat_execution_ownership', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200' },
-  { key: 'communication', i18n: 'cat_communication', color: 'bg-green-100 text-green-700 hover:bg-green-200' },
-  { key: 'risk_flags', i18n: 'cat_risk_flags', color: 'bg-red-100 text-red-700 hover:bg-red-200' },
-]
+interface CandidateSummary {
+  candidate_overview?: {
+    name?: string
+    current_position?: string
+    primary_domain?: string
+    experience_years?: string
+    confidence_level?: string
+  }
+  key_strengths?: Array<{
+    strength: string
+    confidence: number
+    evidence?: Record<string, string | null>
+  }>
+  risk_flags?: Array<{
+    concern: string
+    severity: string
+    evidence?: string
+    mitigation_question?: string
+  }>
+  technical_expertise?: {
+    languages?: Array<{ skill: string; proficiency: string; confidence: number }>
+    frameworks?: Array<{ skill: string; proficiency: string; confidence: number }>
+    tools?: Array<{ tool: string; proficiency: string; confidence: number }>
+  }
+  notable_achievements?: Array<{
+    achievement: string
+    source: string
+    details?: string
+  }>
+  data_quality_assessment?: {
+    overall_confidence: number
+    document_quality: number
+    linkedin_quality: number
+    github_quality: number
+    recommendations?: string[]
+  }
+}
+
+interface InterviewerGuide {
+  interview_overview?: {
+    total_duration_minutes: number
+    question_count: number
+    experience_level: string
+    interview_style: string
+  }
+  interview_flow?: {
+    opening?: { script: string; duration_minutes: number }
+    main_body?: { recommended_order: string[]; transition_phrases: string[] }
+    closing?: { script: string; duration_minutes: number }
+  }
+  category_breakdown?: Array<{
+    category: string
+    question_count: number
+    time_allocation_minutes: number
+    evaluation_priority: string
+    focus_areas: string[]
+  }>
+  evaluation_matrix?: {
+    scoring_scale: string
+    passing_threshold: number
+    strong_hire_threshold: number
+    category_weights: Record<string, number>
+  }
+  red_flags_summary?: string[]
+  green_flags_summary?: string[]
+}
 
 interface InterviewScript {
-  candidate_summary: string | Record<string, unknown> | null
+  metadata?: {
+    language?: string
+    total_questions?: number
+    experience_level?: string
+    has_linkedin_data?: boolean
+  }
   questions: Question[]
-  interviewer_guide: string | Record<string, unknown> | null
-  full_glossary: Array<Record<string, string>>
-  metadata: Record<string, unknown>
+  candidate_summary?: CandidateSummary
+  interviewer_guide?: InterviewerGuide
+  decision_guide?: Record<string, unknown>
+  full_glossary?: Array<Record<string, string>>
+  linkedin_profile?: {
+    name?: string
+    headline?: string
+    current_company?: string
+    profile_url?: string
+    projects?: Array<{ title: string; description?: string }>
+    honors_and_awards?: Array<{ title: string; issuer?: string; description?: string }>
+  }
+  generated_at?: string
 }
 
 export function ResultPage() {
   const { t } = useTranslation()
   const { jobId } = useParams<{ jobId: string }>()
   const [script, setScript] = useState<InterviewScript | null>(null)
-  const [activeCategory, setActiveCategory] = useState('all')
+  const [activeTab, setActiveTab] = useState<'questions' | 'summary' | 'guide'>('questions')
   const [scores, setScores] = useState<Record<number, number>>({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -93,9 +166,8 @@ export function ResultPage() {
   }
 
   const questions = script.questions || []
-  const filtered = activeCategory === 'all'
-    ? questions
-    : questions.filter((q) => q.category === activeCategory)
+  const summary = script.candidate_summary
+  const guide = script.interviewer_guide
 
   const handleScoreChange = (index: number, score: number) => {
     setScores((prev) => ({ ...prev, [index]: score }))
@@ -110,19 +182,30 @@ export function ResultPage() {
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-4">
-          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600">
-            <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-600 shadow-lg">
+            <svg className="h-7 w-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
             </svg>
           </div>
           <div>
             <h1 className="text-2xl font-bold text-gray-900">{t('interview_script')}</h1>
-            <p className="text-sm text-gray-500">#{jobId?.slice(0, 8)} · {questions.length}개 질문</p>
+            <div className="flex items-center gap-2 text-sm text-gray-500">
+              <span>#{jobId?.slice(0, 8)}</span>
+              <span>·</span>
+              <span>{questions.length}개 질문</span>
+              {script.metadata?.experience_level && (
+                <>
+                  <span>·</span>
+                  <span className="px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700 text-xs font-medium">
+                    {script.metadata.experience_level}
+                  </span>
+                </>
+              )}
+            </div>
           </div>
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
-          {/* Score display */}
           {maxScore > 0 && (
             <div className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2">
               <svg className="h-5 w-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -134,7 +217,6 @@ export function ResultPage() {
             </div>
           )}
 
-          {/* Action buttons */}
           <div className="flex gap-2 no-print">
             <button
               onClick={() => downloadJSON(script, `interview-${jobId?.slice(0, 8)}.json`)}
@@ -158,74 +240,403 @@ export function ResultPage() {
         </div>
       </div>
 
-      {/* Candidate Summary */}
-      {script.candidate_summary && (
-        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-          <div className="mb-3 flex items-center gap-2">
-            <svg className="h-5 w-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-            </svg>
-            <h2 className="text-lg font-semibold text-gray-900">{t('candidate_summary')}</h2>
-          </div>
-          <p className="text-sm leading-relaxed text-gray-600">
-            {typeof script.candidate_summary === 'string'
-              ? script.candidate_summary
-              : JSON.stringify(script.candidate_summary, null, 2)}
-          </p>
+      {/* Tab Navigation */}
+      <div className="flex gap-1 p-1 bg-gray-100 rounded-xl no-print">
+        <button
+          onClick={() => setActiveTab('questions')}
+          className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+            activeTab === 'questions'
+              ? 'bg-white text-indigo-700 shadow-sm'
+              : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          질문 목록 ({questions.length})
+        </button>
+        <button
+          onClick={() => setActiveTab('summary')}
+          className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+            activeTab === 'summary'
+              ? 'bg-white text-indigo-700 shadow-sm'
+              : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          후보자 분석
+        </button>
+        <button
+          onClick={() => setActiveTab('guide')}
+          className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+            activeTab === 'guide'
+              ? 'bg-white text-indigo-700 shadow-sm'
+              : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          면접관 가이드
+        </button>
+      </div>
+
+      {/* Questions Tab */}
+      {activeTab === 'questions' && (
+        <div className="space-y-4">
+          {questions.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-gray-50 py-12">
+              <svg className="h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <p className="mt-3 text-sm text-gray-500">생성된 질문이 없습니다</p>
+            </div>
+          ) : (
+            questions.map((q, i) => (
+              <QuestionCard
+                key={i}
+                question={q}
+                index={i}
+                onScoreChange={handleScoreChange}
+              />
+            ))
+          )}
         </div>
       )}
 
-      {/* Category tabs */}
-      <div className="flex flex-wrap gap-2 no-print">
-        {CATEGORY_KEYS.map((cat) => {
-          const count = cat.key === 'all'
-            ? questions.length
-            : questions.filter((q) => q.category === cat.key).length
-          const isActive = activeCategory === cat.key
+      {/* Candidate Summary Tab */}
+      {activeTab === 'summary' && summary && (
+        <div className="space-y-6">
+          {/* Candidate Overview */}
+          {summary.candidate_overview && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                <svg className="h-5 w-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                </svg>
+                후보자 개요
+              </h2>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {summary.candidate_overview.name && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">이름</dt>
+                    <dd className="mt-1 text-lg font-semibold text-gray-900">{summary.candidate_overview.name}</dd>
+                  </div>
+                )}
+                {summary.candidate_overview.current_position && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">현재 직책</dt>
+                    <dd className="mt-1 text-gray-900">{summary.candidate_overview.current_position}</dd>
+                  </div>
+                )}
+                {summary.candidate_overview.primary_domain && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">주요 도메인</dt>
+                    <dd className="mt-1 text-gray-900">{summary.candidate_overview.primary_domain}</dd>
+                  </div>
+                )}
+                {summary.candidate_overview.experience_years && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">경력</dt>
+                    <dd className="mt-1 text-gray-900">{summary.candidate_overview.experience_years}</dd>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
 
-          return (
-            <button
-              key={cat.key}
-              onClick={() => setActiveCategory(cat.key)}
-              className={`inline-flex items-center gap-1.5 rounded-full px-4 py-2 text-sm font-medium transition-all ${
-                isActive
-                  ? 'bg-indigo-600 text-white shadow-md'
-                  : cat.color
-              }`}
-            >
-              {t(cat.i18n)}
-              <span className={`rounded-full px-1.5 py-0.5 text-xs ${
-                isActive ? 'bg-white/20' : 'bg-black/5'
-              }`}>
-                {count}
-              </span>
-            </button>
-          )
-        })}
-      </div>
+          {/* Key Strengths */}
+          {summary.key_strengths && summary.key_strengths.length > 0 && (
+            <div className="rounded-xl border border-green-200 bg-green-50 p-6">
+              <h2 className="text-lg font-semibold text-green-900 mb-4 flex items-center gap-2">
+                <svg className="h-5 w-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                주요 강점
+              </h2>
+              <div className="space-y-3">
+                {summary.key_strengths.map((item, i) => (
+                  <div key={i} className="bg-white rounded-lg p-4 border border-green-200">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="font-medium text-green-900">{item.strength}</span>
+                      <span className="text-sm text-green-600">신뢰도: {Math.round(item.confidence * 100)}%</span>
+                    </div>
+                    {item.evidence && (
+                      <div className="text-sm text-green-700 space-y-1">
+                        {item.evidence.resume && <p>📄 이력서: {item.evidence.resume}</p>}
+                        {item.evidence.linkedin && <p>💼 LinkedIn: {item.evidence.linkedin}</p>}
+                        {item.evidence.github && <p>🔗 GitHub: {item.evidence.github}</p>}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
-      {/* Questions */}
-      <div className="space-y-4">
-        {filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-gray-50 py-12">
-            <svg className="h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-            <p className="mt-3 text-sm text-gray-500">이 카테고리에 해당하는 질문이 없습니다</p>
+          {/* Risk Flags */}
+          {summary.risk_flags && summary.risk_flags.length > 0 && (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+              <h2 className="text-lg font-semibold text-red-900 mb-4 flex items-center gap-2">
+                <svg className="h-5 w-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                위험 요소
+              </h2>
+              <div className="space-y-3">
+                {summary.risk_flags.map((item, i) => (
+                  <div key={i} className="bg-white rounded-lg p-4 border border-red-200">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="font-medium text-red-900">{item.concern}</span>
+                      <span className={`text-xs px-2 py-1 rounded-full ${
+                        item.severity === 'high' ? 'bg-red-200 text-red-800' :
+                        item.severity === 'medium' ? 'bg-yellow-200 text-yellow-800' :
+                        'bg-gray-200 text-gray-800'
+                      }`}>
+                        {item.severity}
+                      </span>
+                    </div>
+                    {item.evidence && <p className="text-sm text-red-700 mb-2">{item.evidence}</p>}
+                    {item.mitigation_question && (
+                      <p className="text-sm text-red-800 bg-red-100 p-2 rounded">
+                        💡 확인 질문: {item.mitigation_question}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Technical Expertise */}
+          {summary.technical_expertise && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                <svg className="h-5 w-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                </svg>
+                기술 역량
+              </h2>
+              <div className="space-y-4">
+                {summary.technical_expertise.languages && summary.technical_expertise.languages.length > 0 && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-500 mb-2">프로그래밍 언어</h3>
+                    <div className="flex flex-wrap gap-2">
+                      {summary.technical_expertise.languages.map((lang, i) => (
+                        <span key={i} className="px-3 py-1 rounded-full bg-purple-100 text-purple-700 text-sm">
+                          {lang.skill} ({lang.proficiency})
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {summary.technical_expertise.frameworks && summary.technical_expertise.frameworks.length > 0 && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-500 mb-2">프레임워크</h3>
+                    <div className="flex flex-wrap gap-2">
+                      {summary.technical_expertise.frameworks.map((fw, i) => (
+                        <span key={i} className="px-3 py-1 rounded-full bg-blue-100 text-blue-700 text-sm">
+                          {fw.skill} ({fw.proficiency})
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {summary.technical_expertise.tools && summary.technical_expertise.tools.length > 0 && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-500 mb-2">도구</h3>
+                    <div className="flex flex-wrap gap-2">
+                      {summary.technical_expertise.tools.map((tool, i) => (
+                        <span key={i} className="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
+                          {tool.tool} ({tool.proficiency})
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Data Quality Assessment */}
+          {summary.data_quality_assessment && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">데이터 품질 평가</h2>
+              <div className="grid gap-4 sm:grid-cols-4">
+                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                  <div className="text-2xl font-bold text-indigo-600">
+                    {Math.round(summary.data_quality_assessment.overall_confidence * 100)}%
+                  </div>
+                  <div className="text-sm text-gray-500">전체 신뢰도</div>
+                </div>
+                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                  <div className="text-2xl font-bold text-blue-600">
+                    {Math.round(summary.data_quality_assessment.document_quality * 100)}%
+                  </div>
+                  <div className="text-sm text-gray-500">문서 품질</div>
+                </div>
+                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                  <div className="text-2xl font-bold text-green-600">
+                    {Math.round(summary.data_quality_assessment.linkedin_quality * 100)}%
+                  </div>
+                  <div className="text-sm text-gray-500">LinkedIn</div>
+                </div>
+                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                  <div className="text-2xl font-bold text-purple-600">
+                    {Math.round(summary.data_quality_assessment.github_quality * 100)}%
+                  </div>
+                  <div className="text-sm text-gray-500">GitHub</div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Interviewer Guide Tab */}
+      {activeTab === 'guide' && guide && (
+        <div className="space-y-6">
+          {/* Interview Overview */}
+          {guide.interview_overview && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">면접 개요</h2>
+              <div className="grid gap-4 sm:grid-cols-4">
+                <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                  <div className="text-2xl font-bold text-indigo-600">
+                    {guide.interview_overview.total_duration_minutes}분
+                  </div>
+                  <div className="text-sm text-gray-500">총 소요시간</div>
+                </div>
+                <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                  <div className="text-2xl font-bold text-indigo-600">
+                    {guide.interview_overview.question_count}개
+                  </div>
+                  <div className="text-sm text-gray-500">질문 수</div>
+                </div>
+                <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                  <div className="text-lg font-bold text-indigo-600">
+                    {guide.interview_overview.experience_level}
+                  </div>
+                  <div className="text-sm text-gray-500">경력 수준</div>
+                </div>
+                <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                  <div className="text-lg font-bold text-indigo-600">
+                    {guide.interview_overview.interview_style}
+                  </div>
+                  <div className="text-sm text-gray-500">면접 스타일</div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Interview Flow */}
+          {guide.interview_flow && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">면접 진행 순서</h2>
+              <div className="space-y-4">
+                {guide.interview_flow.opening && (
+                  <div className="p-4 bg-green-50 rounded-lg border border-green-200">
+                    <h3 className="font-medium text-green-900 mb-2">
+                      🎬 오프닝 ({guide.interview_flow.opening.duration_minutes}분)
+                    </h3>
+                    <p className="text-sm text-green-800">{guide.interview_flow.opening.script}</p>
+                  </div>
+                )}
+                {guide.interview_flow.main_body && (
+                  <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
+                    <h3 className="font-medium text-blue-900 mb-2">📋 본 면접</h3>
+                    <p className="text-sm text-blue-800 mb-2">
+                      진행 순서: {guide.interview_flow.main_body.recommended_order?.join(' → ')}
+                    </p>
+                    {guide.interview_flow.main_body.transition_phrases && (
+                      <div className="text-sm text-blue-700">
+                        <p className="font-medium mb-1">전환 문구:</p>
+                        <ul className="list-disc list-inside">
+                          {guide.interview_flow.main_body.transition_phrases.map((phrase, i) => (
+                            <li key={i}>{phrase}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                )}
+                {guide.interview_flow.closing && (
+                  <div className="p-4 bg-amber-50 rounded-lg border border-amber-200">
+                    <h3 className="font-medium text-amber-900 mb-2">
+                      🏁 클로징 ({guide.interview_flow.closing.duration_minutes}분)
+                    </h3>
+                    <p className="text-sm text-amber-800">{guide.interview_flow.closing.script}</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Evaluation Matrix */}
+          {guide.evaluation_matrix && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">평가 기준</h2>
+              <div className="grid gap-4 sm:grid-cols-3 mb-4">
+                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                  <div className="text-lg font-bold text-gray-900">
+                    {guide.evaluation_matrix.scoring_scale}
+                  </div>
+                  <div className="text-sm text-gray-500">점수 범위</div>
+                </div>
+                <div className="text-center p-3 bg-green-50 rounded-lg">
+                  <div className="text-lg font-bold text-green-600">
+                    ≥ {guide.evaluation_matrix.passing_threshold}
+                  </div>
+                  <div className="text-sm text-gray-500">합격 기준</div>
+                </div>
+                <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                  <div className="text-lg font-bold text-indigo-600">
+                    ≥ {guide.evaluation_matrix.strong_hire_threshold}
+                  </div>
+                  <div className="text-sm text-gray-500">Strong Hire</div>
+                </div>
+              </div>
+              {guide.evaluation_matrix.category_weights && (
+                <div>
+                  <h3 className="text-sm font-medium text-gray-500 mb-2">카테고리별 가중치</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(guide.evaluation_matrix.category_weights).map(([cat, weight]) => (
+                      <span key={cat} className="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
+                        {cat}: {Math.round(Number(weight) * 100)}%
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Red/Green Flags */}
+          <div className="grid gap-6 sm:grid-cols-2">
+            {guide.green_flags_summary && guide.green_flags_summary.length > 0 && (
+              <div className="rounded-xl border border-green-200 bg-green-50 p-6">
+                <h2 className="text-lg font-semibold text-green-900 mb-3">✅ Green Flags</h2>
+                <ul className="space-y-2">
+                  {guide.green_flags_summary.map((flag, i) => (
+                    <li key={i} className="text-sm text-green-800 flex items-start gap-2">
+                      <span className="text-green-500">•</span>
+                      {flag}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {guide.red_flags_summary && guide.red_flags_summary.length > 0 && (
+              <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+                <h2 className="text-lg font-semibold text-red-900 mb-3">🚩 Red Flags</h2>
+                <ul className="space-y-2">
+                  {guide.red_flags_summary.map((flag, i) => (
+                    <li key={i} className="text-sm text-red-800 flex items-start gap-2">
+                      <span className="text-red-500">•</span>
+                      {flag}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
-        ) : (
-          filtered.map((q, i) => (
-            <QuestionCard
-              key={i}
-              question={q}
-              index={i}
-              onScoreChange={handleScoreChange}
-            />
-          ))
-        )}
-      </div>
+        </div>
+      )}
 
-      {/* Glossary */}
+      {/* Glossary (shown on all tabs) */}
       {script.full_glossary && script.full_glossary.length > 0 && (
         <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
           <div className="mb-4 flex items-center gap-2">

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -33,10 +33,15 @@ server {
 
     location /api {
         proxy_pass http://backend;
+        proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # WebSocket 지원
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
     }
 
     location /docs {


### PR DESCRIPTION
## 요약

- **nginx WebSocket 프록시 지원**: 실시간 Job 진행률 WebSocket 연결을 위한 nginx 설정 추가
- **QuestionCard 컴포넌트 개선**: 백엔드 finalization 출력 구조 완벽 지원
- **ResultPage 전면 개편**: 탭 기반 UI로 질문/후보자 분석/면접관 가이드 분리

## 상세 변경 사항

### 🔧 nginx/nginx.conf
- `/api` 경로에 WebSocket 업그레이드 헤더 추가
- `proxy_http_version 1.1` 설정
- `Upgrade`, `Connection` 헤더 설정
- `proxy_read_timeout 86400` (24시간 타임아웃)

### 🎨 frontend/src/components/QuestionCard.tsx
- `revised_question`, `revision_type`, `new_confidence_score` 등 새 필드 지원
- 신뢰도 점수 색상 코딩 (90%+: 녹색, 70%+: 파랑, 50%+: 노랑, 50%-: 빨강)
- 수정 유형 배지: 중복 병합, 명확성 개선, 환각 수정, 근거 강화, 범위 조정
- 원본 질문과 수정된 질문 비교 UI
- 수정 이유 및 근거 참조 표시

### 📊 frontend/src/pages/ResultPage.tsx
- **탭 네비게이션**: 질문 목록 / 후보자 분석 / 면접관 가이드
- **후보자 분석 탭**:
  - 후보자 개요 (이름, 직위, 요약)
  - 핵심 강점 (강점명, 설명, 신뢰도, 근거)
  - 위험 플래그 (위험 유형, 심각도, 완화 전략)
  - 기술 전문성 (언어, 프레임워크, 도구)
  - 데이터 품질 점수 (문서/LinkedIn/GitHub)
- **면접관 가이드 탭**:
  - 면접 스크립트 (오프닝, 클로징, 시간 배분)
  - 질문 흐름 및 전환 표현
  - 평가 매트릭스 (점수 척도, 합격/강력 합격 기준, 카테고리별 가중치)
  - 그린 플래그 / 레드 플래그 목록

## 테스트 계획

- [ ] WebSocket 연결 테스트 (`wss://test.mystery-place.com/api/v1/jobs/{id}/ws`)
- [ ] ResultPage 탭 전환 테스트
- [ ] 후보자 분석 데이터 렌더링 확인
- [ ] 면접관 가이드 데이터 렌더링 확인
- [ ] 레거시 데이터와의 하위 호환성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)