### PR TITLE
fix: OAuth callback 라우팅 수정

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -11,7 +11,12 @@ server {
     # Backend API Proxy
     # ============================================
 
-    # Backend OAuth endpoints
+    # Frontend OAuth callback (SPA route) - 반드시 /auth보다 먼저 정의
+    location = /auth/callback {
+        try_files $uri /index.html;
+    }
+
+    # Backend OAuth endpoints (provider별 로그인/콜백)
     location /auth {
         proxy_pass http://iaas-backend:8000;
         proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- Google OAuth 로그인 후 `/auth/callback` 경로에서 "Not Found" 에러 수정
- nginx 설정에 SPA 라우트 처리를 위한 exact match 규칙 추가

## 문제 원인
nginx가 `/auth/*` 패턴의 모든 요청을 백엔드로 프록시하고 있었음:
```nginx
location /auth {
    proxy_pass http://iaas-backend:8000;
    ...
}
```

하지만 `/auth/callback`은 프론트엔드 SPA 라우트로, React Router에서 처리해야 함.

## 해결 방법
`/auth/callback`에 대한 exact match 규칙을 `/auth` 프록시 규칙보다 **먼저** 정의:
```nginx
# Frontend OAuth callback (SPA route) - 반드시 /auth보다 먼저 정의
location = /auth/callback {
    try_files $uri /index.html;
}

# Backend OAuth endpoints (provider별 로그인/콜백)
location /auth {
    proxy_pass http://iaas-backend:8000;
    ...
}
```

## 테스트 결과
```bash
curl -s https://test.mystery-place.com/auth/callback -o /dev/null -w "%{http_code}"
200
```

## Test plan
- [ ] Google OAuth 로그인 시도
- [ ] 로그인 완료 후 `/auth/callback`으로 정상 리다이렉트 확인
- [ ] 프론트엔드에서 토큰 처리 후 메인 페이지 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)