### PR TITLE
feat: Job별 분석 로그 저장 및 조회 기능

### DIFF
--- a/backend/alembic/versions/003_add_analysis_logs.py
+++ b/backend/alembic/versions/003_add_analysis_logs.py
@@ -1,0 +1,41 @@
+"""Add analysis_logs table for activity execution tracking.
+
+Revision ID: 003_analysis_logs
+Revises: 002_embeddings
+Create Date: 2026-02-05
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "003_analysis_logs"
+down_revision: Union[str, None] = "002_embeddings"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analysis_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("job_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("activity_name", sa.String(100), nullable=False),
+        sa.Column("phase", sa.String(50), nullable=False),
+        sa.Column("log_type", sa.String(20), nullable=False),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("data", postgresql.JSONB(), server_default="{}"),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("idx_analysis_logs_job", "analysis_logs", ["job_id"])
+    op.create_index("idx_analysis_logs_activity", "analysis_logs", ["activity_name"])
+    op.create_index("idx_analysis_logs_phase", "analysis_logs", ["phase"])
+    op.create_index("idx_analysis_logs_created", "analysis_logs", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("analysis_logs")

--- a/backend/app/api/routes/analysis_logs.py
+++ b/backend/app/api/routes/analysis_logs.py
@@ -1,0 +1,122 @@
+"""
+backend/app/api/routes/analysis_logs.py
+Analysis Logs API - 분석 로그 조회 엔드포인트
+"""
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, get_db
+from app.models.database import JobDB, UserDB
+from app.services.analysis_log_service import AnalysisLogService
+
+router = APIRouter(prefix="/api/v1/jobs", tags=["analysis-logs"])
+
+
+class AnalysisLogResponse(BaseModel):
+    """분석 로그 응답 모델."""
+    id: str
+    job_id: str
+    activity_name: str
+    phase: str
+    log_type: str
+    message: Optional[str]
+    data: dict
+    duration_ms: Optional[int]
+    created_at: str
+
+    class Config:
+        from_attributes = True
+
+
+class AnalysisSummaryResponse(BaseModel):
+    """분석 요약 응답 모델."""
+    job_id: str
+    total_logs: int
+    completed_activities: int
+    errors: int
+    total_duration_ms: int
+    total_duration_sec: float
+    phase_stats: dict
+    activity_stats: dict
+
+
+@router.get("/{job_id}/analysis-logs", response_model=list[AnalysisLogResponse])
+async def get_analysis_logs(
+    job_id: str,
+    phase: Optional[str] = Query(None, description="Filter by phase"),
+    activity_name: Optional[str] = Query(None, description="Filter by activity name"),
+    log_type: Optional[str] = Query(None, description="Filter by log type (start, progress, result, error)"),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    user: UserDB = Depends(get_current_user),
+):
+    """Job의 분석 로그 조회.
+
+    필터링 옵션:
+    - phase: enriching, planning, analyzing, generating, reviewing
+    - activity_name: document_analysis, code_analysis, jd_analysis 등
+    - log_type: start, progress, result, error
+    """
+    # Verify job ownership
+    job_uuid = uuid.UUID(job_id)
+    result = await db.execute(select(JobDB).where(JobDB.id == job_uuid))
+    job = result.scalar_one_or_none()
+
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.user_id != user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to view this job's logs")
+
+    service = AnalysisLogService(db)
+    logs = await service.get_logs_for_job(
+        job_id=job_id,
+        phase=phase,
+        activity_name=activity_name,
+        log_type=log_type,
+        limit=limit,
+        offset=offset,
+    )
+
+    return [
+        AnalysisLogResponse(
+            id=str(log.id),
+            job_id=str(log.job_id),
+            activity_name=log.activity_name,
+            phase=log.phase,
+            log_type=log.log_type,
+            message=log.message,
+            data=log.data or {},
+            duration_ms=log.duration_ms,
+            created_at=log.created_at.isoformat() if log.created_at else "",
+        )
+        for log in logs
+    ]
+
+
+@router.get("/{job_id}/analysis-summary", response_model=AnalysisSummaryResponse)
+async def get_analysis_summary(
+    job_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: UserDB = Depends(get_current_user),
+):
+    """Job의 분석 요약 정보 조회."""
+    # Verify job ownership
+    job_uuid = uuid.UUID(job_id)
+    result = await db.execute(select(JobDB).where(JobDB.id == job_uuid))
+    job = result.scalar_one_or_none()
+
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.user_id != user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to view this job's summary")
+
+    service = AnalysisLogService(db)
+    summary = await service.get_analysis_summary(job_id)
+
+    return AnalysisSummaryResponse(**summary)

--- a/backend/app/api/routes/internal.py
+++ b/backend/app/api/routes/internal.py
@@ -1,0 +1,78 @@
+"""
+backend/app/api/routes/internal.py
+Internal API - Activity에서 사용하는 내부 엔드포인트
+"""
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db
+from app.services.analysis_log_service import AnalysisLogService
+
+router = APIRouter(prefix="/api/internal", tags=["internal"])
+logger = logging.getLogger(__name__)
+
+
+class CreateAnalysisLogRequest(BaseModel):
+    """분석 로그 생성 요청 모델."""
+    job_id: str
+    activity_name: str
+    phase: str
+    log_type: str  # 'start', 'progress', 'result', 'error'
+    message: Optional[str] = None
+    data: Optional[dict] = None
+    duration_ms: Optional[int] = None
+
+
+class CreateAnalysisLogResponse(BaseModel):
+    """분석 로그 생성 응답 모델."""
+    id: str
+    created_at: str
+
+
+@router.post(
+    "/analysis-logs",
+    response_model=CreateAnalysisLogResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_analysis_log(
+    request: CreateAnalysisLogRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Activity에서 분석 로그를 기록하는 내부 엔드포인트.
+
+    Note: 이 엔드포인트는 내부 네트워크에서만 접근 가능해야 합니다.
+    프로덕션 환경에서는 적절한 네트워크 보안 설정이 필요합니다.
+    """
+    # Validate log_type
+    valid_log_types = {"start", "progress", "result", "error"}
+    if request.log_type not in valid_log_types:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid log_type. Must be one of: {valid_log_types}",
+        )
+
+    try:
+        service = AnalysisLogService(db)
+        log_entry = await service.create_log(
+            job_id=request.job_id,
+            activity_name=request.activity_name,
+            phase=request.phase,
+            log_type=request.log_type,
+            message=request.message,
+            data=request.data,
+            duration_ms=request.duration_ms,
+        )
+
+        return CreateAnalysisLogResponse(
+            id=str(log_entry.id),
+            created_at=log_entry.created_at.isoformat() if log_entry.created_at else "",
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Failed to create analysis log: {e}")
+        raise HTTPException(status_code=500, detail="Failed to create analysis log")

--- a/backend/app/api/routes/ws.py
+++ b/backend/app/api/routes/ws.py
@@ -1,10 +1,11 @@
 """
 backend/app/api/routes/ws.py
-WebSocket 실시간 Job 진행률 스트리밍
+WebSocket 실시간 Job 진행률 및 분석 로그 스트리밍
 """
 import asyncio
 import json
 import logging
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
 
@@ -91,6 +92,129 @@ async def job_progress_ws(
         logger.debug(f"WebSocket disconnected for job {job_id}")
     except Exception as e:
         logger.error(f"WebSocket error: {e}")
+        try:
+            await websocket.close(code=1011)
+        except Exception:
+            pass
+
+
+@router.websocket("/api/v1/jobs/{job_id}/logs/ws")
+async def job_logs_ws(
+    websocket: WebSocket,
+    job_id: str,
+    token: str = Query(default=""),
+):
+    """Job 분석 로그를 WebSocket으로 실시간 스트리밍.
+
+    인증: ws://host/api/v1/jobs/{job_id}/logs/ws?token=<api_key>
+    DB 폴링으로 새 로그 전송 (2초 간격).
+    """
+    # Authenticate
+    if not token:
+        await websocket.close(code=4001, reason="Missing token")
+        return
+
+    try:
+        from app.api.deps import validate_api_key
+        from app.core.database import async_session
+
+        async with async_session() as db:
+            user = await validate_api_key(token, db)
+            if not user:
+                await websocket.close(code=4003, reason="Invalid token")
+                return
+    except Exception:
+        await websocket.close(code=4003, reason="Authentication failed")
+        return
+
+    await websocket.accept()
+
+    try:
+        from app.core.database import async_session
+        from app.models.database import JobDB
+        from app.services.analysis_log_service import AnalysisLogService
+        from sqlalchemy import select
+        import uuid
+
+        # Verify job exists and user owns it
+        async with async_session() as db:
+            result = await db.execute(
+                select(JobDB).where(JobDB.id == uuid.UUID(job_id))
+            )
+            job = result.scalar_one_or_none()
+
+        if not job:
+            await websocket.send_json({"error": "Job not found"})
+            await websocket.close(code=4004)
+            return
+
+        if job.user_id != user.id:
+            await websocket.send_json({"error": "Not authorized"})
+            await websocket.close(code=4003)
+            return
+
+        # Track last seen log time
+        last_log_time = datetime.now(timezone.utc)
+
+        # Send initial summary
+        async with async_session() as db:
+            service = AnalysisLogService(db)
+            summary = await service.get_analysis_summary(job_id)
+            await websocket.send_json({"event": "summary", "data": summary})
+
+        while True:
+            try:
+                # Check for new logs
+                async with async_session() as db:
+                    service = AnalysisLogService(db)
+                    new_logs = await service.get_logs_since(job_id, last_log_time)
+
+                    if new_logs:
+                        for log in new_logs:
+                            log_data = {
+                                "event": "log",
+                                "data": {
+                                    "id": str(log.id),
+                                    "activity_name": log.activity_name,
+                                    "phase": log.phase,
+                                    "log_type": log.log_type,
+                                    "message": log.message,
+                                    "data": log.data or {},
+                                    "duration_ms": log.duration_ms,
+                                    "created_at": log.created_at.isoformat() if log.created_at else "",
+                                },
+                            }
+                            await websocket.send_json(log_data)
+                            if log.created_at:
+                                last_log_time = log.created_at
+
+                    # Check job status
+                    result = await db.execute(
+                        select(JobDB).where(JobDB.id == uuid.UUID(job_id))
+                    )
+                    job = result.scalar_one_or_none()
+
+                    if job and job.status in ("completed", "failed"):
+                        # Send final summary
+                        summary = await service.get_analysis_summary(job_id)
+                        await websocket.send_json({
+                            "event": "done",
+                            "status": job.status,
+                            "summary": summary,
+                        })
+                        break
+
+            except Exception as e:
+                logger.debug(f"Log polling error: {e}")
+                await websocket.send_json({"event": "error", "message": str(e)})
+                break
+
+            await asyncio.sleep(2)
+
+    except WebSocketDisconnect:
+        logger.debug(f"Logs WebSocket disconnected for job {job_id}")
+    except Exception as e:
+        logger.error(f"Logs WebSocket error: {e}")
         try:
             await websocket.close(code=1011)
         except Exception:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,8 @@ from app.api.routes.auth import router as auth_router
 from app.api.routes.jobs import router as jobs_router
 from app.api.routes.ws import router as ws_router
 from app.api.routes.upload import router as upload_router
+from app.api.routes.analysis_logs import router as analysis_logs_router
+from app.api.routes.internal import router as internal_router
 
 logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL))
 logger = logging.getLogger(__name__)
@@ -110,6 +112,8 @@ app.include_router(auth_router)
 app.include_router(jobs_router)
 app.include_router(ws_router)
 app.include_router(upload_router)
+app.include_router(analysis_logs_router)
+app.include_router(internal_router)
 
 
 @app.get("/")

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import (
-    Boolean, Column, DateTime, ForeignKey, Index, String, Text, BigInteger,
+    Boolean, Column, DateTime, ForeignKey, Index, Integer, String, Text, BigInteger,
     UniqueConstraint, func,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -96,6 +96,7 @@ class JobDB(Base):
 
     user = relationship("UserDB", back_populates="jobs")
     checkpoints = relationship("CheckpointDB", back_populates="job", cascade="all, delete-orphan")
+    analysis_logs = relationship("AnalysisLogDB", back_populates="job", cascade="all, delete-orphan")
 
 
 class CheckpointDB(Base):
@@ -112,6 +113,29 @@ class CheckpointDB(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     job = relationship("JobDB", back_populates="checkpoints")
+
+
+class AnalysisLogDB(Base):
+    """Activity 실행 로그 - 분석 중간 결과 및 진행 상황 추적."""
+    __tablename__ = "analysis_logs"
+    __table_args__ = (
+        Index("idx_analysis_logs_job", "job_id"),
+        Index("idx_analysis_logs_activity", "activity_name"),
+        Index("idx_analysis_logs_phase", "phase"),
+        Index("idx_analysis_logs_created", "created_at"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    job_id = Column(UUID(as_uuid=True), ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False)
+    activity_name = Column(String(100), nullable=False)  # 'document_analysis', 'code_analysis', etc.
+    phase = Column(String(50), nullable=False)  # 'enriching', 'analyzing', 'generating'
+    log_type = Column(String(20), nullable=False)  # 'start', 'progress', 'result', 'error'
+    message = Column(Text)
+    data = Column(JSONB, server_default="{}")  # Structured analysis data
+    duration_ms = Column(Integer)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    job = relationship("JobDB", back_populates="analysis_logs")
 
 
 class EmbeddingDB(Base):

--- a/backend/app/services/activity_logger.py
+++ b/backend/app/services/activity_logger.py
@@ -1,0 +1,239 @@
+"""
+backend/app/services/activity_logger.py
+Activity Logger - Temporal Activity에서 사용하는 로깅 헬퍼
+
+Temporal Activity는 별도 프로세스에서 실행되므로 직접 DB 접근 대신
+내부 API를 통해 로그를 기록합니다.
+"""
+import logging
+import time
+from typing import Optional
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class ActivityLogger:
+    """Temporal Activity용 로깅 헬퍼.
+
+    Usage:
+        log = ActivityLogger(job_id, "document_analysis", "analyzing")
+        await log.start("Starting document analysis", {"doc_count": 3})
+        await log.progress("Processing document 1/3", {"current": 1})
+        await log.result("Completed", {"profiles": [...], "duration_ms": 1234})
+    """
+
+    def __init__(
+        self,
+        job_id: str,
+        activity_name: str,
+        phase: str,
+        base_url: Optional[str] = None,
+    ):
+        self.job_id = job_id
+        self.activity_name = activity_name
+        self.phase = phase
+        self.base_url = base_url or f"http://localhost:{settings.PORT}"
+        self._start_time: Optional[float] = None
+
+    async def _post_log(
+        self,
+        log_type: str,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> bool:
+        """Internal API로 로그 전송."""
+        payload = {
+            "job_id": self.job_id,
+            "activity_name": self.activity_name,
+            "phase": self.phase,
+            "log_type": log_type,
+            "message": message,
+            "data": data or {},
+            "duration_ms": duration_ms,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.post(
+                    f"{self.base_url}/api/internal/analysis-logs",
+                    json=payload,
+                )
+                if response.status_code != 201:
+                    logger.warning(f"Failed to post log: {response.status_code} - {response.text}")
+                    return False
+                return True
+        except Exception as e:
+            logger.warning(f"Failed to post analysis log: {e}")
+            return False
+
+    async def start(
+        self,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+    ) -> bool:
+        """Activity 시작 로그."""
+        self._start_time = time.time()
+        return await self._post_log(
+            log_type="start",
+            message=message or f"Starting {self.activity_name}",
+            data=data,
+        )
+
+    async def progress(
+        self,
+        message: str,
+        data: Optional[dict] = None,
+    ) -> bool:
+        """Activity 진행 상황 로그."""
+        return await self._post_log(
+            log_type="progress",
+            message=message,
+            data=data,
+        )
+
+    async def result(
+        self,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> bool:
+        """Activity 결과 로그."""
+        if duration_ms is None and self._start_time:
+            duration_ms = int((time.time() - self._start_time) * 1000)
+
+        return await self._post_log(
+            log_type="result",
+            message=message or f"Completed {self.activity_name}",
+            data=data,
+            duration_ms=duration_ms,
+        )
+
+    async def error(
+        self,
+        message: str,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> bool:
+        """Activity 에러 로그."""
+        if duration_ms is None and self._start_time:
+            duration_ms = int((time.time() - self._start_time) * 1000)
+
+        return await self._post_log(
+            log_type="error",
+            message=message,
+            data=data,
+            duration_ms=duration_ms,
+        )
+
+
+class SyncActivityLogger:
+    """동기 Activity용 로깅 헬퍼 (httpx 동기 버전)."""
+
+    def __init__(
+        self,
+        job_id: str,
+        activity_name: str,
+        phase: str,
+        base_url: Optional[str] = None,
+    ):
+        self.job_id = job_id
+        self.activity_name = activity_name
+        self.phase = phase
+        self.base_url = base_url or f"http://localhost:{settings.PORT}"
+        self._start_time: Optional[float] = None
+
+    def _post_log(
+        self,
+        log_type: str,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> bool:
+        """Internal API로 로그 전송 (동기)."""
+        payload = {
+            "job_id": self.job_id,
+            "activity_name": self.activity_name,
+            "phase": self.phase,
+            "log_type": log_type,
+            "message": message,
+            "data": data or {},
+            "duration_ms": duration_ms,
+        }
+
+        try:
+            with httpx.Client(timeout=5.0) as client:
+                response = client.post(
+                    f"{self.base_url}/api/internal/analysis-logs",
+                    json=payload,
+                )
+                if response.status_code != 201:
+                    logger.warning(f"Failed to post log: {response.status_code}")
+                    return False
+                return True
+        except Exception as e:
+            logger.warning(f"Failed to post analysis log: {e}")
+            return False
+
+    def start(
+        self,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+    ) -> bool:
+        """Activity 시작 로그."""
+        self._start_time = time.time()
+        return self._post_log(
+            log_type="start",
+            message=message or f"Starting {self.activity_name}",
+            data=data,
+        )
+
+    def progress(
+        self,
+        message: str,
+        data: Optional[dict] = None,
+    ) -> bool:
+        """Activity 진행 상황 로그."""
+        return self._post_log(
+            log_type="progress",
+            message=message,
+            data=data,
+        )
+
+    def result(
+        self,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> bool:
+        """Activity 결과 로그."""
+        if duration_ms is None and self._start_time:
+            duration_ms = int((time.time() - self._start_time) * 1000)
+
+        return self._post_log(
+            log_type="result",
+            message=message or f"Completed {self.activity_name}",
+            data=data,
+            duration_ms=duration_ms,
+        )
+
+    def error(
+        self,
+        message: str,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> bool:
+        """Activity 에러 로그."""
+        if duration_ms is None and self._start_time:
+            duration_ms = int((time.time() - self._start_time) * 1000)
+
+        return self._post_log(
+            log_type="error",
+            message=message,
+            data=data,
+            duration_ms=duration_ms,
+        )

--- a/backend/app/services/analysis_log_service.py
+++ b/backend/app/services/analysis_log_service.py
@@ -1,0 +1,249 @@
+"""
+backend/app/services/analysis_log_service.py
+Analysis Log Service - DB 기반 분석 로그 관리
+"""
+import logging
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select, func, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.database import AnalysisLogDB
+
+logger = logging.getLogger(__name__)
+
+
+class AnalysisLogService:
+    """Analysis log CRUD 및 조회 서비스."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create_log(
+        self,
+        job_id: str,
+        activity_name: str,
+        phase: str,
+        log_type: str,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> AnalysisLogDB:
+        """새 분석 로그 생성."""
+        log_entry = AnalysisLogDB(
+            id=uuid.uuid4(),
+            job_id=uuid.UUID(job_id),
+            activity_name=activity_name,
+            phase=phase,
+            log_type=log_type,
+            message=message,
+            data=data or {},
+            duration_ms=duration_ms,
+        )
+        self.db.add(log_entry)
+        await self.db.commit()
+        await self.db.refresh(log_entry)
+        return log_entry
+
+    async def log_activity_start(
+        self,
+        job_id: str,
+        activity_name: str,
+        phase: str,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+    ) -> AnalysisLogDB:
+        """Activity 시작 로그."""
+        return await self.create_log(
+            job_id=job_id,
+            activity_name=activity_name,
+            phase=phase,
+            log_type="start",
+            message=message or f"Starting {activity_name}",
+            data=data,
+        )
+
+    async def log_activity_progress(
+        self,
+        job_id: str,
+        activity_name: str,
+        phase: str,
+        message: str,
+        data: Optional[dict] = None,
+    ) -> AnalysisLogDB:
+        """Activity 진행 상황 로그."""
+        return await self.create_log(
+            job_id=job_id,
+            activity_name=activity_name,
+            phase=phase,
+            log_type="progress",
+            message=message,
+            data=data,
+        )
+
+    async def log_activity_result(
+        self,
+        job_id: str,
+        activity_name: str,
+        phase: str,
+        message: Optional[str] = None,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> AnalysisLogDB:
+        """Activity 결과 로그."""
+        return await self.create_log(
+            job_id=job_id,
+            activity_name=activity_name,
+            phase=phase,
+            log_type="result",
+            message=message or f"Completed {activity_name}",
+            data=data,
+            duration_ms=duration_ms,
+        )
+
+    async def log_activity_error(
+        self,
+        job_id: str,
+        activity_name: str,
+        phase: str,
+        message: str,
+        data: Optional[dict] = None,
+        duration_ms: Optional[int] = None,
+    ) -> AnalysisLogDB:
+        """Activity 에러 로그."""
+        return await self.create_log(
+            job_id=job_id,
+            activity_name=activity_name,
+            phase=phase,
+            log_type="error",
+            message=message,
+            data=data,
+            duration_ms=duration_ms,
+        )
+
+    async def get_logs_for_job(
+        self,
+        job_id: str,
+        phase: Optional[str] = None,
+        activity_name: Optional[str] = None,
+        log_type: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[AnalysisLogDB]:
+        """Job별 로그 조회 (필터링 지원)."""
+        conditions = [AnalysisLogDB.job_id == uuid.UUID(job_id)]
+
+        if phase:
+            conditions.append(AnalysisLogDB.phase == phase)
+        if activity_name:
+            conditions.append(AnalysisLogDB.activity_name == activity_name)
+        if log_type:
+            conditions.append(AnalysisLogDB.log_type == log_type)
+
+        query = (
+            select(AnalysisLogDB)
+            .where(and_(*conditions))
+            .order_by(AnalysisLogDB.created_at.asc())
+            .limit(limit)
+            .offset(offset)
+        )
+
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
+    async def get_logs_since(
+        self,
+        job_id: str,
+        since: datetime,
+    ) -> list[AnalysisLogDB]:
+        """특정 시간 이후의 로그 조회 (WebSocket 스트리밍용)."""
+        query = (
+            select(AnalysisLogDB)
+            .where(
+                and_(
+                    AnalysisLogDB.job_id == uuid.UUID(job_id),
+                    AnalysisLogDB.created_at > since,
+                )
+            )
+            .order_by(AnalysisLogDB.created_at.asc())
+        )
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
+    async def get_analysis_summary(self, job_id: str) -> dict:
+        """Job 분석 요약 정보."""
+        job_uuid = uuid.UUID(job_id)
+
+        # 총 로그 수
+        total_query = select(func.count(AnalysisLogDB.id)).where(
+            AnalysisLogDB.job_id == job_uuid
+        )
+        total_result = await self.db.execute(total_query)
+        total_count = total_result.scalar() or 0
+
+        # 완료된 Activity 수 (log_type='result')
+        completed_query = select(func.count(AnalysisLogDB.id)).where(
+            and_(
+                AnalysisLogDB.job_id == job_uuid,
+                AnalysisLogDB.log_type == "result",
+            )
+        )
+        completed_result = await self.db.execute(completed_query)
+        completed_count = completed_result.scalar() or 0
+
+        # 에러 수
+        error_query = select(func.count(AnalysisLogDB.id)).where(
+            and_(
+                AnalysisLogDB.job_id == job_uuid,
+                AnalysisLogDB.log_type == "error",
+            )
+        )
+        error_result = await self.db.execute(error_query)
+        error_count = error_result.scalar() or 0
+
+        # 총 소요 시간
+        duration_query = select(func.sum(AnalysisLogDB.duration_ms)).where(
+            and_(
+                AnalysisLogDB.job_id == job_uuid,
+                AnalysisLogDB.duration_ms.isnot(None),
+            )
+        )
+        duration_result = await self.db.execute(duration_query)
+        total_duration_ms = duration_result.scalar() or 0
+
+        # Phase별 통계
+        phase_query = (
+            select(
+                AnalysisLogDB.phase,
+                func.count(AnalysisLogDB.id).label("count"),
+            )
+            .where(AnalysisLogDB.job_id == job_uuid)
+            .group_by(AnalysisLogDB.phase)
+        )
+        phase_result = await self.db.execute(phase_query)
+        phase_stats = {row.phase: row.count for row in phase_result.all()}
+
+        # Activity별 통계
+        activity_query = (
+            select(
+                AnalysisLogDB.activity_name,
+                func.count(AnalysisLogDB.id).label("count"),
+            )
+            .where(AnalysisLogDB.job_id == job_uuid)
+            .group_by(AnalysisLogDB.activity_name)
+        )
+        activity_result = await self.db.execute(activity_query)
+        activity_stats = {row.activity_name: row.count for row in activity_result.all()}
+
+        return {
+            "job_id": job_id,
+            "total_logs": total_count,
+            "completed_activities": completed_count,
+            "errors": error_count,
+            "total_duration_ms": total_duration_ms,
+            "total_duration_sec": round(total_duration_ms / 1000, 2) if total_duration_ms else 0,
+            "phase_stats": phase_stats,
+            "activity_stats": activity_stats,
+        }

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -7,6 +7,7 @@ import logging
 from temporalio import activity
 
 from app.core.observability import observe_activity
+from app.services.activity_logger import ActivityLogger
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +36,25 @@ async def analyze_code(
     jd_tech_stack = (execution_plan or {}).get("jd_tech_stack") or input_data.get("jd_tech_stack", [])
     candidate_username = input_data.get("candidate_github_username")
 
+    # Initialize activity logger
+    job_id = input_data.get("job_id")
+    alog = ActivityLogger(job_id, "code_analysis", "analyzing") if job_id else None
+
+    if alog:
+        await alog.start("Starting code analysis", {
+            "github_urls_count": len(github_urls),
+            "jd_tech_stack": jd_tech_stack,
+            "candidate_username": candidate_username,
+        })
+
     # Phase 1: JD 매칭 레포 선별
     activity.heartbeat("Phase 1: Filtering repos by JD tech stack...")
+    if alog:
+        await alog.progress("Phase 1: Filtering repos by JD tech stack", {
+            "phase": 1,
+            "target_languages": jd_tech_stack,
+        })
+
     target_repos = await github.filter_repos_by_language(
         github_urls=github_urls,
         target_languages=jd_tech_stack,
@@ -44,7 +62,18 @@ async def analyze_code(
     )
 
     if not target_repos:
+        if alog:
+            await alog.result("No matching repositories found", {
+                "repositories_count": 0,
+                "top_question_candidates_count": 0,
+            })
         return {"repositories": [], "top_question_candidates": []}
+
+    if alog:
+        await alog.progress("Phase 1 complete: Repos filtered", {
+            "filtered_repos_count": len(target_repos),
+            "repos": [r.get("name", "unknown") for r in target_repos],
+        })
 
     # Phase 2-4: 레포별 분석
     repositories = []
@@ -54,6 +83,13 @@ async def analyze_code(
 
         # Phase 2: PyDriller
         activity.heartbeat(f"Phase 2: Analyzing {repo_name} ({i+1}/{len(target_repos)})")
+        if alog:
+            await alog.progress(f"Phase 2: Analyzing {repo_name}", {
+                "phase": 2,
+                "repo_index": i + 1,
+                "total_repos": len(target_repos),
+                "repo_name": repo_name,
+            })
         file_types = _jd_to_file_types(jd_tech_stack)
         driller_result = await analyzer.analyze_with_pydriller(
             repo_url=repo_url,
@@ -65,6 +101,12 @@ async def analyze_code(
 
         # Phase 3: AST
         activity.heartbeat(f"Phase 3: AST analysis for {repo_name}...")
+        if alog:
+            await alog.progress(f"Phase 3: AST analysis for {repo_name}", {
+                "phase": 3,
+                "repo_name": repo_name,
+                "files_count": len(driller_result.get("files", [])),
+            })
         top_files = analyzer.select_top_files(
             files=driller_result["files"],
             jd_tech_stack=jd_tech_stack,
@@ -75,6 +117,13 @@ async def analyze_code(
 
         # Phase 4: LLM
         activity.heartbeat(f"Phase 4: LLM analysis for {repo_name}...")
+        if alog:
+            await alog.progress(f"Phase 4: LLM analysis for {repo_name}", {
+                "phase": 4,
+                "repo_name": repo_name,
+                "ast_functions_count": len(ast_result.get("functions", [])),
+                "ast_classes_count": len(ast_result.get("classes", [])),
+            })
         ranked_files = analyzer.rank_files_for_llm(
             files=driller_result["files"],
             jd_tech_stack=jd_tech_stack,
@@ -122,6 +171,17 @@ async def analyze_code(
             logger.info(f"Extracted {kg_entity_count} KG entities from code analysis for job {job_id}")
         except Exception as e:
             logger.warning(f"KG extraction failed (non-fatal): {e}")
+
+    # Log final result
+    if alog:
+        await alog.result("Code analysis completed", {
+            "repositories_analyzed": len(repositories),
+            "combined_tech_stack": code_analysis_result.get("combined_tech_stack", []),
+            "total_patterns": code_analysis_result.get("total_patterns", 0),
+            "total_notable_implementations": code_analysis_result.get("total_notable_implementations", 0),
+            "top_question_candidates_count": len(code_analysis_result.get("top_question_candidates", [])),
+            "kg_entity_count": kg_entity_count,
+        })
 
     return {
         **code_analysis_result,

--- a/backend/app/workflows/activities/document_analysis.py
+++ b/backend/app/workflows/activities/document_analysis.py
@@ -7,6 +7,7 @@ import logging
 from temporalio import activity
 
 from app.core.observability import observe_activity
+from app.services.activity_logger import ActivityLogger
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,18 @@ async def analyze_documents(input_data: dict) -> dict:
     """
     from app.services.document_parser import parse_document
     from app.services.cached_llm import CachedLLMService
+
+    # Initialize activity logger
+    job_id = input_data.get("job_id")
+    alog = ActivityLogger(job_id, "document_analysis", "analyzing") if job_id else None
+
+    doc_keys = ["resume_path", "portfolio_path", "cover_letter_path"]
+    available_docs = [k for k in doc_keys if input_data.get(k)]
+
+    if alog:
+        await alog.start("Starting document analysis", {
+            "available_documents": available_docs,
+        })
 
     llm = CachedLLMService()
     documents = []
@@ -46,10 +59,21 @@ async def analyze_documents(input_data: dict) -> dict:
                 logger.warning(f"Failed to parse {doc_key}: {e}")
 
     if not documents:
+        if alog:
+            await alog.result("No documents to analyze", {
+                "profile_keys": [],
+                "parse_results": [],
+            })
         return {"profile": {}, "raw_texts": [], "parse_info": []}
 
     # LLM으로 프로필 추출 (Activity별 최적 모델 사용)
     activity.heartbeat("Extracting candidate profile with LLM...")
+    if alog:
+        await alog.progress("Extracting candidate profile with LLM", {
+            "documents_count": len(documents),
+            "total_chars": sum(len(d) for d in documents),
+        })
+
     from app.prompts import get_prompt
     prompt = get_prompt("document_analysis.yaml", "extract_profile", documents="\n---\n".join(documents))
     profile = await llm.run(prompt, activity_name="analyze_documents")
@@ -78,6 +102,15 @@ async def analyze_documents(input_data: dict) -> dict:
             logger.info(f"Extracted {kg_entity_count} KG entities for job {job_id}")
         except Exception as e:
             logger.warning(f"KG extraction failed (non-fatal): {e}")
+
+    # Log final result
+    if alog:
+        profile_keys = list(profile.keys()) if isinstance(profile, dict) else []
+        await alog.result("Document analysis completed", {
+            "profile_keys": profile_keys,
+            "parse_results": parse_results,
+            "kg_entity_count": kg_entity_count,
+        })
 
     return {
         "profile": profile if isinstance(profile, dict) else {},

--- a/backend/app/workflows/activities/jd_analysis.py
+++ b/backend/app/workflows/activities/jd_analysis.py
@@ -7,6 +7,7 @@ import logging
 from temporalio import activity
 
 from app.core.observability import observe_activity
+from app.services.activity_logger import ActivityLogger
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +24,21 @@ async def analyze_jd(jd_text: str, job_id: str | None = None) -> dict:
     """
     from app.services.cached_llm import CachedLLMService
 
+    # Initialize activity logger
+    alog = ActivityLogger(job_id, "jd_analysis", "analyzing") if job_id else None
+
+    if alog:
+        await alog.start("Starting JD analysis", {
+            "jd_text_length": len(jd_text),
+        })
+
     llm = CachedLLMService()
 
     from app.prompts import get_prompt
     prompt = get_prompt("jd_analysis.yaml", "analyze", jd_text=jd_text)
+
+    if alog:
+        await alog.progress("Extracting requirements with LLM", {})
 
     result = await llm.run(prompt, activity_name="analyze_jd")
 
@@ -71,6 +83,17 @@ async def analyze_jd(jd_text: str, job_id: str | None = None) -> dict:
             logger.info(f"Extracted {kg_entity_count} KG entities from JD for job {job_id}")
         except Exception as e:
             logger.warning(f"KG extraction failed (non-fatal): {e}")
+
+    # Log final result
+    if alog:
+        await alog.result("JD analysis completed", {
+            "job_title": jd_result.get("job_title"),
+            "company_name": jd_result.get("company_name"),
+            "requirements_count": len(jd_result.get("requirements", [])),
+            "responsibilities_count": len(jd_result.get("responsibilities", [])),
+            "tech_stack": jd_result.get("tech_stack", []),
+            "kg_entity_count": kg_entity_count,
+        })
 
     return {
         **jd_result,

--- a/backend/app/workflows/activities/planning.py
+++ b/backend/app/workflows/activities/planning.py
@@ -7,6 +7,7 @@ import logging
 from temporalio import activity
 
 from app.core.observability import observe_activity
+from app.services.activity_logger import ActivityLogger
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,19 @@ async def create_execution_plan(enriched_input: dict) -> dict:
     3. 실행 계획 생성
     """
     from app.services.github_service import GitHubService
+
+    # Initialize activity logger
+    job_id = enriched_input.get("raw_input", {}).get("job_id")
+    alog = ActivityLogger(job_id, "planning", "planning") if job_id else None
+
+    github_urls = enriched_input.get("github_urls", [])
+    available = enriched_input.get("available_analyses", [])
+
+    if alog:
+        await alog.start("Creating execution plan", {
+            "github_urls_count": len(github_urls),
+            "available_analyses": available,
+        })
 
     github = GitHubService()
     raw_input = enriched_input.get("raw_input", {})
@@ -56,6 +70,14 @@ async def create_execution_plan(enriched_input: dict) -> dict:
         ) + 120,
         "raw_input": raw_input,
     }
+
+    # Log final result
+    if alog:
+        await alog.result("Execution plan created", {
+            "enabled_phases": [p["name"] for p in plan["phases"] if p["enabled"]],
+            "estimated_total_time_seconds": plan["estimated_total_time_seconds"],
+            "repos_analyzed": len(workload),
+        })
 
     return plan
 

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -7,6 +7,7 @@ import logging
 from temporalio import activity
 
 from app.core.observability import observe_activity
+from app.services.activity_logger import ActivityLogger
 
 logger = logging.getLogger(__name__)
 
@@ -25,10 +26,19 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
     """
     from app.services.cached_llm import CachedLLMService
 
+    # Initialize activity logger
+    alog = ActivityLogger(job_id, "select_topics", "generating") if job_id else None
+
     llm = CachedLLMService()
     raw_input = enriched_input.get("raw_input", {})
     experience_level = raw_input.get("experience_level", "미들")
     max_questions = raw_input.get("max_questions", 25)
+
+    if alog:
+        await alog.start("Selecting question topics", {
+            "experience_level": experience_level,
+            "max_questions": max_questions,
+        })
 
     # 질문 후보 수집
     candidates = []
@@ -112,6 +122,11 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
 
     result = await llm.run(prompt, activity_name="select_topics")
     if isinstance(result, list):
+        if alog:
+            await alog.result("Topics selected", {
+                "topics_count": len(result[:max_questions]),
+                "candidates_considered": len(candidates),
+            })
         return result[:max_questions]
 
     # Fallback: generate placeholder topics from candidates
@@ -134,6 +149,11 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
                     "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"][j],
                     "source": "generated",
                 })
+    if alog:
+        await alog.result("Topics selected (fallback)", {
+            "topics_count": len(topics[:max_questions]),
+            "candidates_considered": len(candidates),
+        })
     return topics[:max_questions]
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { JobListPage } from './pages/JobListPage'
 import { CreateJobPage } from './pages/CreateJobPage'
 import { JobStatusPage } from './pages/JobStatusPage'
 import { ResultPage } from './pages/ResultPage'
+import { AnalysisLogsPage } from './pages/AnalysisLogsPage'
 import { NotFoundPage } from './pages/NotFoundPage'
 import { AuthCallbackPage } from './pages/AuthCallbackPage'
 import { useAuth } from './hooks/useAuth'
@@ -44,6 +45,10 @@ function App() {
           <Route
             path="/jobs/:jobId/result"
             element={isAuthenticated ? <ResultPage /> : <Navigate to="/login" />}
+          />
+          <Route
+            path="/jobs/:jobId/logs"
+            element={isAuthenticated ? <AnalysisLogsPage /> : <Navigate to="/login" />}
           />
           <Route path="/" element={<Navigate to={isAuthenticated ? '/jobs' : '/login'} />} />
           <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/hooks/useAnalysisLogs.ts
+++ b/frontend/src/hooks/useAnalysisLogs.ts
@@ -1,0 +1,196 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { apiFetch, getToken } from '../lib/api'
+
+export interface AnalysisLog {
+  id: string
+  job_id: string
+  activity_name: string
+  phase: string
+  log_type: 'start' | 'progress' | 'result' | 'error'
+  message: string | null
+  data: Record<string, unknown>
+  duration_ms: number | null
+  created_at: string
+}
+
+export interface AnalysisSummary {
+  job_id: string
+  total_logs: number
+  completed_activities: number
+  errors: number
+  total_duration_ms: number
+  total_duration_sec: number
+  phase_stats: Record<string, number>
+  activity_stats: Record<string, number>
+}
+
+interface UseAnalysisLogsReturn {
+  logs: AnalysisLog[]
+  summary: AnalysisSummary | null
+  loading: boolean
+  error: string | null
+  streaming: boolean
+  fetchLogs: (filters?: {
+    phase?: string
+    activity_name?: string
+    log_type?: string
+  }) => Promise<void>
+  fetchSummary: () => Promise<void>
+}
+
+const MAX_RECONNECT_ATTEMPTS = 5
+const BASE_DELAY_MS = 1000
+
+export function useAnalysisLogs(jobId: string | undefined): UseAnalysisLogsReturn {
+  const [logs, setLogs] = useState<AnalysisLog[]>([])
+  const [summary, setSummary] = useState<AnalysisSummary | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [streaming, setStreaming] = useState(false)
+
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const attemptRef = useRef(0)
+  const terminalRef = useRef(false)
+
+  const fetchLogs = useCallback(async (filters?: {
+    phase?: string
+    activity_name?: string
+    log_type?: string
+  }) => {
+    if (!jobId) return
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const params = new URLSearchParams()
+      if (filters?.phase) params.append('phase', filters.phase)
+      if (filters?.activity_name) params.append('activity_name', filters.activity_name)
+      if (filters?.log_type) params.append('log_type', filters.log_type)
+
+      const queryString = params.toString()
+      const path = `/jobs/${jobId}/analysis-logs${queryString ? `?${queryString}` : ''}`
+      const data = await apiFetch(path)
+      setLogs(data || [])
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [jobId])
+
+  const fetchSummary = useCallback(async () => {
+    if (!jobId) return
+
+    try {
+      const data = await apiFetch(`/jobs/${jobId}/analysis-summary`)
+      setSummary(data)
+    } catch (e) {
+      console.error('Failed to fetch summary:', e)
+    }
+  }, [jobId])
+
+  // WebSocket streaming connection
+  const connectWebSocket = useCallback(() => {
+    if (!jobId || terminalRef.current) return
+
+    const token = getToken()
+    if (!token) return
+
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const host = window.location.host
+    const url = `${protocol}//${host}/api/v1/jobs/${jobId}/logs/ws?token=${encodeURIComponent(token)}`
+
+    try {
+      const ws = new WebSocket(url)
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        setStreaming(true)
+        setError(null)
+        attemptRef.current = 0
+      }
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data)
+
+          if (data.event === 'summary') {
+            setSummary(data.data)
+          } else if (data.event === 'log') {
+            setLogs((prev) => {
+              // Check for duplicate
+              const exists = prev.some((log) => log.id === data.data.id)
+              if (exists) return prev
+              return [...prev, data.data]
+            })
+          } else if (data.event === 'done') {
+            terminalRef.current = true
+            if (data.summary) setSummary(data.summary)
+            ws.close()
+          } else if (data.event === 'error') {
+            setError(data.message)
+          }
+        } catch {
+          // ignore parse errors
+        }
+      }
+
+      ws.onclose = () => {
+        setStreaming(false)
+        wsRef.current = null
+
+        // Auto-reconnect with exponential backoff if not terminal
+        if (!terminalRef.current && attemptRef.current < MAX_RECONNECT_ATTEMPTS) {
+          const delay = BASE_DELAY_MS * Math.pow(2, attemptRef.current)
+          attemptRef.current += 1
+          reconnectRef.current = setTimeout(connectWebSocket, delay)
+        }
+      }
+
+      ws.onerror = () => {
+        setError('WebSocket 연결 실패')
+        setStreaming(false)
+      }
+    } catch {
+      setError('WebSocket 연결 실패')
+    }
+  }, [jobId])
+
+  // Initial fetch and WebSocket connection
+  useEffect(() => {
+    if (!jobId) return
+
+    terminalRef.current = false
+    attemptRef.current = 0
+
+    // Fetch initial data
+    fetchLogs()
+    fetchSummary()
+
+    // Connect WebSocket for streaming
+    connectWebSocket()
+
+    return () => {
+      terminalRef.current = true
+      if (wsRef.current) {
+        wsRef.current.close()
+        wsRef.current = null
+      }
+      if (reconnectRef.current) {
+        clearTimeout(reconnectRef.current)
+      }
+    }
+  }, [jobId, fetchLogs, fetchSummary, connectWebSocket])
+
+  return {
+    logs,
+    summary,
+    loading,
+    error,
+    streaming,
+    fetchLogs,
+    fetchSummary,
+  }
+}

--- a/frontend/src/pages/AnalysisLogsPage.tsx
+++ b/frontend/src/pages/AnalysisLogsPage.tsx
@@ -1,0 +1,289 @@
+import { useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAnalysisLogs, type AnalysisLog } from '../hooks/useAnalysisLogs'
+
+// Phase configuration
+const PHASE_CONFIG: Record<string, { color: string; bgColor: string; label: string }> = {
+  enriching: { color: 'text-blue-700', bgColor: 'bg-blue-100', label: '입력 보강' },
+  planning: { color: 'text-purple-700', bgColor: 'bg-purple-100', label: '계획 수립' },
+  analyzing: { color: 'text-indigo-700', bgColor: 'bg-indigo-100', label: '분석' },
+  generating: { color: 'text-amber-700', bgColor: 'bg-amber-100', label: '질문 생성' },
+  reviewing: { color: 'text-cyan-700', bgColor: 'bg-cyan-100', label: '품질 검토' },
+}
+
+// Log type icons
+const LOG_TYPE_CONFIG: Record<string, { icon: string; color: string }> = {
+  start: { icon: '▶️', color: 'text-blue-600' },
+  progress: { icon: '🔄', color: 'text-amber-600' },
+  result: { icon: '✅', color: 'text-green-600' },
+  error: { icon: '❌', color: 'text-red-600' },
+}
+
+// Activity display names
+const ACTIVITY_NAMES: Record<string, string> = {
+  document_analysis: '문서 분석',
+  code_analysis: '코드 분석',
+  jd_analysis: 'JD 분석',
+  planning: '계획 수립',
+  input_enrichment: '입력 보강',
+  question_generation: '질문 생성',
+  quality_review: '품질 검토',
+  finalization: '최종 처리',
+}
+
+function LogCard({ log, isExpanded, onToggle }: { log: AnalysisLog; isExpanded: boolean; onToggle: () => void }) {
+  const typeConfig = LOG_TYPE_CONFIG[log.log_type] || LOG_TYPE_CONFIG.progress
+  const phaseConfig = PHASE_CONFIG[log.phase] || { color: 'text-gray-700', bgColor: 'bg-gray-100', label: log.phase }
+  const activityName = ACTIVITY_NAMES[log.activity_name] || log.activity_name
+  const hasData = log.data && Object.keys(log.data).length > 0
+
+  return (
+    <div className={`rounded-lg border bg-white transition-all ${
+      log.log_type === 'error' ? 'border-red-200' : 'border-gray-200'
+    }`}>
+      <div
+        className="flex cursor-pointer items-center gap-3 p-4 hover:bg-gray-50"
+        onClick={onToggle}
+      >
+        {/* Type Icon */}
+        <span className="text-lg" title={log.log_type}>{typeConfig.icon}</span>
+
+        {/* Phase Badge */}
+        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${phaseConfig.bgColor} ${phaseConfig.color}`}>
+          {phaseConfig.label}
+        </span>
+
+        {/* Activity Name */}
+        <span className="font-medium text-gray-900">{activityName}</span>
+
+        {/* Duration */}
+        {log.duration_ms !== null && (
+          <span className="text-sm text-gray-500">
+            {(log.duration_ms / 1000).toFixed(1)}s
+          </span>
+        )}
+
+        {/* Timestamp */}
+        <span className="ml-auto text-xs text-gray-400">
+          {new Date(log.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+        </span>
+
+        {/* Expand Arrow */}
+        {hasData && (
+          <svg
+            className={`h-4 w-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
+      </div>
+
+      {/* Message */}
+      {log.message && (
+        <div className={`border-t px-4 py-2 text-sm ${log.log_type === 'error' ? 'bg-red-50 text-red-700' : 'text-gray-600'}`}>
+          {log.message}
+        </div>
+      )}
+
+      {/* Expanded Data */}
+      {isExpanded && hasData && (
+        <div className="border-t bg-gray-50 p-4">
+          <pre className="max-h-64 overflow-auto rounded-lg bg-gray-900 p-3 text-xs text-gray-100">
+            {JSON.stringify(log.data, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SummaryCard({ summary }: { summary: { total_logs: number; completed_activities: number; errors: number; total_duration_sec: number } }) {
+  return (
+    <div className="mb-6 grid grid-cols-4 gap-4">
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <div className="text-2xl font-bold text-gray-900">{summary.total_logs}</div>
+        <div className="text-sm text-gray-500">총 로그</div>
+      </div>
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <div className="text-2xl font-bold text-green-600">{summary.completed_activities}</div>
+        <div className="text-sm text-gray-500">완료</div>
+      </div>
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <div className="text-2xl font-bold text-red-600">{summary.errors}</div>
+        <div className="text-sm text-gray-500">에러</div>
+      </div>
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <div className="text-2xl font-bold text-indigo-600">{summary.total_duration_sec.toFixed(1)}s</div>
+        <div className="text-sm text-gray-500">총 소요시간</div>
+      </div>
+    </div>
+  )
+}
+
+export function AnalysisLogsPage() {
+  const { t } = useTranslation()
+  const { jobId } = useParams<{ jobId: string }>()
+  const { logs, summary, loading, error, streaming, fetchLogs } = useAnalysisLogs(jobId)
+
+  const [expandedLogId, setExpandedLogId] = useState<string | null>(null)
+  const [phaseFilter, setPhaseFilter] = useState<string>('')
+  const [activityFilter, setActivityFilter] = useState<string>('')
+
+  // Get unique phases and activities for filters
+  const phases = [...new Set(logs.map((log) => log.phase))]
+  const activities = [...new Set(logs.map((log) => log.activity_name))]
+
+  // Filter logs
+  const filteredLogs = logs.filter((log) => {
+    if (phaseFilter && log.phase !== phaseFilter) return false
+    if (activityFilter && log.activity_name !== activityFilter) return false
+    return true
+  })
+
+  const handleToggleExpand = (logId: string) => {
+    setExpandedLogId((prev) => (prev === logId ? null : logId))
+  }
+
+  const handleRefresh = () => {
+    fetchLogs({
+      phase: phaseFilter || undefined,
+      activity_name: activityFilter || undefined,
+    })
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-4xl">
+        <div className="flex flex-col items-center justify-center rounded-xl border border-red-200 bg-red-50 px-6 py-12">
+          <svg className="h-12 w-12 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <p className="mt-3 text-sm font-medium text-red-800">{error}</p>
+          <Link
+            to={`/jobs/${jobId}`}
+            className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+          >
+            Job 상태로 돌아가기
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <div className="flex items-center gap-3">
+            <Link
+              to={`/jobs/${jobId}`}
+              className="text-gray-500 hover:text-gray-700"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </Link>
+            <h1 className="text-xl font-bold text-gray-900">분석 로그</h1>
+            <span className="text-sm text-gray-500">#{jobId?.slice(0, 8)}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          {/* Streaming indicator */}
+          {streaming && (
+            <span className="flex items-center gap-2 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-green-500" />
+              실시간 스트리밍
+            </span>
+          )}
+          <button
+            onClick={handleRefresh}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            <svg className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            새로고침
+          </button>
+        </div>
+      </div>
+
+      {/* Summary */}
+      {summary && <SummaryCard summary={summary} />}
+
+      {/* Filters */}
+      <div className="mb-4 flex items-center gap-3">
+        <select
+          value={phaseFilter}
+          onChange={(e) => setPhaseFilter(e.target.value)}
+          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        >
+          <option value="">모든 단계</option>
+          {phases.map((phase) => (
+            <option key={phase} value={phase}>
+              {PHASE_CONFIG[phase]?.label || phase}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={activityFilter}
+          onChange={(e) => setActivityFilter(e.target.value)}
+          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        >
+          <option value="">모든 Activity</option>
+          {activities.map((activity) => (
+            <option key={activity} value={activity}>
+              {ACTIVITY_NAMES[activity] || activity}
+            </option>
+          ))}
+        </select>
+
+        {(phaseFilter || activityFilter) && (
+          <button
+            onClick={() => {
+              setPhaseFilter('')
+              setActivityFilter('')
+            }}
+            className="text-sm text-gray-500 hover:text-gray-700"
+          >
+            필터 초기화
+          </button>
+        )}
+      </div>
+
+      {/* Logs List */}
+      {loading && logs.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-indigo-200 border-t-indigo-600"></div>
+          <p className="mt-3 text-sm text-gray-500">{t('loading')}</p>
+        </div>
+      ) : filteredLogs.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-gray-200 py-12">
+          <svg className="h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <p className="mt-3 text-sm text-gray-500">
+            {phaseFilter || activityFilter ? '필터 조건에 맞는 로그가 없습니다' : '아직 분석 로그가 없습니다'}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filteredLogs.map((log) => (
+            <LogCard
+              key={log.id}
+              log={log}
+              isExpanded={expandedLogId === log.id}
+              onToggle={() => handleToggleExpand(log.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/JobListPage.tsx
+++ b/frontend/src/pages/JobListPage.tsx
@@ -193,6 +193,16 @@ export function JobListPage() {
                     </div>
                   </div>
                   <div className="flex items-center gap-3">
+                    {/* Logs link */}
+                    <Link
+                      to={`/jobs/${job.job_id}/logs`}
+                      className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                      title="분석 로그"
+                    >
+                      <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </svg>
+                    </Link>
                     {job.status === 'completed' && (
                       <Link
                         to={`/jobs/${job.job_id}/result`}

--- a/frontend/src/pages/JobStatusPage.tsx
+++ b/frontend/src/pages/JobStatusPage.tsx
@@ -252,6 +252,22 @@ export function JobStatusPage() {
         </div>
       </div>
 
+      {/* Analysis Logs Link */}
+      <div className="mb-6">
+        <Link
+          to={`/jobs/${jobId}/logs`}
+          className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 shadow-sm transition-all hover:border-gray-300 hover:bg-gray-50"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          분석 로그 보기
+          {!isTerminal && connected && (
+            <span className="ml-1 h-2 w-2 animate-pulse rounded-full bg-green-500" />
+          )}
+        </Link>
+      </div>
+
       {/* Timeline */}
       <div className="mb-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
         <h2 className="mb-4 text-sm font-semibold text-gray-900">처리 단계</h2>

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -218,6 +218,15 @@ export function ResultPage() {
           )}
 
           <div className="flex gap-2 no-print">
+            <Link
+              to={`/jobs/${jobId}/logs`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-indigo-300 bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700 transition-colors hover:bg-indigo-100"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              분석 로그
+            </Link>
             <button
               onClick={() => downloadJSON(script, `interview-${jobId?.slice(0, 8)}.json`)}
               className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"


### PR DESCRIPTION
## 개요
Job별 분석 로그를 DB에 저장하고 프론트엔드에서 가독성 좋게 확인할 수 있는 기능 추가

## 주요 변경사항

### Backend

**새 파일:**
- `backend/alembic/versions/003_add_analysis_logs.py` - DB 마이그레이션
- `backend/app/services/analysis_log_service.py` - 로그 CRUD 서비스
- `backend/app/services/activity_logger.py` - Activity 로깅 헬퍼
- `backend/app/api/routes/analysis_logs.py` - REST API 엔드포인트
- `backend/app/api/routes/internal.py` - 내부 로깅 API

**API 엔드포인트:**
| 엔드포인트 | 설명 |
|-----------|------|
| `GET /api/v1/jobs/{job_id}/analysis-logs` | 로그 조회 (필터링 지원) |
| `GET /api/v1/jobs/{job_id}/analysis-summary` | 요약 정보 조회 |
| `WS /api/v1/jobs/{job_id}/logs/ws` | 실시간 로그 스트리밍 |
| `POST /api/internal/analysis-logs` | Activity 로그 기록용 |

**Activity 로깅 추가:**
- document_analysis, code_analysis, jd_analysis
- planning, question_generation (select_topics)

### Frontend

**새 파일:**
- `frontend/src/hooks/useAnalysisLogs.ts` - REST + WebSocket 통합 훅
- `frontend/src/pages/AnalysisLogsPage.tsx` - 로그 조회 페이지

**기능:**
- Phase별 필터링
- Activity별 필터링
- 요약 통계 카드 (총 로그, 완료, 에러, 소요시간)
- 접이식 JSON 상세보기
- 실시간 스트리밍 인디케이터

**네비게이션 추가:**
- JobStatusPage: "분석 로그 보기" 버튼
- JobListPage: 로그 아이콘 버튼
- ResultPage: "분석 로그" 버튼

## 테스트 방법
1. Job 생성 및 분석 실행
2. `/jobs/:jobId/logs` 페이지에서 로그 확인
3. 실시간 스트리밍 확인 (진행 중인 Job)

---
🤖 Generated with [Claude Code](https://claude.ai/code)