### PR TITLE
feat: v2 출력 포맷 마이그레이션 - 4탭 UI 구조 구현

### DIFF
--- a/backend/app/api/routes/jobs.py
+++ b/backend/app/api/routes/jobs.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from app.models.input import CreateJobRequest, CreateJobResponse
 from app.models.database import CheckpointDB
 from app.services import job_service
+from app.api.transformers import ensure_compatible_format
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/jobs", tags=["jobs"])
@@ -102,15 +103,29 @@ async def get_job(
 @router.get("/{job_id}/result")
 async def get_job_result(
     job_id: str,
+    version: str = Query("v2", regex="^v[12]$", description="API response format version"),
     user: UserDB = Depends(get_current_user_or_api_key),
     db: AsyncSession = Depends(get_db),
 ):
-    """완성된 면접 스크립트 조회"""
+    """완성된 면접 스크립트 조회
+
+    Args:
+        job_id: Job ID
+        version: Response format version (v1 or v2, default v2)
+            - v1: Legacy format with evaluation_scenarios object
+            - v2: New format with scenarios array, intel, analysis, decision
+
+    Returns:
+        Interview script in requested format
+    """
     job = await job_service.get_job(job_id, user.id, db)
     if job.status != "completed" or not job.final_output:
         from app.exceptions import ValidationError
         raise ValidationError("Job is not completed yet")
-    return job.final_output
+
+    # Transform to requested format
+    script = ensure_compatible_format(job.final_output, version)
+    return script
 
 
 WORKFLOW_STEPS = [

--- a/backend/app/api/transformers.py
+++ b/backend/app/api/transformers.py
@@ -1,0 +1,153 @@
+"""
+backend/app/api/transformers.py
+API 응답 포맷 변환기 (v1 ↔ v2)
+"""
+from typing import Any
+
+
+def transform_to_v1_format(script: dict) -> dict:
+    """v2 → v1 포맷 변환 (하위 호환)
+
+    v2의 scenarios 배열 → v1의 evaluation_scenarios 객체
+    v2의 follow_up good/poor 객체 → v1의 scoring 객체
+    """
+    v1_script = {**script}
+
+    # Remove v2-only fields
+    v1_script.pop("intel", None)
+    v1_script.pop("analysis", None)
+    v1_script.pop("decision", None)
+    v1_script.pop("category_weights", None)
+    v1_script.pop("candidate", None)
+
+    questions = v1_script.get("questions", [])
+    for q in questions:
+        # v2 scenarios 배열 → v1 evaluation_scenarios 객체
+        scenarios = q.pop("scenarios", [])
+        if scenarios and not q.get("evaluation_scenarios"):
+            evaluation_scenarios = {
+                "expert": {},
+                "mid": {},
+                "low": {},
+            }
+            for s in scenarios:
+                level = s.get("level", "").lower()
+                if level in evaluation_scenarios:
+                    evaluation_scenarios[level] = {
+                        "description": s.get("text", ""),
+                        "indicators": [],
+                        "score": s.get("score", 0),
+                    }
+            q["evaluation_scenarios"] = evaluation_scenarios
+
+        # v2 title → v1 topic (기존 topic이 없는 경우)
+        if "title" in q and not q.get("topic"):
+            q["topic"] = q.pop("title")
+
+        # v2 answer_keywords (question level) → v1 expected_answer.answer_keywords
+        if "answer_keywords" in q:
+            answer_keywords = q.pop("answer_keywords")
+            if q.get("expected_answer"):
+                if not q["expected_answer"].get("answer_keywords"):
+                    q["expected_answer"]["answer_keywords"] = answer_keywords
+
+        # v2 follow_ups good/poor → v1 scoring
+        for fu in q.get("follow_ups", []):
+            good = fu.pop("good", None)
+            poor = fu.pop("poor", None)
+            trigger = fu.pop("trigger", None)
+
+            # trigger (v2) → trigger_level (v1)
+            if trigger and not fu.get("trigger_level"):
+                fu["trigger_level"] = trigger.lower()
+
+            # good/poor 객체 → scoring 객체
+            if good and poor and not fu.get("scoring"):
+                fu["scoring"] = {
+                    "good": good.get("text", ""),
+                    "good_score": good.get("score", 0),
+                    "poor": poor.get("text", ""),
+                    "poor_score": poor.get("score", 0),
+                }
+
+        # Remove v2-only fields from question
+        q.pop("is_risk", None)
+
+    return v1_script
+
+
+def transform_to_v2_format(script: dict) -> dict:
+    """v1 → v2 포맷 변환
+
+    v1의 evaluation_scenarios 객체 → v2의 scenarios 배열
+    v1의 scoring 객체 → v2의 good/poor 객체
+    """
+    v2_script = {**script}
+
+    questions = v2_script.get("questions", [])
+    for q in questions:
+        # v1 evaluation_scenarios 객체 → v2 scenarios 배열
+        eval_scenarios = q.get("evaluation_scenarios", {})
+        if eval_scenarios and not q.get("scenarios"):
+            scenarios = []
+            level_map = {"expert": "Expert", "mid": "Mid", "low": "Low"}
+            for level_key, level_data in eval_scenarios.items():
+                if isinstance(level_data, dict):
+                    scenarios.append({
+                        "level": level_map.get(level_key, level_key.capitalize()),
+                        "score": level_data.get("score", 0),
+                        "text": level_data.get("description", ""),
+                        "depth_expectations": "",
+                    })
+            q["scenarios"] = sorted(
+                scenarios,
+                key=lambda x: {"Expert": 0, "Mid": 1, "Low": 2}.get(x["level"], 3)
+            )
+
+        # v1 topic → v2 title
+        if q.get("topic") and not q.get("title"):
+            q["title"] = q["topic"]
+
+        # v1 expected_answer.answer_keywords → v2 answer_keywords (question level)
+        expected = q.get("expected_answer", {})
+        if expected and expected.get("answer_keywords") and not q.get("answer_keywords"):
+            q["answer_keywords"] = expected["answer_keywords"]
+
+        # v1 follow_ups scoring → v2 good/poor
+        for fu in q.get("follow_ups", []):
+            scoring = fu.get("scoring", {})
+            trigger_level = fu.get("trigger_level")
+
+            # trigger_level (v1) → trigger (v2)
+            if trigger_level and not fu.get("trigger"):
+                fu["trigger"] = trigger_level.capitalize()
+
+            # scoring 객체 → good/poor 객체
+            if scoring and not fu.get("good"):
+                fu["good"] = {
+                    "text": scoring.get("good", ""),
+                    "score": scoring.get("good_score", 0),
+                }
+                fu["poor"] = {
+                    "text": scoring.get("poor", ""),
+                    "score": scoring.get("poor_score", 0),
+                }
+
+        # Add default is_risk field
+        if "is_risk" not in q:
+            category = q.get("category", "")
+            q["is_risk"] = category == "risk_flags" or "risk" in category.lower()
+
+    # Ensure candidate alias exists
+    if v2_script.get("candidate_summary") and not v2_script.get("candidate"):
+        v2_script["candidate"] = v2_script["candidate_summary"]
+
+    return v2_script
+
+
+def ensure_compatible_format(script: dict, version: str = "v2") -> dict:
+    """요청된 버전에 맞게 스크립트 포맷 보장"""
+    if version == "v1":
+        return transform_to_v1_format(script)
+    else:
+        return transform_to_v2_format(script)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,6 +22,7 @@ from .question import (
     InterviewQuestion, InterviewScript, TerminologyEntry,
     EvaluationScenario, FollowUpQuestion, CodeReference,
     ExpectedAnswer, InterviewerNote, CandidateSummary,
+    ScenarioLevel, FollowUpResponse, AnswerKeyword,
 )
 from .checkpoint import (
     PipelineStep, PIPELINE_STEPS,
@@ -29,6 +30,19 @@ from .checkpoint import (
 )
 from .workflow import WorkflowState, AnalysisPhaseResult
 from .database import Base, UserDB, OAuthAccountDB, APIKeyDB, JobDB, CheckpointDB, EmbeddingDB
+
+# v2 모델
+from .intel import (
+    IntelBrief, JDSummary, CompetencyMatch, GitHubSummary,
+    LinkedInPosition, RequirementMatch,
+)
+from .deep_analysis import (
+    DeepAnalysis, EngineeringDNAItem, RiskFlag, SkillMatchRow,
+)
+from .decision import (
+    DecisionSupport, DecisionSummary, InterviewerGuideTips,
+    JDCompetencyWeight, ResumeTip, CoverLetterInsight,
+)
 
 __all__ = [
     # Enums
@@ -42,12 +56,21 @@ __all__ = [
     "CreateJobRequest", "CreateJobResponse",
     # Analysis
     "CandidateProfile", "CodeAnalysis", "JDAnalysis",
-    # Question
+    # Question (v1/v2)
     "InterviewQuestion", "InterviewScript",
+    "ScenarioLevel", "FollowUpResponse", "AnswerKeyword",
     # Checkpoint
     "PipelineStep", "PIPELINE_STEPS",
     # Workflow
     "WorkflowState",
     # Database ORM
     "Base", "UserDB", "OAuthAccountDB", "APIKeyDB", "JobDB", "CheckpointDB", "EmbeddingDB",
+    # v2 Intel
+    "IntelBrief", "JDSummary", "CompetencyMatch", "GitHubSummary",
+    "LinkedInPosition", "RequirementMatch",
+    # v2 Deep Analysis
+    "DeepAnalysis", "EngineeringDNAItem", "RiskFlag", "SkillMatchRow",
+    # v2 Decision
+    "DecisionSupport", "DecisionSummary", "InterviewerGuideTips",
+    "JDCompetencyWeight", "ResumeTip", "CoverLetterInsight",
 ]

--- a/backend/app/models/decision.py
+++ b/backend/app/models/decision.py
@@ -1,0 +1,51 @@
+"""
+backend/app/models/decision.py
+Decision 탭 데이터 모델
+"""
+from pydantic import BaseModel, Field
+
+
+class DecisionSummary(BaseModel):
+    """후보자 요약"""
+    experience: str
+    jd_match: str
+    level: str
+    strengths: list[str] = Field(default_factory=list)
+    concerns: list[str] = Field(default_factory=list)
+
+
+class ResumeTip(BaseModel):
+    """이력서 기반 확인 포인트"""
+    area: str
+    detail: str
+    source: str
+
+
+class CoverLetterInsight(BaseModel):
+    """커버레터 검증 포인트"""
+    claim: str
+    verify_with: str
+
+
+class InterviewerGuideTips(BaseModel):
+    """면접관 가이드 팁"""
+    interview_flow: str
+    time_allocation: dict[str, str] = Field(default_factory=dict)
+    resume_based_tips: list[ResumeTip] = Field(default_factory=list)
+    cover_letter_insights: list[CoverLetterInsight] = Field(default_factory=list)
+    red_flags_to_watch: list[str] = Field(default_factory=list)
+    positive_signals: list[str] = Field(default_factory=list)
+
+
+class JDCompetencyWeight(BaseModel):
+    """JD 역량 가중치"""
+    competency: str
+    weight: float
+    related_questions: list[int] = Field(default_factory=list)
+
+
+class DecisionSupport(BaseModel):
+    """Decision 탭 데이터"""
+    summary: DecisionSummary
+    interviewer_guide: InterviewerGuideTips
+    jd_competency_map: list[JDCompetencyWeight] = Field(default_factory=list)

--- a/backend/app/models/deep_analysis.py
+++ b/backend/app/models/deep_analysis.py
@@ -1,0 +1,43 @@
+"""
+backend/app/models/deep_analysis.py
+Deep Analysis 탭 데이터 모델
+"""
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class EngineeringDNAItem(BaseModel):
+    """Engineering DNA 항목"""
+    label: str  # 예: "테스트 커버리지"
+    value: int  # 퍼센트 (0-100)
+    display: str  # 표시 텍스트 (예: "82%", "우수", "미확인")
+    color: Literal["emerald", "blue", "amber", "red", "slate"]
+    note: str | None = None  # 추가 설명
+    tooltip: str | None = None  # 마우스오버 설명
+
+
+class RiskFlag(BaseModel):
+    """리스크 플래그"""
+    label: str
+    detail: str
+
+
+class SkillMatchRow(BaseModel):
+    """스킬 매칭 테이블 행"""
+    skill: str  # JD 요구 스킬
+    candidate: str  # 후보자 보유 스킬
+    type: Literal["exact", "similar", "partial", "none"]
+    evidence: str  # 증거 출처
+    confidence: int  # 신뢰도 (0-100)
+
+
+class DeepAnalysis(BaseModel):
+    """Deep Analysis 탭 데이터"""
+    # 5축 레이더 차트: [role_fit, technical, execution, communication, risk]
+    radar_candidate: list[int] = Field(default_factory=list)  # 후보자 점수
+    radar_required: list[int] = Field(default_factory=list)  # JD 요구 점수
+    engineering_dna: list[EngineeringDNAItem] = Field(default_factory=list)
+    risk_flags: list[RiskFlag] = Field(default_factory=list)
+    skill_table: list[SkillMatchRow] = Field(default_factory=list)
+    overall_match: int = 0  # 전체 매칭 퍼센트

--- a/backend/app/models/intel.py
+++ b/backend/app/models/intel.py
@@ -1,0 +1,64 @@
+"""
+backend/app/models/intel.py
+Intel Brief 탭 데이터 모델
+"""
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class RequirementMatch(BaseModel):
+    """JD 요구사항 매칭"""
+    text: str
+    desc: str
+    matched: bool
+
+
+class JDSummary(BaseModel):
+    """JD 요약"""
+    title: str
+    subtitle: str
+    requirements: list[RequirementMatch] = Field(default_factory=list)
+    success_metrics: list[str] = Field(default_factory=list)
+
+
+class CompetencyMatch(BaseModel):
+    """JD 역량 vs 후보자 매칭"""
+    name: str
+    match: Literal["strong", "match", "partial", "unknown", "none"]
+    match_label: str
+    desc: str  # 비개발자용 설명
+    why: str  # 왜 필요한가
+    color: Literal["emerald", "amber", "red", "blue", "slate"]
+    icon: str  # ✅/⚠️/❌
+
+
+class LinkedInPosition(BaseModel):
+    """LinkedIn 경력 항목"""
+    initial: str
+    title: str
+    company: str
+    detail: str
+
+
+class GitHubSummary(BaseModel):
+    """GitHub 기여 활동 요약"""
+    contributions: int
+    repos: int
+    main_languages: str
+    tech_match: str
+    tech_match_note: str
+    tenure_pattern: str
+    tenure_note: str
+    activity_gap: str | None = None
+    chart_data: list[int] = Field(default_factory=list)  # 12개월 기여도 데이터
+
+
+class IntelBrief(BaseModel):
+    """Intel Brief 탭 데이터"""
+    jd_summary: JDSummary
+    jd_full: str | None = None  # JD 원문 HTML
+    competencies: list[CompetencyMatch] = Field(default_factory=list)
+    github: GitHubSummary | None = None
+    linkedin: list[LinkedInPosition] = Field(default_factory=list)
+    linkedin_warning: str | None = None

--- a/backend/app/models/question.py
+++ b/backend/app/models/question.py
@@ -17,8 +17,12 @@ class TerminologyEntry(BaseModel):
     """기술 용어 설명 (비개발자 친화)"""
     term: str
     definition: str
-    plain_language_explanation: str
-    context: str
+    plain_language_explanation: str = ""
+    context: str = ""
+    # v2 추가 필드 (optional for backward compatibility)
+    pronunciation: str | None = None
+    explanation: str | None = None
+    plain_language: str | None = None
 
 
 # --- 키워드 & 채점 ---
@@ -29,7 +33,16 @@ class AnswerKeyword(BaseModel):
     explanation: str
 
 
+# --- v2 꼬리질문 응답 ---
+
+class FollowUpResponse(BaseModel):
+    """꼬리질문 응답 (v2)"""
+    text: str
+    score: int
+
+
 class FollowUpScoring(BaseModel):
+    """꼬리질문 채점 (v1 호환)"""
     good: str
     good_score: int
     poor: str
@@ -39,11 +52,17 @@ class FollowUpScoring(BaseModel):
 class FollowUpQuestion(BaseModel):
     """꼬리질문"""
     id: str
-    trigger_level: Literal["expert", "mid", "low", "any"]
+    # v1: trigger_level, v2: trigger (둘 다 지원)
+    trigger_level: Literal["expert", "mid", "low", "any"] | None = None
+    trigger: Literal["Expert", "Mid", "Low", "any"] | None = None  # v2 format
     question_text: str
     why_matters: str
     listen_for: str
-    scoring: FollowUpScoring
+    # v1 format
+    scoring: FollowUpScoring | None = None
+    # v2 format (개별 good/poor 객체)
+    good: FollowUpResponse | None = None
+    poor: FollowUpResponse | None = None
     terminology: list[TerminologyEntry] = Field(default_factory=list)
 
 
@@ -70,26 +89,42 @@ class CodeEvidence(BaseModel):
 # --- 예상 답변 ---
 
 class ExpectedAnswer(BaseModel):
-    core_answer: str
-    example_script: str
+    # v1 fields
+    core_answer: str = ""
+    example_script: str = ""
     answer_keywords: list[AnswerKeyword] = Field(default_factory=list)
     depth_expectations: dict[str, str] = Field(default_factory=dict)
     code_evidence: list[CodeEvidence] = Field(default_factory=list)
     key_points: list[str] = Field(default_factory=list)
+    # v2 fields
+    core: str | None = None  # v2 alias for core_answer
+    example: str | None = None  # v2 alias for example_script
 
 
 # --- 평가 시나리오 ---
 
 class EvaluationScenarioLevel(BaseModel):
+    """v1 평가 시나리오 레벨"""
     description: str
     indicators: list[str] = Field(default_factory=list)
     score: int
 
 
 class EvaluationScenario(BaseModel):
+    """v1 평가 시나리오 (expert/mid/low 객체)"""
     expert: EvaluationScenarioLevel
     mid: EvaluationScenarioLevel
     low: EvaluationScenarioLevel
+
+
+# --- v2 시나리오 배열 ---
+
+class ScenarioLevel(BaseModel):
+    """v2 시나리오 레벨 (배열 형태)"""
+    level: Literal["Expert", "Mid", "Low"]
+    score: int
+    text: str
+    depth_expectations: str = ""
 
 
 # --- 면접관 노트 ---
@@ -98,6 +133,7 @@ class InterviewerNote(BaseModel):
     business_interpretation: str
     daily_analogy: str
     level_expectations: dict[str, str] | None = None
+    level_expectation: str | None = None  # v2 단일 문자열
 
 
 # --- JD 역량 매핑 ---
@@ -113,24 +149,36 @@ class JDCompetencyMapping(BaseModel):
 # --- 면접 질문 ---
 
 class InterviewQuestion(BaseModel):
-    """면접 질문 (최종 모델)"""
-    id: str
-    sequence: int
-    category: QuestionCategory
-    topic: str
-    difficulty: Difficulty
+    """면접 질문 (최종 모델) - v1/v2 호환"""
+    id: str | int  # v2는 int 사용
+    sequence: int = 0
+    category: QuestionCategory | str  # v2는 string category
+    topic: str = ""
+    difficulty: Difficulty | str  # v2는 string difficulty (Easy/Medium/Hard)
+
+    # v2 추가 필드
+    title: str = ""  # 짧은 제목 (예: "첫 90일 우선순위")
+    is_risk: bool = False  # 위험 신호 검증 질문 여부
 
     question_text: str
-    context_bridge: str
+    context_bridge: str = ""
     alternative_phrasings: list[str] = Field(default_factory=list)
 
     why_matters: str
     listen_for: str
 
     code_reference: CodeReference | None = None
-    evaluation_scenarios: EvaluationScenario
+
+    # v1: evaluation_scenarios (객체)
+    evaluation_scenarios: EvaluationScenario | None = None
+    # v2: scenarios (배열)
+    scenarios: list[ScenarioLevel] = Field(default_factory=list)
+
+    # v2: 질문 레벨 answer_keywords
+    answer_keywords: list[AnswerKeyword] = Field(default_factory=list)
+
     follow_ups: list[FollowUpQuestion] = Field(default_factory=list)
-    expected_answer: ExpectedAnswer
+    expected_answer: ExpectedAnswer | None = None
     terminology: list[TerminologyEntry] = Field(default_factory=list)
 
     language: str = "ko"
@@ -145,23 +193,36 @@ class InterviewQuestion(BaseModel):
 
 class CandidateSummary(BaseModel):
     name: str
-    experience_level: str
-    experience_years: int
+    experience_level: str = ""
+    experience_years: int = 0
     key_skills: list[str] = Field(default_factory=list)
-    jd_match_score: float
+    jd_match_score: float = 0.0
     strengths: list[str] = Field(default_factory=list)
     areas_to_probe: list[str] = Field(default_factory=list)
+    # v2 추가 필드
+    initials: str = ""
+    role: str = ""
+    company_context: str = ""
+    experience: str = ""  # v2 문자열 형태 (예: "7년")
+    jd_match: str = ""  # v2 문자열 형태 (예: "78%")
+    level: str = ""
+    current_title: str = ""
 
 
 class InterviewerGuide(BaseModel):
-    total_duration_minutes: int
-    question_order_rationale: str
+    total_duration_minutes: int = 60
+    question_order_rationale: str = ""
     tips: list[str] = Field(default_factory=list)
     warning_signs: list[str] = Field(default_factory=list)
 
 
+# --- v2 Import ---
+# IntelBrief, DeepAnalysis, DecisionSupport are imported from separate modules
+# to avoid circular imports and keep this file clean
+
+
 class InterviewScript(BaseModel):
-    """최종 면접 스크립트"""
+    """최종 면접 스크립트 - v1/v2 호환"""
     job_id: str
     generated_at: datetime
     output_language: str
@@ -171,3 +232,10 @@ class InterviewScript(BaseModel):
     decision_guide: dict[str, Any] = Field(default_factory=dict)
     full_glossary: list[TerminologyEntry] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    # v2 추가 필드 (Optional for backward compatibility)
+    candidate: CandidateSummary | None = None  # v2 alias
+    intel: Any | None = None  # IntelBrief
+    analysis: Any | None = None  # DeepAnalysis
+    decision: Any | None = None  # DecisionSupport
+    category_weights: dict[str, float] | None = None

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -49,6 +49,8 @@ from app.workflows.activities.knowledge_graph_activities import (
     get_evidence_chain,
     clear_knowledge_graph,
 )
+from app.workflows.activities.intel_generation import generate_intel_brief
+from app.workflows.activities.analysis_generation import generate_deep_analysis
 
 ACTIVITIES = [
     enrich_input,
@@ -79,6 +81,9 @@ ACTIVITIES = [
     get_kg_question_candidates,
     get_evidence_chain,
     clear_knowledge_graph,
+    # v2 Intel/Analysis generation
+    generate_intel_brief,
+    generate_deep_analysis,
 ]
 
 

--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -1,0 +1,277 @@
+"""
+backend/app/workflows/activities/analysis_generation.py
+Deep Analysis 생성 Activity
+"""
+import logging
+from typing import Any
+
+from temporalio import activity
+
+from app.core.observability import observe_activity
+from app.models.deep_analysis import (
+    DeepAnalysis, EngineeringDNAItem, RiskFlag, SkillMatchRow,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _calculate_radar_scores(
+    jd_analysis: dict,
+    code_analysis: dict | None,
+    document_analysis: dict,
+) -> tuple[list[int], list[int]]:
+    """5축 레이더 점수 계산
+
+    축: [role_fit, technical, execution, communication, risk]
+    """
+    # JD 요구 점수 (기본값)
+    required_scores = [80, 80, 60, 70, 70]
+
+    # 후보자 점수 계산
+    candidate_scores = [50, 50, 50, 50, 50]  # 기본값
+
+    profile = document_analysis.get("profile", {})
+    skills = profile.get("skills", [])
+
+    # Role Fit: JD 매칭 점수 기반
+    jd_match = document_analysis.get("jd_match_score", 0.5)
+    candidate_scores[0] = min(100, int(jd_match * 100 + 20))
+
+    # Technical: 기술 스킬 기반
+    if code_analysis:
+        tech_stack = code_analysis.get("tech_stack", [])
+        tech_score = min(100, 50 + len(tech_stack) * 5)
+        candidate_scores[1] = tech_score
+
+        # 코드 품질 지표 반영
+        quality = code_analysis.get("quality_metrics", {})
+        test_coverage = quality.get("test_coverage", 0)
+        candidate_scores[1] = min(100, (candidate_scores[1] + test_coverage) // 2 + 20)
+
+    # Execution: 경험 기반
+    experiences = profile.get("experiences", [])
+    execution_score = min(100, 40 + len(experiences) * 10)
+    candidate_scores[2] = execution_score
+
+    # Communication: 문서 품질 기반
+    if code_analysis:
+        doc_quality = code_analysis.get("quality_metrics", {}).get("documentation_score", 50)
+        candidate_scores[3] = min(100, doc_quality + 20)
+
+    # Risk: 리스크 플래그 기반 (낮을수록 좋음)
+    risk_flags = code_analysis.get("risk_flags", []) if code_analysis else []
+    candidate_scores[4] = max(30, 100 - len(risk_flags) * 15)
+
+    return candidate_scores, required_scores
+
+
+def _analyze_engineering_dna(code_analysis: dict | None) -> list[EngineeringDNAItem]:
+    """Engineering DNA 분석"""
+    items = []
+
+    if not code_analysis:
+        items.append(EngineeringDNAItem(
+            label="코드 분석",
+            value=0,
+            display="미확인",
+            color="slate",
+            note="GitHub 데이터가 제공되지 않았습니다",
+        ))
+        return items
+
+    quality = code_analysis.get("quality_metrics", {})
+
+    # 테스트 커버리지
+    test_coverage = quality.get("test_coverage", 0)
+    items.append(EngineeringDNAItem(
+        label="테스트 커버리지",
+        value=test_coverage,
+        display=f"{test_coverage}%",
+        color="emerald" if test_coverage >= 70 else "amber" if test_coverage >= 40 else "red",
+    ))
+
+    # 문서화 품질
+    doc_score = quality.get("documentation_score", 0)
+    doc_display = "우수" if doc_score >= 80 else "보통" if doc_score >= 50 else "미흡"
+    items.append(EngineeringDNAItem(
+        label="문서화 품질",
+        value=doc_score,
+        display=doc_display,
+        color="blue" if doc_score >= 80 else "amber" if doc_score >= 50 else "red",
+    ))
+
+    # IaC 사용 여부
+    iac_score = quality.get("iac_score", 0)
+    items.append(EngineeringDNAItem(
+        label="IaC",
+        value=iac_score,
+        display="확인됨" if iac_score >= 50 else "미확인",
+        color="emerald" if iac_score >= 50 else "red",
+        note="Terraform, Ansible 같은 자동화 도구 사용 흔적이 GitHub에서 발견되지 않았습니다" if iac_score < 50 else None,
+        tooltip="서버 환경을 코드 파일로 관리하는 방식",
+    ))
+
+    # 코드 복잡도
+    complexity = quality.get("complexity_score", 50)
+    complexity_display = "낮음" if complexity <= 30 else "보통" if complexity <= 70 else "높음"
+    items.append(EngineeringDNAItem(
+        label="코드 복잡도",
+        value=complexity,
+        display=complexity_display,
+        color="emerald" if complexity <= 30 else "amber" if complexity <= 70 else "red",
+    ))
+
+    return items
+
+
+def _extract_risk_flags(
+    code_analysis: dict | None,
+    document_analysis: dict,
+) -> list[RiskFlag]:
+    """리스크 플래그 추출"""
+    flags = []
+
+    # 코드 분석 기반 리스크
+    if code_analysis:
+        code_risks = code_analysis.get("risk_flags", [])
+        for risk in code_risks:
+            if isinstance(risk, dict):
+                flags.append(RiskFlag(
+                    label=risk.get("label", "리스크"),
+                    detail=risk.get("detail", risk.get("description", "")),
+                ))
+            elif isinstance(risk, str):
+                flags.append(RiskFlag(label="주의", detail=risk))
+
+    # 문서 분석 기반 리스크
+    profile = document_analysis.get("profile", {})
+    areas_to_probe = profile.get("areas_to_probe", [])
+    for area in areas_to_probe[:3]:  # 상위 3개
+        if isinstance(area, str):
+            flags.append(RiskFlag(label="확인 필요", detail=area))
+
+    return flags[:5]  # 최대 5개
+
+
+def _build_skill_table(
+    jd_analysis: dict,
+    code_analysis: dict | None,
+    document_analysis: dict,
+) -> list[SkillMatchRow]:
+    """스킬 매칭 테이블 생성"""
+    rows = []
+
+    jd_requirements = jd_analysis.get("requirements", [])
+    candidate_skills = document_analysis.get("profile", {}).get("skills", [])
+    code_skills = code_analysis.get("tech_stack", []) if code_analysis else []
+
+    all_candidate_skills = set(s.lower() for s in candidate_skills + code_skills)
+
+    for req in jd_requirements[:6]:  # 상위 6개
+        skill = req.get("skill", req.get("text", ""))
+        skill_lower = skill.lower()
+
+        # 매칭 타입 결정
+        match_type = "none"
+        candidate_skill = "—"
+        evidence = "증거 없음"
+        confidence = 0
+
+        for cs in candidate_skills:
+            if skill_lower == cs.lower():
+                match_type = "exact"
+                candidate_skill = cs
+                evidence = "이력서"
+                confidence = 95
+                break
+            elif skill_lower in cs.lower() or cs.lower() in skill_lower:
+                match_type = "similar"
+                candidate_skill = cs
+                evidence = "이력서"
+                confidence = 75
+                break
+
+        # 코드 분석에서 확인
+        if match_type == "none" and code_analysis:
+            for cs in code_skills:
+                if skill_lower == cs.lower():
+                    match_type = "exact"
+                    candidate_skill = cs
+                    evidence = "GitHub"
+                    confidence = 90
+                    break
+                elif skill_lower in cs.lower() or cs.lower() in skill_lower:
+                    match_type = "partial"
+                    candidate_skill = cs
+                    evidence = "GitHub"
+                    confidence = 60
+                    break
+
+        rows.append(SkillMatchRow(
+            skill=skill,
+            candidate=candidate_skill,
+            type=match_type,
+            evidence=evidence,
+            confidence=confidence,
+        ))
+
+    return rows
+
+
+@activity.defn
+@observe_activity(name="generate_deep_analysis", phase="finalization")
+async def generate_deep_analysis(
+    jd_analysis: dict,
+    code_analysis: dict | None,
+    document_analysis: dict,
+    job_id: str | None = None,
+) -> dict:
+    """Deep Analysis 생성
+
+    Args:
+        jd_analysis: JD 분석 결과
+        code_analysis: 코드 분석 결과 (optional)
+        document_analysis: 문서 분석 결과
+        job_id: Job ID (observability용)
+
+    Returns:
+        DeepAnalysis 데이터
+    """
+    logger.info(f"Generating Deep Analysis for job_id={job_id}")
+    activity.heartbeat()
+
+    # 1. 5축 레이더 점수 계산
+    radar_candidate, radar_required = _calculate_radar_scores(
+        jd_analysis, code_analysis, document_analysis
+    )
+    activity.heartbeat()
+
+    # 2. Engineering DNA 분석
+    engineering_dna = _analyze_engineering_dna(code_analysis)
+    activity.heartbeat()
+
+    # 3. 리스크 플래그 추출
+    risk_flags = _extract_risk_flags(code_analysis, document_analysis)
+    activity.heartbeat()
+
+    # 4. 스킬 매칭 테이블 생성
+    skill_table = _build_skill_table(jd_analysis, code_analysis, document_analysis)
+
+    # 전체 매칭 점수 계산
+    if skill_table:
+        avg_confidence = sum(row.confidence for row in skill_table) / len(skill_table)
+        overall_match = int(avg_confidence)
+    else:
+        overall_match = 50
+
+    deep_analysis = DeepAnalysis(
+        radar_candidate=radar_candidate,
+        radar_required=radar_required,
+        engineering_dna=engineering_dna,
+        risk_flags=risk_flags,
+        skill_table=skill_table,
+        overall_match=overall_match,
+    )
+
+    logger.info(f"Deep Analysis generated: overall_match={overall_match}%")
+    return deep_analysis.model_dump()

--- a/backend/app/workflows/activities/intel_generation.py
+++ b/backend/app/workflows/activities/intel_generation.py
@@ -1,0 +1,211 @@
+"""
+backend/app/workflows/activities/intel_generation.py
+Intel Brief 생성 Activity
+"""
+import logging
+from typing import Any
+
+from temporalio import activity
+
+from app.core.observability import observe_activity
+from app.models.intel import (
+    IntelBrief, JDSummary, CompetencyMatch, GitHubSummary,
+    LinkedInPosition, RequirementMatch,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_jd_summary(jd_analysis: dict) -> JDSummary:
+    """JD 분석에서 요약 정보 추출"""
+    requirements = jd_analysis.get("requirements", [])
+    req_matches = []
+    for req in requirements[:5]:  # 상위 5개 요구사항
+        req_matches.append(RequirementMatch(
+            text=req.get("skill", req.get("text", "")),
+            desc=req.get("description", req.get("desc", "")),
+            matched=req.get("matched", False),
+        ))
+
+    return JDSummary(
+        title=jd_analysis.get("job_title", jd_analysis.get("title", "Position")),
+        subtitle=jd_analysis.get("company_context", jd_analysis.get("subtitle", "")),
+        requirements=req_matches,
+        success_metrics=jd_analysis.get("success_metrics", []),
+    )
+
+
+def _match_competencies(
+    jd_analysis: dict,
+    document_analysis: dict,
+    code_analysis: dict | None,
+) -> list[CompetencyMatch]:
+    """JD 역량과 후보자 매칭 분석"""
+    competencies = []
+    jd_requirements = jd_analysis.get("requirements", [])
+    candidate_skills = document_analysis.get("profile", {}).get("skills", [])
+    code_skills = []
+    if code_analysis:
+        code_skills = code_analysis.get("tech_stack", [])
+
+    # 색상 및 아이콘 매핑
+    match_config = {
+        "strong": ("emerald", "✅"),
+        "match": ("emerald", "✅"),
+        "partial": ("amber", "⚠️"),
+        "unknown": ("amber", "⚠️"),
+        "none": ("red", "❌"),
+    }
+
+    for req in jd_requirements[:6]:  # 상위 6개 역량
+        skill = req.get("skill", req.get("text", ""))
+        desc = req.get("description", req.get("desc", ""))
+        why = req.get("importance", req.get("why", ""))
+
+        # 매칭 레벨 결정
+        skill_lower = skill.lower()
+        candidate_skills_lower = [s.lower() for s in candidate_skills]
+        code_skills_lower = [s.lower() for s in code_skills]
+
+        match_level = "none"
+        match_label = "후보자: 증거 없음"
+
+        # 정확 매칭 확인
+        if any(skill_lower in cs for cs in candidate_skills_lower + code_skills_lower):
+            match_level = "strong"
+            match_label = "후보자: 강한 매칭"
+        # 부분 매칭 확인
+        elif any(
+            any(word in cs for word in skill_lower.split())
+            for cs in candidate_skills_lower + code_skills_lower
+        ):
+            match_level = "partial"
+            match_label = "후보자: 부분 매칭"
+
+        color, icon = match_config.get(match_level, ("slate", "❓"))
+
+        competencies.append(CompetencyMatch(
+            name=skill,
+            match=match_level,
+            match_label=match_label,
+            desc=desc,
+            why=why,
+            color=color,
+            icon=icon,
+        ))
+
+    return competencies
+
+
+def _extract_github_summary(code_analysis: dict | None) -> GitHubSummary | None:
+    """코드 분석에서 GitHub 요약 추출"""
+    if not code_analysis:
+        return None
+
+    repos = code_analysis.get("repositories", [])
+    total_commits = sum(r.get("commit_count", 0) for r in repos)
+    tech_stack = code_analysis.get("tech_stack", [])
+
+    # 월별 기여도 데이터 (12개월)
+    chart_data = code_analysis.get("monthly_contributions", [0] * 12)
+    if len(chart_data) < 12:
+        chart_data = chart_data + [0] * (12 - len(chart_data))
+
+    return GitHubSummary(
+        contributions=total_commits,
+        repos=len(repos),
+        main_languages=", ".join(tech_stack[:3]) if tech_stack else "N/A",
+        tech_match="높음" if tech_stack else "미확인",
+        tech_match_note=f"{len(tech_stack)}개 기술 스택 확인" if tech_stack else "코드 분석 데이터 없음",
+        tenure_pattern=code_analysis.get("tenure_pattern", "미확인"),
+        tenure_note=code_analysis.get("tenure_note", ""),
+        activity_gap=code_analysis.get("activity_gap"),
+        chart_data=chart_data[:12],
+    )
+
+
+def _extract_linkedin_positions(linkedin_profile: dict | None) -> list[LinkedInPosition]:
+    """LinkedIn 프로필에서 경력 추출"""
+    if not linkedin_profile:
+        return []
+
+    experiences = linkedin_profile.get("experiences", [])
+    positions = []
+
+    for exp in experiences[:5]:  # 최근 5개
+        company = exp.get("company", exp.get("company_name", "Unknown"))
+        title = exp.get("title", exp.get("position", ""))
+        duration = exp.get("duration", exp.get("tenure", ""))
+
+        positions.append(LinkedInPosition(
+            initial=company[0].upper() if company else "?",
+            title=title,
+            company=company,
+            detail=duration,
+        ))
+
+    return positions
+
+
+@activity.defn
+@observe_activity(name="generate_intel_brief", phase="finalization")
+async def generate_intel_brief(
+    jd_analysis: dict,
+    document_analysis: dict,
+    code_analysis: dict | None,
+    linkedin_profile: dict | None,
+    jd_text: str | None = None,
+    job_id: str | None = None,
+) -> dict:
+    """Intel Brief 생성
+
+    Args:
+        jd_analysis: JD 분석 결과
+        document_analysis: 문서 분석 결과
+        code_analysis: 코드 분석 결과 (optional)
+        linkedin_profile: LinkedIn 프로필 (optional)
+        jd_text: JD 원문 (optional)
+        job_id: Job ID (observability용)
+
+    Returns:
+        IntelBrief 데이터
+    """
+    logger.info(f"Generating Intel Brief for job_id={job_id}")
+    activity.heartbeat()
+
+    # 1. JD 요약 생성
+    jd_summary = _extract_jd_summary(jd_analysis)
+    activity.heartbeat()
+
+    # 2. 역량 매칭 분석
+    competencies = _match_competencies(jd_analysis, document_analysis, code_analysis)
+    activity.heartbeat()
+
+    # 3. GitHub 기여도 데이터 포맷
+    github_summary = _extract_github_summary(code_analysis)
+    activity.heartbeat()
+
+    # 4. LinkedIn 타임라인 구성
+    linkedin_positions = _extract_linkedin_positions(linkedin_profile)
+
+    # LinkedIn 경고 메시지
+    linkedin_warning = None
+    if linkedin_profile:
+        warnings = []
+        experiences = linkedin_profile.get("experiences", [])
+        if not any("CTO" in e.get("title", "") or "VP" in e.get("title", "") for e in experiences):
+            warnings.append("CTO/VP 타이틀 경험 없음")
+        if warnings:
+            linkedin_warning = " · ".join(warnings)
+
+    intel_brief = IntelBrief(
+        jd_summary=jd_summary,
+        jd_full=jd_text,
+        competencies=competencies,
+        github=github_summary,
+        linkedin=linkedin_positions,
+        linkedin_warning=linkedin_warning,
+    )
+
+    logger.info(f"Intel Brief generated with {len(competencies)} competencies")
+    return intel_brief.model_dump()

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -34,6 +34,8 @@ with workflow.unsafe.imports_passed_through():
         start_job_trace,
         end_job_trace,
     )
+    from app.workflows.activities.intel_generation import generate_intel_brief
+    from app.workflows.activities.analysis_generation import generate_deep_analysis
 
 logger = logging.getLogger(__name__)
 
@@ -307,6 +309,54 @@ class InterviewGenerationWorkflow:
             # Attach decision guide to final output
             if isinstance(final_script, dict) and decision_guide:
                 final_script["decision_guide"] = decision_guide
+
+            # Phase 4c: Generate v2 Intel and Analysis (병렬)
+            self._update_status(JobStatus.REVIEWING, "Phase 4: Intel/Analysis", 92)
+
+            # Prepare inputs for intel/analysis generation
+            jd_text = raw_input.get("jd_text", "")
+            document_analysis = analysis.get("document_analysis", {})
+            jd_analysis_data = analysis.get("jd_analysis", {})
+            code_analysis_data = analysis.get("code_analysis")
+            linkedin_profile = enriched.get("linkedin_profile")
+
+            intel_analysis_tasks = [
+                workflow.execute_activity(
+                    generate_intel_brief,
+                    args=[
+                        jd_analysis_data,
+                        document_analysis,
+                        code_analysis_data,
+                        linkedin_profile,
+                        jd_text,
+                        job_id,
+                    ],
+                    start_to_close_timeout=timedelta(minutes=2),
+                    heartbeat_timeout=timedelta(seconds=60),
+                    retry_policy=DEFAULT_RETRY,
+                ),
+                workflow.execute_activity(
+                    generate_deep_analysis,
+                    args=[
+                        jd_analysis_data,
+                        code_analysis_data,
+                        document_analysis,
+                        job_id,
+                    ],
+                    start_to_close_timeout=timedelta(minutes=2),
+                    heartbeat_timeout=timedelta(seconds=60),
+                    retry_policy=DEFAULT_RETRY,
+                ),
+            ]
+
+            intel_analysis_results = await asyncio.gather(*intel_analysis_tasks)
+            intel_brief = intel_analysis_results[0]
+            deep_analysis = intel_analysis_results[1]
+
+            # Attach v2 data to final script
+            if isinstance(final_script, dict):
+                final_script["intel"] = intel_brief
+                final_script["analysis"] = deep_analysis
 
             # DB에 결과 저장
             job_id = input_data.get("job_id")

--- a/frontend/e2e/result-page.spec.ts
+++ b/frontend/e2e/result-page.spec.ts
@@ -1,0 +1,445 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * ResultPage E2E Tests
+ * 4-Tab UI (v2) 구조 테스트: Intel Brief → Deep Analysis → Live Interview → Decision
+ */
+
+test.describe('ResultPage - 4 Tab UI', () => {
+  // Mock API response for v2 format
+  const mockV2Response = {
+    job_id: 'test-job-123',
+    generated_at: new Date().toISOString(),
+    output_language: 'ko',
+    candidate_summary: {
+      name: '홍길동',
+      current_title: '시니어 백엔드 개발자',
+      years_experience: 5,
+      key_skills: ['Python', 'FastAPI', 'PostgreSQL'],
+      education: '서울대학교 컴퓨터공학과',
+      key_achievements: ['대규모 API 설계', '성능 최적화 50% 개선'],
+    },
+    intel: {
+      jd_summary: {
+        title: '백엔드 개발자',
+        subtitle: '핀테크 스타트업',
+        requirements: [
+          { text: 'Python 3년 이상', desc: '백엔드 개발 경험', matched: true },
+          { text: 'FastAPI 경험', desc: 'REST API 개발', matched: true },
+        ],
+        success_metrics: ['API 응답시간 100ms 이하', '테스트 커버리지 80%'],
+      },
+      competencies: [
+        {
+          name: 'Python 개발',
+          match: 'strong',
+          match_label: '강점',
+          desc: 'Python 기반 백엔드 개발 능력',
+          why: 'FastAPI 서비스 개발에 필수',
+          color: 'emerald',
+          icon: '✅',
+        },
+        {
+          name: 'DB 설계',
+          match: 'match',
+          match_label: '일치',
+          desc: '데이터베이스 스키마 설계',
+          why: 'PostgreSQL 기반 서비스 운영',
+          color: 'green',
+          icon: '✅',
+        },
+      ],
+      github: {
+        contributions: 1234,
+        repos: 45,
+        main_languages: 'Python, TypeScript',
+        tech_match: '높음',
+        tech_match_note: 'JD 요구 기술과 높은 일치도',
+        tenure_pattern: '안정적',
+        tenure_note: '평균 2.5년 재직',
+        activity_gap: null,
+        chart_data: [50, 60, 45, 80, 90, 100, 75, 85, 95, 88, 92, 78],
+      },
+      linkedin: [
+        { company: 'ABC 테크', role: '시니어 개발자', period: '2022-현재' },
+        { company: 'XYZ 스타트업', role: '개발자', period: '2019-2022' },
+      ],
+      linkedin_warning: null,
+    },
+    analysis: {
+      radar_candidate: [85, 80, 75, 70, 65],
+      radar_required: [80, 75, 70, 75, 60],
+      engineering_dna: [
+        { label: '테스트 커버리지', value: 82, display: '82%', color: 'emerald', note: '우수', tooltip: '단위 테스트 커버리지' },
+        { label: '코드 리뷰 참여', value: 90, display: '90%', color: 'emerald', note: '우수', tooltip: 'PR 리뷰 참여율' },
+        { label: '문서화', value: 65, display: '65%', color: 'amber', note: '보통', tooltip: 'README 및 API 문서화' },
+      ],
+      risk_flags: [],
+      skill_table: [
+        { skill: 'Python', candidate: 'Python 3.11', type: 'exact', evidence: 'GitHub', confidence: 95 },
+        { skill: 'FastAPI', candidate: 'FastAPI', type: 'exact', evidence: '이력서', confidence: 90 },
+        { skill: 'PostgreSQL', candidate: 'PostgreSQL', type: 'exact', evidence: 'GitHub', confidence: 85 },
+      ],
+      overall_match: 82,
+    },
+    questions: [
+      {
+        id: 'q1',
+        title: '첫 90일 우선순위',
+        category: 'behavioral',
+        difficulty: 'mid',
+        question_text: '입사 후 첫 90일 동안 어떤 우선순위로 업무를 진행하시겠습니까?',
+        why_matters: '온보딩 역량과 전략적 사고력 평가',
+        listen_for: '체계적 접근, 팀 협업, 비즈니스 이해',
+        answer_keywords: [
+          { keyword: '온보딩', importance: 'must', explanation: '체계적 적응 계획' },
+          { keyword: '팀 이해', importance: 'good_to_have', explanation: '협업 중시' },
+        ],
+        scenarios: [
+          { level: 'Expert', score: 20, text: '구체적 90일 계획 제시', depth_expectations: '주차별 목표 명확' },
+          { level: 'Mid', score: 12, text: '기본적인 계획 제시', depth_expectations: '일반적 접근' },
+          { level: 'Low', score: 5, text: '모호한 답변', depth_expectations: '구체성 부족' },
+        ],
+        follow_ups: [
+          {
+            id: 'q1-f1',
+            trigger: 'Expert',
+            question_text: '예상되는 어려움과 대응 전략은?',
+            why_matters: '문제 해결 능력',
+            listen_for: '사전 대비, 리스크 관리',
+            good: { text: '구체적 리스크 식별', score: 8 },
+            poor: { text: '문제 인식 부족', score: 2 },
+          },
+        ],
+        terminology: [],
+        interviewer_note: {
+          business_interpretation: '신규 입사자의 전략적 사고력을 평가합니다',
+          daily_analogy: '새 집으로 이사했을 때 정착 계획과 비슷합니다',
+          level_expectation: '시니어: 구체적 실행계획, 주니어: 학습 의지',
+        },
+        is_risk: false,
+      },
+      {
+        id: 'q2',
+        title: 'API 설계 경험',
+        category: 'technical',
+        difficulty: 'hard',
+        question_text: '대규모 트래픽을 처리하는 API를 설계한 경험을 설명해주세요.',
+        why_matters: '기술적 깊이와 실무 경험 평가',
+        listen_for: '확장성, 캐싱, 로드밸런싱',
+        answer_keywords: [
+          { keyword: '캐싱', importance: 'must', explanation: '성능 최적화' },
+          { keyword: '로드밸런싱', importance: 'good_to_have', explanation: '트래픽 분산' },
+        ],
+        scenarios: [
+          { level: 'Expert', score: 25, text: '구체적 아키텍처 설명', depth_expectations: '수치 기반 성능 개선' },
+          { level: 'Mid', score: 15, text: '일반적 접근 설명', depth_expectations: '기본 개념 이해' },
+          { level: 'Low', score: 5, text: '경험 부족', depth_expectations: '이론적 지식만' },
+        ],
+        follow_ups: [],
+        terminology: [
+          { term: 'CDN', definition: 'Content Delivery Network, 콘텐츠 전송 네트워크' },
+        ],
+        interviewer_note: {
+          business_interpretation: '실제 프로덕션 경험을 검증합니다',
+          daily_analogy: '고속도로 톨게이트 병목 해결과 비슷합니다',
+          level_expectation: '시니어: 직접 설계 경험, 주니어: 학습 경험',
+        },
+        is_risk: false,
+      },
+    ],
+    decision: {
+      summary: {
+        experience: '5년',
+        jd_match: '높음',
+        level: '시니어',
+        strengths: ['Python 전문성', 'API 설계 경험', '팀 협업 능력'],
+        concerns: ['프론트엔드 경험 부족', '대기업 경험 없음'],
+      },
+      interviewer_guide: {
+        interview_flow: '기술 심층 → 행동 면접 → 문화 적합성',
+        time_allocation: { '기술 심층': '40분', '행동 면접': '15분', '문화 적합성': '5분' },
+        resume_based_tips: [
+          { section: '경력', insight: 'API 설계 경험 심층 확인', question_link: 'Q2 참조' },
+        ],
+        cover_letter_insights: [],
+        red_flags_to_watch: ['기술 깊이 부족 시 추가 검증'],
+        positive_signals: ['구체적 수치 기반 답변', '팀 협업 사례'],
+      },
+      jd_competency_map: [
+        { competency: 'Python 개발', weight: 0.3, related_questions: [2] },
+        { competency: '시스템 설계', weight: 0.25, related_questions: [2] },
+        { competency: '팀 협업', weight: 0.2, related_questions: [1] },
+      ],
+    },
+    category_weights: {
+      technical: 0.4,
+      behavioral: 0.3,
+      cultural: 0.15,
+      problem_solving: 0.15,
+    },
+    interviewer_guide: {
+      preparation: '이력서 기반 질문 준비',
+      time_per_question: '5분',
+      evaluation_criteria: '구체성, 논리성, 실무 경험',
+    },
+    full_glossary: [
+      { term: 'API', definition: 'Application Programming Interface' },
+      { term: 'CDN', definition: 'Content Delivery Network' },
+    ],
+    metadata: {
+      version: 'v2',
+      generated_by: 'test',
+    },
+  }
+
+  test.beforeEach(async ({ page }) => {
+    // Mock API responses
+    await page.route('**/api/v1/jobs/test-job-123/result**', async (route) => {
+      const url = route.request().url()
+      if (url.includes('version=v2') || !url.includes('version=')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockV2Response),
+        })
+      } else {
+        // v1 fallback (simplified)
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ...mockV2Response,
+            intel: undefined,
+            analysis: undefined,
+            decision: undefined,
+          }),
+        })
+      }
+    })
+
+    // Navigate to result page
+    await page.goto('/result/test-job-123')
+  })
+
+  test('4개 탭이 모두 표시되어야 함', async ({ page }) => {
+    // Wait for page to load
+    await page.waitForLoadState('networkidle')
+
+    // Check all 4 tabs are visible
+    await expect(page.getByRole('tab', { name: /intel brief/i })).toBeVisible()
+    await expect(page.getByRole('tab', { name: /deep analysis/i })).toBeVisible()
+    await expect(page.getByRole('tab', { name: /live interview/i })).toBeVisible()
+    await expect(page.getByRole('tab', { name: /decision/i })).toBeVisible()
+  })
+
+  test('Intel Brief 탭 - JD 요약 및 역량 매칭 표시', async ({ page }) => {
+    await page.waitForLoadState('networkidle')
+
+    // Click Intel Brief tab (should be default)
+    const intelTab = page.getByRole('tab', { name: /intel brief/i })
+    await intelTab.click()
+
+    // Check JD summary content
+    await expect(page.getByText('백엔드 개발자')).toBeVisible()
+    await expect(page.getByText('핀테크 스타트업')).toBeVisible()
+
+    // Check competency matching
+    await expect(page.getByText('Python 개발')).toBeVisible()
+    await expect(page.getByText('강점')).toBeVisible()
+
+    // Check GitHub chart data exists
+    await expect(page.locator('svg').first()).toBeVisible()
+  })
+
+  test('Deep Analysis 탭 - 레이더 차트 및 스킬 테이블 표시', async ({ page }) => {
+    await page.waitForLoadState('networkidle')
+
+    // Click Deep Analysis tab
+    const analysisTab = page.getByRole('tab', { name: /deep analysis/i })
+    await analysisTab.click()
+
+    // Check overall match score
+    await expect(page.getByText('82%')).toBeVisible()
+
+    // Check radar chart exists (SVG)
+    await expect(page.locator('svg').first()).toBeVisible()
+
+    // Check engineering DNA items
+    await expect(page.getByText('테스트 커버리지')).toBeVisible()
+    await expect(page.getByText('코드 리뷰 참여')).toBeVisible()
+
+    // Check skill table
+    await expect(page.getByText('Python 3.11')).toBeVisible()
+    await expect(page.getByText('FastAPI')).toBeVisible()
+  })
+
+  test('Live Interview 탭 - 질문 선택 및 채점 UI', async ({ page }) => {
+    await page.waitForLoadState('networkidle')
+
+    // Click Live Interview tab
+    const interviewTab = page.getByRole('tab', { name: /live interview/i })
+    await interviewTab.click()
+
+    // Check question selection phase
+    await expect(page.getByText('첫 90일 우선순위')).toBeVisible()
+    await expect(page.getByText('API 설계 경험')).toBeVisible()
+
+    // Click on first question to select
+    const firstQuestion = page.getByText('첫 90일 우선순위')
+    await firstQuestion.click()
+
+    // Check question details are shown
+    await expect(page.getByText('입사 후 첫 90일 동안')).toBeVisible()
+  })
+
+  test('Decision 탭 - 채용 추천 및 가이드 표시', async ({ page }) => {
+    await page.waitForLoadState('networkidle')
+
+    // Click Decision tab
+    const decisionTab = page.getByRole('tab', { name: /decision/i })
+    await decisionTab.click()
+
+    // Check candidate summary
+    await expect(page.getByText('5년')).toBeVisible()
+    await expect(page.getByText('높음')).toBeVisible()
+    await expect(page.getByText('시니어')).toBeVisible()
+
+    // Check strengths and concerns
+    await expect(page.getByText('Python 전문성')).toBeVisible()
+    await expect(page.getByText('프론트엔드 경험 부족')).toBeVisible()
+
+    // Check interviewer guide
+    await expect(page.getByText('기술 심층 → 행동 면접 → 문화 적합성')).toBeVisible()
+  })
+
+  test('탭 간 전환이 올바르게 작동해야 함', async ({ page }) => {
+    await page.waitForLoadState('networkidle')
+
+    // Navigate through all tabs
+    const tabs = [
+      { name: /intel brief/i, content: '백엔드 개발자' },
+      { name: /deep analysis/i, content: '테스트 커버리지' },
+      { name: /live interview/i, content: '첫 90일 우선순위' },
+      { name: /decision/i, content: 'Python 전문성' },
+    ]
+
+    for (const tab of tabs) {
+      await page.getByRole('tab', { name: tab.name }).click()
+      await expect(page.getByText(tab.content)).toBeVisible()
+    }
+  })
+
+  test('후보자 정보가 헤더에 표시되어야 함', async ({ page }) => {
+    await page.waitForLoadState('networkidle')
+
+    // Check candidate info in header
+    await expect(page.getByText('홍길동')).toBeVisible()
+    await expect(page.getByText('시니어 백엔드 개발자')).toBeVisible()
+  })
+
+  test('JSON 내보내기 버튼이 작동해야 함', async ({ page }) => {
+    await page.waitForLoadState('networkidle')
+
+    // Find and click export button
+    const exportButton = page.getByRole('button', { name: /export|내보내기|json/i })
+
+    if (await exportButton.isVisible()) {
+      // Set up download handler
+      const downloadPromise = page.waitForEvent('download')
+      await exportButton.click()
+      const download = await downloadPromise
+
+      // Verify download started
+      expect(download.suggestedFilename()).toContain('.json')
+    }
+  })
+})
+
+test.describe('ResultPage - v1 Fallback', () => {
+  const mockV1Response = {
+    job_id: 'test-job-v1',
+    questions: [
+      {
+        id: 'q1',
+        topic: '기술 질문',
+        category: 'technical',
+        difficulty: 'mid',
+        question_text: '테스트 질문입니다.',
+        why_matters: '테스트 이유',
+        listen_for: '테스트 항목',
+        evaluation_scenarios: {
+          expert: { text: '전문가 답변', score: 20 },
+          mid: { text: '중급 답변', score: 12 },
+          low: { text: '초급 답변', score: 5 },
+        },
+        follow_up_questions: [],
+        terminology: [],
+      },
+    ],
+    candidate_summary: {
+      name: 'v1 후보자',
+      current_title: '개발자',
+      years_experience: 3,
+    },
+    interviewer_guide: {
+      preparation: '준비 사항',
+    },
+    full_glossary: [],
+    metadata: { version: 'v1' },
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/v1/jobs/test-job-v1/result**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockV1Response),
+      })
+    })
+
+    await page.goto('/result/test-job-v1')
+  })
+
+  test('v1 데이터로 fallback 탭 구조가 표시되어야 함', async ({ page }) => {
+    await page.waitForLoadState('networkidle')
+
+    // v1 format should show fallback tabs
+    await expect(page.getByRole('tab', { name: /questions|질문/i })).toBeVisible()
+  })
+})
+
+test.describe('ResultPage - 로딩 및 에러 상태', () => {
+  test('로딩 상태가 표시되어야 함', async ({ page }) => {
+    // Delay the response to see loading state
+    await page.route('**/api/v1/jobs/*/result**', async (route) => {
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ questions: [] }),
+      })
+    })
+
+    await page.goto('/result/test-job-loading')
+
+    // Check for loading indicator
+    await expect(page.getByText(/loading|로딩|불러오는/i)).toBeVisible()
+  })
+
+  test('에러 상태가 표시되어야 함', async ({ page }) => {
+    await page.route('**/api/v1/jobs/*/result**', async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Job not found' }),
+      })
+    })
+
+    await page.goto('/result/non-existent-job')
+    await page.waitForLoadState('networkidle')
+
+    // Check for error message
+    await expect(page.getByText(/error|에러|오류|찾을 수 없|not found/i)).toBeVisible()
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
@@ -19,6 +21,7 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@eslint/js": "^9.39.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/frontend/src/components/charts/ContributionChart.tsx
+++ b/frontend/src/components/charts/ContributionChart.tsx
@@ -1,0 +1,134 @@
+/**
+ * ContributionChart - Line chart for GitHub contribution data
+ *
+ * Shows 12-month contribution history with area fill.
+ */
+
+interface ContributionChartProps {
+  /** Monthly contribution counts (12 values) */
+  data: number[]
+  /** Optional month labels */
+  labels?: string[]
+  /** Chart width */
+  width?: number
+  /** Chart height */
+  height?: number
+  /** Line color */
+  color?: string
+}
+
+const DEFAULT_LABELS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+]
+
+export function ContributionChart({
+  data,
+  labels = DEFAULT_LABELS,
+  width = 400,
+  height = 150,
+  color = '#6366f1'
+}: ContributionChartProps) {
+  const padding = { top: 20, right: 20, bottom: 30, left: 40 }
+  const chartWidth = width - padding.left - padding.right
+  const chartHeight = height - padding.top - padding.bottom
+
+  const maxValue = Math.max(...data, 10)
+  const minValue = 0
+
+  // Calculate point positions
+  const points = data.map((value, index) => ({
+    x: padding.left + (index / (data.length - 1)) * chartWidth,
+    y: padding.top + chartHeight - ((value - minValue) / (maxValue - minValue)) * chartHeight
+  }))
+
+  // Generate path for line
+  const linePath = points
+    .map((p, i) => (i === 0 ? `M ${p.x} ${p.y}` : `L ${p.x} ${p.y}`))
+    .join(' ')
+
+  // Generate path for area fill
+  const areaPath = `${linePath} L ${points[points.length - 1].x} ${padding.top + chartHeight} L ${points[0].x} ${padding.top + chartHeight} Z`
+
+  // Y-axis ticks
+  const yTicks = [0, Math.round(maxValue / 2), maxValue]
+
+  return (
+    <svg width={width} height={height} className="overflow-visible">
+      {/* Grid lines */}
+      {yTicks.map((tick) => {
+        const y = padding.top + chartHeight - (tick / maxValue) * chartHeight
+        return (
+          <g key={tick}>
+            <line
+              x1={padding.left}
+              y1={y}
+              x2={width - padding.right}
+              y2={y}
+              stroke="#e5e7eb"
+              strokeWidth={1}
+            />
+            <text
+              x={padding.left - 8}
+              y={y}
+              textAnchor="end"
+              dominantBaseline="middle"
+              className="fill-gray-400 text-xs"
+            >
+              {tick}
+            </text>
+          </g>
+        )
+      })}
+
+      {/* Area fill */}
+      <path
+        d={areaPath}
+        fill={`${color}20`}
+      />
+
+      {/* Line */}
+      <path
+        d={linePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* Data points */}
+      {points.map((point, index) => (
+        <g key={index}>
+          <circle
+            cx={point.x}
+            cy={point.y}
+            r={4}
+            fill="white"
+            stroke={color}
+            strokeWidth={2}
+          />
+          {/* Tooltip on hover - value */}
+          <title>{`${labels[index]}: ${data[index]}`}</title>
+        </g>
+      ))}
+
+      {/* X-axis labels (show every other month for space) */}
+      {labels.map((label, index) => {
+        if (index % 2 !== 0 && index !== labels.length - 1) return null
+        const x = padding.left + (index / (data.length - 1)) * chartWidth
+        return (
+          <text
+            key={index}
+            x={x}
+            y={height - 8}
+            textAnchor="middle"
+            className="fill-gray-500 text-xs"
+          >
+            {label}
+          </text>
+        )
+      })}
+    </svg>
+  )
+}

--- a/frontend/src/components/charts/ProgressBar.tsx
+++ b/frontend/src/components/charts/ProgressBar.tsx
@@ -1,0 +1,149 @@
+/**
+ * ProgressBar - Animated progress bar for Engineering DNA display
+ */
+
+interface ProgressBarProps {
+  /** Label text */
+  label: string
+  /** Value (0-100) */
+  value: number
+  /** Display text (e.g., "82%", "우수", "미확인") */
+  display: string
+  /** Color variant */
+  color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray'
+  /** Optional note text */
+  note?: string
+  /** Optional tooltip text */
+  tooltip?: string
+}
+
+const colorMap = {
+  emerald: {
+    bg: 'bg-emerald-100',
+    fill: 'bg-emerald-500',
+    text: 'text-emerald-700',
+    border: 'border-emerald-200'
+  },
+  blue: {
+    bg: 'bg-blue-100',
+    fill: 'bg-blue-500',
+    text: 'text-blue-700',
+    border: 'border-blue-200'
+  },
+  amber: {
+    bg: 'bg-amber-100',
+    fill: 'bg-amber-500',
+    text: 'text-amber-700',
+    border: 'border-amber-200'
+  },
+  red: {
+    bg: 'bg-red-100',
+    fill: 'bg-red-500',
+    text: 'text-red-700',
+    border: 'border-red-200'
+  },
+  gray: {
+    bg: 'bg-gray-100',
+    fill: 'bg-gray-400',
+    text: 'text-gray-600',
+    border: 'border-gray-200'
+  }
+}
+
+export function ProgressBar({
+  label,
+  value,
+  display,
+  color,
+  note,
+  tooltip
+}: ProgressBarProps) {
+  const colors = colorMap[color]
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-700">{label}</span>
+          {tooltip && (
+            <span className="group relative">
+              <svg
+                className="w-4 h-4 text-gray-400 cursor-help"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-48 p-2 bg-gray-900 text-white text-xs rounded-lg shadow-lg z-10">
+                {tooltip}
+              </span>
+            </span>
+          )}
+        </div>
+        <span className={`text-sm font-semibold ${colors.text}`}>{display}</span>
+      </div>
+
+      <div className={`h-2.5 rounded-full ${colors.bg} overflow-hidden`}>
+        <div
+          className={`h-full rounded-full ${colors.fill} transition-all duration-500 ease-out`}
+          style={{ width: `${Math.min(value, 100)}%` }}
+        />
+      </div>
+
+      {note && (
+        <p className={`text-xs ${colors.text} ${colors.bg} ${colors.border} border rounded-md px-2 py-1`}>
+          ℹ️ {note}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/**
+ * ProgressBarGroup - Multiple progress bars in a card
+ */
+interface ProgressBarGroupProps {
+  title: string
+  items: Array<{
+    label: string
+    value: number
+    display: string
+    color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray'
+    note?: string
+    tooltip?: string
+  }>
+}
+
+export function ProgressBarGroup({ title, items }: ProgressBarGroupProps) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+      <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+        <svg
+          className="w-5 h-5 text-indigo-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+          />
+        </svg>
+        {title}
+      </h3>
+      <div className="space-y-4">
+        {items.map((item, index) => (
+          <ProgressBar key={index} {...item} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/charts/RadarChart.tsx
+++ b/frontend/src/components/charts/RadarChart.tsx
@@ -1,0 +1,173 @@
+/**
+ * RadarChart - 5-axis radar chart for candidate vs required comparison
+ *
+ * Uses pure SVG for rendering without external dependencies.
+ */
+
+interface RadarChartProps {
+  /** Candidate scores (5 values, 0-100) */
+  candidateData: number[]
+  /** Required scores (5 values, 0-100) */
+  requiredData: number[]
+  /** Labels for each axis */
+  labels?: string[]
+  /** Chart size in pixels */
+  size?: number
+}
+
+const DEFAULT_LABELS = [
+  '역할 적합도',
+  '기술 역량',
+  '실행력',
+  '커뮤니케이션',
+  '위험 요소'
+]
+
+export function RadarChart({
+  candidateData,
+  requiredData,
+  labels = DEFAULT_LABELS,
+  size = 300
+}: RadarChartProps) {
+  const center = size / 2
+  const maxRadius = size * 0.4
+  const numAxes = 5
+  const angleStep = (2 * Math.PI) / numAxes
+  const startAngle = -Math.PI / 2 // Start from top
+
+  // Calculate point position on radar
+  const getPoint = (value: number, axisIndex: number): { x: number; y: number } => {
+    const angle = startAngle + axisIndex * angleStep
+    const radius = (value / 100) * maxRadius
+    return {
+      x: center + radius * Math.cos(angle),
+      y: center + radius * Math.sin(angle)
+    }
+  }
+
+  // Generate polygon points string
+  const getPolygonPoints = (data: number[]): string => {
+    return data
+      .map((value, i) => {
+        const point = getPoint(value, i)
+        return `${point.x},${point.y}`
+      })
+      .join(' ')
+  }
+
+  // Generate grid lines
+  const gridLevels = [20, 40, 60, 80, 100]
+
+  return (
+    <div className="relative">
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        {/* Background grid circles */}
+        {gridLevels.map((level) => {
+          const radius = (level / 100) * maxRadius
+          const points = Array.from({ length: numAxes }, (_, i) => {
+            const angle = startAngle + i * angleStep
+            return `${center + radius * Math.cos(angle)},${center + radius * Math.sin(angle)}`
+          }).join(' ')
+          return (
+            <polygon
+              key={level}
+              points={points}
+              fill="none"
+              stroke="#e5e7eb"
+              strokeWidth={1}
+            />
+          )
+        })}
+
+        {/* Axis lines */}
+        {Array.from({ length: numAxes }, (_, i) => {
+          const angle = startAngle + i * angleStep
+          const endX = center + maxRadius * Math.cos(angle)
+          const endY = center + maxRadius * Math.sin(angle)
+          return (
+            <line
+              key={i}
+              x1={center}
+              y1={center}
+              x2={endX}
+              y2={endY}
+              stroke="#d1d5db"
+              strokeWidth={1}
+            />
+          )
+        })}
+
+        {/* Required polygon (background) */}
+        <polygon
+          points={getPolygonPoints(requiredData)}
+          fill="rgba(99, 102, 241, 0.2)"
+          stroke="#6366f1"
+          strokeWidth={2}
+          strokeDasharray="4 2"
+        />
+
+        {/* Candidate polygon (foreground) */}
+        <polygon
+          points={getPolygonPoints(candidateData)}
+          fill="rgba(16, 185, 129, 0.3)"
+          stroke="#10b981"
+          strokeWidth={2}
+        />
+
+        {/* Data points */}
+        {candidateData.map((value, i) => {
+          const point = getPoint(value, i)
+          return (
+            <circle
+              key={i}
+              cx={point.x}
+              cy={point.y}
+              r={4}
+              fill="#10b981"
+              stroke="white"
+              strokeWidth={2}
+            />
+          )
+        })}
+
+        {/* Labels */}
+        {labels.map((label, i) => {
+          const angle = startAngle + i * angleStep
+          const labelRadius = maxRadius + 25
+          const x = center + labelRadius * Math.cos(angle)
+          const y = center + labelRadius * Math.sin(angle)
+
+          // Adjust text anchor based on position
+          let textAnchor: 'start' | 'middle' | 'end' = 'middle'
+          if (Math.cos(angle) > 0.3) textAnchor = 'start'
+          else if (Math.cos(angle) < -0.3) textAnchor = 'end'
+
+          return (
+            <text
+              key={i}
+              x={x}
+              y={y}
+              textAnchor={textAnchor}
+              dominantBaseline="middle"
+              className="fill-gray-600 text-xs font-medium"
+            >
+              {label}
+            </text>
+          )
+        })}
+      </svg>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-6 mt-4">
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-0.5 bg-emerald-500"></div>
+          <span className="text-xs text-gray-600">후보자</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-0.5 bg-indigo-500" style={{ borderStyle: 'dashed' }}></div>
+          <span className="text-xs text-gray-600">요구 수준</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/charts/index.ts
+++ b/frontend/src/components/charts/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Chart component exports
+ */
+export { RadarChart } from './RadarChart'
+export { ContributionChart } from './ContributionChart'
+export { ProgressBar, ProgressBarGroup } from './ProgressBar'

--- a/frontend/src/components/tabs/DecisionTab.tsx
+++ b/frontend/src/components/tabs/DecisionTab.tsx
@@ -1,0 +1,274 @@
+/**
+ * DecisionTab - JD Competency Achievement + Hiring Recommendation
+ */
+import type { DecisionSupport, Candidate, CategoryWeights } from '../../types/interview'
+
+interface DecisionTabProps {
+  decision: DecisionSupport
+  candidate?: Candidate
+  categoryWeights?: CategoryWeights
+  totalScore?: number
+  maxScore?: number
+}
+
+export function DecisionTab({
+  decision,
+  candidate,
+  categoryWeights,
+  totalScore = 0,
+  maxScore = 100
+}: DecisionTabProps) {
+  const { summary, interviewer_guide, jd_competency_map } = decision
+  const scorePercent = maxScore > 0 ? Math.round((totalScore / maxScore) * 100) : 0
+
+  // Determine recommendation based on score
+  const getRecommendation = () => {
+    if (scorePercent >= 80) return { label: 'Strong Hire', color: 'emerald', icon: '🌟' }
+    if (scorePercent >= 60) return { label: 'Hire', color: 'green', icon: '✅' }
+    if (scorePercent >= 40) return { label: 'Leaning No', color: 'amber', icon: '⚠️' }
+    return { label: 'No Hire', color: 'red', icon: '❌' }
+  }
+
+  const recommendation = getRecommendation()
+
+  return (
+    <div className="space-y-6">
+      {/* Score Summary Card */}
+      <div className={`bg-gradient-to-r ${
+        recommendation.color === 'emerald' ? 'from-emerald-500 to-teal-600' :
+        recommendation.color === 'green' ? 'from-green-500 to-emerald-600' :
+        recommendation.color === 'amber' ? 'from-amber-500 to-orange-600' :
+        'from-red-500 to-rose-600'
+      } rounded-xl p-6 text-white shadow-lg`}>
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-medium opacity-90">채용 추천</h3>
+            <p className="text-4xl font-bold mt-1">{recommendation.icon} {recommendation.label}</p>
+            {candidate && (
+              <p className="text-sm opacity-80 mt-2">{candidate.name} · {candidate.role || candidate.current_title}</p>
+            )}
+          </div>
+          <div className="text-right">
+            <div className="text-5xl font-bold">{scorePercent}%</div>
+            <div className="text-sm opacity-80">{totalScore} / {maxScore} 점</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Decision Summary */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+          <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          후보자 요약
+        </h3>
+
+        <div className="grid sm:grid-cols-3 gap-4 mb-6">
+          <div className="p-4 bg-gray-50 rounded-lg">
+            <div className="text-sm text-gray-500">경력</div>
+            <div className="font-semibold text-gray-900">{summary.experience}</div>
+          </div>
+          <div className="p-4 bg-gray-50 rounded-lg">
+            <div className="text-sm text-gray-500">JD 매칭</div>
+            <div className="font-semibold text-gray-900">{summary.jd_match}</div>
+          </div>
+          <div className="p-4 bg-gray-50 rounded-lg">
+            <div className="text-sm text-gray-500">레벨</div>
+            <div className="font-semibold text-gray-900">{summary.level}</div>
+          </div>
+        </div>
+
+        <div className="grid sm:grid-cols-2 gap-6">
+          {/* Strengths */}
+          <div className="p-4 bg-emerald-50 rounded-xl border border-emerald-200">
+            <h4 className="font-semibold text-emerald-900 mb-3 flex items-center gap-2">
+              <span>✅</span> 강점
+            </h4>
+            <ul className="space-y-2">
+              {summary.strengths.map((strength, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-emerald-800">
+                  <span className="text-emerald-500 mt-0.5">•</span>
+                  {strength}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Concerns */}
+          <div className="p-4 bg-amber-50 rounded-xl border border-amber-200">
+            <h4 className="font-semibold text-amber-900 mb-3 flex items-center gap-2">
+              <span>⚠️</span> 우려 사항
+            </h4>
+            <ul className="space-y-2">
+              {summary.concerns.map((concern, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-amber-800">
+                  <span className="text-amber-500 mt-0.5">•</span>
+                  {concern}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* JD Competency Map */}
+      {jd_competency_map && jd_competency_map.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            JD 역량 달성도
+          </h3>
+
+          <div className="space-y-4">
+            {jd_competency_map.map((comp, i) => (
+              <div key={i} className="p-4 bg-gray-50 rounded-lg">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="font-medium text-gray-900">{comp.competency}</span>
+                  <span className="text-sm text-indigo-600 font-semibold">
+                    가중치: {Math.round(comp.weight * 100)}%
+                  </span>
+                </div>
+                <div className="h-2 bg-gray-200 rounded-full overflow-hidden mb-2">
+                  <div
+                    className="h-full bg-indigo-500 rounded-full"
+                    style={{ width: `${comp.weight * 100}%` }}
+                  />
+                </div>
+                {comp.related_questions.length > 0 && (
+                  <p className="text-xs text-gray-500">
+                    관련 질문: Q{comp.related_questions.join(', Q')}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Category Weights (if provided separately) */}
+      {categoryWeights && Object.keys(categoryWeights).length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">카테고리별 가중치</h3>
+          <div className="space-y-3">
+            {Object.entries(categoryWeights).map(([cat, weight]) => (
+              <div key={cat} className="flex items-center gap-4">
+                <span className="w-32 text-sm text-gray-600">{cat}</span>
+                <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-indigo-500 rounded-full"
+                    style={{ width: `${weight * 100}%` }}
+                  />
+                </div>
+                <span className="text-sm font-medium text-gray-700 w-12 text-right">
+                  {Math.round(weight * 100)}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Interviewer Guide Tips */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+          <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          면접관 가이드
+        </h3>
+
+        {/* Interview Flow */}
+        {interviewer_guide.interview_flow && (
+          <div className="mb-6 p-4 bg-indigo-50 rounded-lg border border-indigo-200">
+            <h4 className="text-sm font-semibold text-indigo-900 mb-2">면접 진행</h4>
+            <p className="text-sm text-indigo-800">{interviewer_guide.interview_flow}</p>
+          </div>
+        )}
+
+        {/* Time Allocation */}
+        {interviewer_guide.time_allocation && Object.keys(interviewer_guide.time_allocation).length > 0 && (
+          <div className="mb-6">
+            <h4 className="text-sm font-semibold text-gray-700 mb-2">시간 배분</h4>
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(interviewer_guide.time_allocation).map(([phase, time]) => (
+                <span key={phase} className="px-3 py-1 bg-gray-100 rounded-full text-sm">
+                  {phase}: {time}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Resume Tips */}
+        {interviewer_guide.resume_based_tips && interviewer_guide.resume_based_tips.length > 0 && (
+          <div className="mb-6">
+            <h4 className="text-sm font-semibold text-gray-700 mb-2">이력서 기반 팁</h4>
+            <div className="space-y-2">
+              {interviewer_guide.resume_based_tips.map((tip, i) => (
+                <div key={i} className="p-3 bg-gray-50 rounded-lg border border-gray-200">
+                  <span className="text-xs font-semibold text-gray-500 uppercase">{tip.section}</span>
+                  <p className="text-sm text-gray-700 mt-1">{tip.insight}</p>
+                  {tip.question_link && (
+                    <p className="text-xs text-indigo-600 mt-1">→ {tip.question_link}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Cover Letter Insights */}
+        {interviewer_guide.cover_letter_insights && interviewer_guide.cover_letter_insights.length > 0 && (
+          <div className="mb-6">
+            <h4 className="text-sm font-semibold text-gray-700 mb-2">자기소개서 인사이트</h4>
+            <div className="space-y-2">
+              {interviewer_guide.cover_letter_insights.map((insight, i) => (
+                <div key={i} className="p-3 bg-blue-50 rounded-lg border border-blue-200">
+                  <p className="text-sm font-medium text-blue-900">{insight.highlight}</p>
+                  <p className="text-sm text-blue-700 mt-1">{insight.interpretation}</p>
+                  {insight.follow_up_opportunity && (
+                    <p className="text-xs text-blue-600 mt-1">💡 {insight.follow_up_opportunity}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Red/Green Flags */}
+        <div className="grid sm:grid-cols-2 gap-4">
+          {interviewer_guide.positive_signals && interviewer_guide.positive_signals.length > 0 && (
+            <div className="p-4 bg-green-50 rounded-lg border border-green-200">
+              <h4 className="text-sm font-semibold text-green-900 mb-2">✅ 긍정 신호</h4>
+              <ul className="space-y-1">
+                {interviewer_guide.positive_signals.map((signal, i) => (
+                  <li key={i} className="text-sm text-green-800 flex items-start gap-2">
+                    <span className="text-green-500">•</span>
+                    {signal}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {interviewer_guide.red_flags_to_watch && interviewer_guide.red_flags_to_watch.length > 0 && (
+            <div className="p-4 bg-red-50 rounded-lg border border-red-200">
+              <h4 className="text-sm font-semibold text-red-900 mb-2">🚩 주의 사항</h4>
+              <ul className="space-y-1">
+                {interviewer_guide.red_flags_to_watch.map((flag, i) => (
+                  <li key={i} className="text-sm text-red-800 flex items-start gap-2">
+                    <span className="text-red-500">•</span>
+                    {flag}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -1,0 +1,173 @@
+/**
+ * DeepAnalysisTab - Radar Chart + Engineering DNA + Skill Matching Table
+ */
+import type { DeepAnalysis } from '../../types/interview'
+import { RadarChart, ProgressBarGroup } from '../charts'
+
+interface DeepAnalysisTabProps {
+  analysis: DeepAnalysis
+}
+
+export function DeepAnalysisTab({ analysis }: DeepAnalysisTabProps) {
+  const { radar_candidate, radar_required, engineering_dna, risk_flags, skill_table, overall_match } = analysis
+
+  return (
+    <div className="space-y-6">
+      {/* Overall Match Score */}
+      {overall_match !== undefined && (
+        <div className="bg-gradient-to-r from-indigo-500 to-purple-600 rounded-xl p-6 text-white shadow-lg">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-medium text-indigo-100">전체 매칭 점수</h3>
+              <p className="text-4xl font-bold mt-1">{overall_match}%</p>
+            </div>
+            <div className="text-6xl opacity-20">📊</div>
+          </div>
+        </div>
+      )}
+
+      {/* Radar Chart Section */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+          <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />
+          </svg>
+          역량 레이더
+        </h3>
+
+        <div className="flex flex-col lg:flex-row items-center justify-center gap-8">
+          <RadarChart
+            candidateData={radar_candidate}
+            requiredData={radar_required}
+            size={320}
+          />
+
+          {/* Score breakdown */}
+          <div className="space-y-3 w-full lg:w-auto">
+            {['역할 적합도', '기술 역량', '실행력', '커뮤니케이션', '위험 요소'].map((label, i) => {
+              const candidate = radar_candidate[i]
+              const required = radar_required[i]
+              const diff = candidate - required
+              return (
+                <div key={label} className="flex items-center gap-3">
+                  <span className="w-28 text-sm text-gray-600">{label}</span>
+                  <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-emerald-500 rounded-full"
+                      style={{ width: `${candidate}%` }}
+                    />
+                  </div>
+                  <span className={`text-sm font-medium w-16 text-right ${
+                    diff >= 0 ? 'text-emerald-600' : 'text-red-600'
+                  }`}>
+                    {candidate}
+                    <span className="text-xs text-gray-400 ml-1">/ {required}</span>
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Engineering DNA */}
+      {engineering_dna && engineering_dna.length > 0 && (
+        <ProgressBarGroup
+          title="Engineering DNA"
+          items={engineering_dna.map(item => ({
+            label: item.label,
+            value: item.value,
+            display: item.display,
+            color: item.color,
+            note: item.note,
+            tooltip: item.tooltip
+          }))}
+        />
+      )}
+
+      {/* Risk Flags */}
+      {risk_flags && risk_flags.length > 0 && (
+        <div className="bg-red-50 rounded-xl border border-red-200 p-6">
+          <h3 className="text-lg font-semibold text-red-900 mb-4 flex items-center gap-2">
+            <svg className="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            위험 신호
+          </h3>
+          <div className="space-y-3">
+            {risk_flags.map((flag, i) => (
+              <div key={i} className="bg-white rounded-lg p-4 border border-red-200">
+                <div className="font-medium text-red-900">{flag.label}</div>
+                <div className="text-sm text-red-700 mt-1">{flag.detail}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Skill Matching Table */}
+      {skill_table && skill_table.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm overflow-hidden">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+            </svg>
+            스킬 매칭 상세
+          </h3>
+
+          <div className="overflow-x-auto -mx-6">
+            <table className="w-full min-w-[600px]">
+              <thead>
+                <tr className="border-b border-gray-200">
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">JD 요구 스킬</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">후보자 스킬</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">매칭</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">증거</th>
+                  <th className="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">신뢰도</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {skill_table.map((row, i) => (
+                  <tr key={i} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 text-sm font-medium text-gray-900">{row.skill}</td>
+                    <td className="px-6 py-4 text-sm text-gray-700">{row.candidate}</td>
+                    <td className="px-6 py-4">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        row.type === 'exact' ? 'bg-emerald-100 text-emerald-800' :
+                        row.type === 'similar' ? 'bg-blue-100 text-blue-800' :
+                        row.type === 'partial' ? 'bg-amber-100 text-amber-800' :
+                        'bg-gray-100 text-gray-800'
+                      }`}>
+                        {row.type === 'exact' ? '정확 매칭' :
+                         row.type === 'similar' ? '유사' :
+                         row.type === 'partial' ? '부분' : '미매칭'}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500">{row.evidence}</td>
+                    <td className="px-6 py-4 text-right">
+                      <div className="flex items-center justify-end gap-2">
+                        <div className="w-16 h-2 bg-gray-100 rounded-full overflow-hidden">
+                          <div
+                            className={`h-full rounded-full ${
+                              row.confidence >= 80 ? 'bg-emerald-500' :
+                              row.confidence >= 60 ? 'bg-blue-500' :
+                              row.confidence >= 40 ? 'bg-amber-500' :
+                              'bg-red-500'
+                            }`}
+                            style={{ width: `${row.confidence}%` }}
+                          />
+                        </div>
+                        <span className="text-sm font-medium text-gray-700">{row.confidence}%</span>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/tabs/IntelBriefTab.tsx
+++ b/frontend/src/components/tabs/IntelBriefTab.tsx
@@ -1,0 +1,254 @@
+/**
+ * IntelBriefTab - JD Analysis + GitHub Chart + LinkedIn Timeline + Competency Matching
+ */
+import type { IntelBrief, Candidate } from '../../types/interview'
+import { ContributionChart } from '../charts'
+
+interface IntelBriefTabProps {
+  intel: IntelBrief
+  candidate?: Candidate
+}
+
+export function IntelBriefTab({ intel, candidate }: IntelBriefTabProps) {
+  const { jd_summary, competencies, github, linkedin, linkedin_warning } = intel
+
+  return (
+    <div className="space-y-6">
+      {/* Candidate Header */}
+      {candidate && (
+        <div className="bg-gradient-to-r from-indigo-500 to-purple-600 rounded-xl p-6 text-white shadow-lg">
+          <div className="flex items-center gap-4">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/20 text-2xl font-bold">
+              {candidate.initials || candidate.name?.charAt(0) || '?'}
+            </div>
+            <div>
+              <h2 className="text-2xl font-bold">{candidate.name}</h2>
+              <p className="text-indigo-100">{candidate.role || candidate.current_title}</p>
+            </div>
+          </div>
+          <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-4">
+            {candidate.experience && (
+              <div className="bg-white/10 rounded-lg px-4 py-2">
+                <div className="text-sm text-indigo-100">경력</div>
+                <div className="text-lg font-semibold">{candidate.experience}</div>
+              </div>
+            )}
+            {candidate.jd_match && (
+              <div className="bg-white/10 rounded-lg px-4 py-2">
+                <div className="text-sm text-indigo-100">JD 매칭</div>
+                <div className="text-lg font-semibold">{candidate.jd_match}</div>
+              </div>
+            )}
+            {candidate.level && (
+              <div className="bg-white/10 rounded-lg px-4 py-2">
+                <div className="text-sm text-indigo-100">레벨</div>
+                <div className="text-lg font-semibold">{candidate.level}</div>
+              </div>
+            )}
+            {candidate.company_context && (
+              <div className="bg-white/10 rounded-lg px-4 py-2">
+                <div className="text-sm text-indigo-100">대상 회사</div>
+                <div className="text-lg font-semibold">{candidate.company_context}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* JD Summary */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+          <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          JD 요약
+        </h3>
+
+        <div className="mb-4">
+          <h4 className="text-xl font-bold text-gray-900">{jd_summary.title}</h4>
+          <p className="text-sm text-gray-500">{jd_summary.subtitle}</p>
+        </div>
+
+        {/* Requirements */}
+        <div className="mb-4">
+          <h5 className="text-sm font-semibold text-gray-700 mb-2">요구 사항</h5>
+          <div className="space-y-2">
+            {jd_summary.requirements.map((req, i) => (
+              <div
+                key={i}
+                className={`flex items-start gap-3 p-3 rounded-lg ${
+                  req.matched ? 'bg-emerald-50 border border-emerald-200' : 'bg-gray-50 border border-gray-200'
+                }`}
+              >
+                <span className={req.matched ? 'text-emerald-600' : 'text-gray-400'}>
+                  {req.matched ? '✓' : '○'}
+                </span>
+                <div>
+                  <span className={`font-medium ${req.matched ? 'text-emerald-900' : 'text-gray-700'}`}>
+                    {req.text}
+                  </span>
+                  <p className="text-sm text-gray-500 mt-0.5">{req.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Success Metrics */}
+        {jd_summary.success_metrics.length > 0 && (
+          <div>
+            <h5 className="text-sm font-semibold text-gray-700 mb-2">성공 지표</h5>
+            <ul className="space-y-1">
+              {jd_summary.success_metrics.map((metric, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-gray-600">
+                  <span className="text-indigo-500">•</span>
+                  {metric}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {/* Competency Matching */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+          <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          역량 매칭 분석
+        </h3>
+
+        <div className="space-y-4">
+          {competencies.map((comp, i) => (
+            <div
+              key={i}
+              className={`p-4 rounded-lg border ${
+                comp.color === 'emerald' ? 'bg-emerald-50 border-emerald-200' :
+                comp.color === 'amber' ? 'bg-amber-50 border-amber-200' :
+                comp.color === 'red' ? 'bg-red-50 border-red-200' :
+                'bg-gray-50 border-gray-200'
+              }`}
+            >
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-lg">{comp.icon}</span>
+                  <span className="font-semibold text-gray-900">{comp.name}</span>
+                </div>
+                <span className={`text-xs font-medium px-2 py-1 rounded-full ${
+                  comp.color === 'emerald' ? 'bg-emerald-200 text-emerald-800' :
+                  comp.color === 'amber' ? 'bg-amber-200 text-amber-800' :
+                  comp.color === 'red' ? 'bg-red-200 text-red-800' :
+                  'bg-gray-200 text-gray-800'
+                }`}>
+                  {comp.match_label}
+                </span>
+              </div>
+              <p className="text-sm text-gray-600 mb-2">{comp.desc}</p>
+              <p className={`text-sm font-medium ${
+                comp.color === 'emerald' ? 'text-emerald-700' :
+                comp.color === 'amber' ? 'text-amber-700' :
+                comp.color === 'red' ? 'text-red-700' :
+                'text-gray-700'
+              }`}>
+                💡 {comp.why}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* GitHub Summary */}
+      {github && (
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <svg className="w-5 h-5 text-gray-700" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+            </svg>
+            GitHub 활동
+          </h3>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+            <div className="text-center p-3 bg-gray-50 rounded-lg">
+              <div className="text-2xl font-bold text-indigo-600">{github.contributions}</div>
+              <div className="text-sm text-gray-500">기여 수</div>
+            </div>
+            <div className="text-center p-3 bg-gray-50 rounded-lg">
+              <div className="text-2xl font-bold text-indigo-600">{github.repos}</div>
+              <div className="text-sm text-gray-500">저장소</div>
+            </div>
+            <div className="text-center p-3 bg-gray-50 rounded-lg">
+              <div className="text-sm font-semibold text-gray-900">{github.main_languages}</div>
+              <div className="text-sm text-gray-500">주요 언어</div>
+            </div>
+            <div className="text-center p-3 bg-gray-50 rounded-lg">
+              <div className="text-sm font-semibold text-gray-900">{github.tenure_pattern}</div>
+              <div className="text-sm text-gray-500">평균 재직</div>
+            </div>
+          </div>
+
+          {/* Tech Match */}
+          <div className="mb-4 p-3 bg-indigo-50 border border-indigo-200 rounded-lg">
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-indigo-900">기술 매칭: {github.tech_match}</span>
+              {github.tech_match_note && (
+                <span className="text-sm text-amber-600">⚠️ {github.tech_match_note}</span>
+              )}
+            </div>
+          </div>
+
+          {/* Contribution Chart */}
+          {github.chart_data && github.chart_data.length > 0 && (
+            <div className="mt-4">
+              <h4 className="text-sm font-medium text-gray-700 mb-2">월별 기여도</h4>
+              <ContributionChart data={github.chart_data} />
+            </div>
+          )}
+
+          {/* Activity Gap Warning */}
+          {github.activity_gap && (
+            <div className="mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+              <span className="text-amber-800">⚠️ 활동 공백: {github.activity_gap}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* LinkedIn Timeline */}
+      {linkedin && linkedin.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <svg className="w-5 h-5 text-blue-600" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+            </svg>
+            LinkedIn 경력
+          </h3>
+
+          <div className="space-y-4">
+            {linkedin.map((pos, i) => (
+              <div key={i} className="flex items-start gap-4">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-700 font-semibold">
+                  {pos.initial}
+                </div>
+                <div className="flex-1">
+                  <div className="font-semibold text-gray-900">{pos.title}</div>
+                  <div className="text-sm text-gray-600">{pos.company}</div>
+                  <div className="text-sm text-gray-500">{pos.detail}</div>
+                </div>
+                {i < linkedin.length - 1 && (
+                  <div className="absolute left-5 top-12 h-full w-0.5 bg-gray-200" style={{ transform: 'translateX(-50%)' }} />
+                )}
+              </div>
+            ))}
+          </div>
+
+          {linkedin_warning && (
+            <div className="mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+              <span className="text-amber-800">⚠️ {linkedin_warning}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/tabs/LiveInterviewTab.tsx
+++ b/frontend/src/components/tabs/LiveInterviewTab.tsx
@@ -1,0 +1,425 @@
+/**
+ * LiveInterviewTab - Question Selection → Interactive Scoring → Follow-up Branching
+ */
+import { useState } from 'react'
+import type {
+  InterviewQuestion,
+  ScenarioLevelType,
+  ScoresState,
+  CategoryWeights
+} from '../../types/interview'
+
+interface LiveInterviewTabProps {
+  questions: InterviewQuestion[]
+  categoryWeights?: CategoryWeights
+}
+
+export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTabProps) {
+  const [phase, setPhase] = useState<'select' | 'interview'>('select')
+  const [selectedQuestions, setSelectedQuestions] = useState<Set<string>>(new Set())
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [scores, setScores] = useState<ScoresState>({})
+
+  // Get selected questions in order
+  const interviewQuestions = questions.filter(q => selectedQuestions.has(q.id))
+
+  // Toggle question selection
+  const toggleQuestion = (id: string) => {
+    const newSet = new Set(selectedQuestions)
+    if (newSet.has(id)) {
+      newSet.delete(id)
+    } else {
+      newSet.add(id)
+    }
+    setSelectedQuestions(newSet)
+  }
+
+  // Select all questions
+  const selectAll = () => {
+    setSelectedQuestions(new Set(questions.map(q => q.id)))
+  }
+
+  // Start interview
+  const startInterview = () => {
+    if (selectedQuestions.size > 0) {
+      setPhase('interview')
+      setCurrentIndex(0)
+    }
+  }
+
+  // Handle scenario selection
+  const handleScenarioSelect = (questionId: string, level: ScenarioLevelType, score: number) => {
+    setScores(prev => ({
+      ...prev,
+      [questionId]: {
+        ...prev[questionId],
+        selectedLevel: level,
+        followUpScores: prev[questionId]?.followUpScores || {},
+        totalScore: score + Object.values(prev[questionId]?.followUpScores || {}).reduce((a, b) => a + b, 0),
+        maxPossibleScore: 20 + (questions.find(q => q.id === questionId)?.follow_ups.length || 0) * 10
+      }
+    }))
+  }
+
+  // Handle follow-up scoring
+  const handleFollowUpScore = (questionId: string, followUpId: string, score: number) => {
+    setScores(prev => {
+      const current = prev[questionId] || { selectedLevel: undefined, followUpScores: {}, totalScore: 0, maxPossibleScore: 20 }
+      const newFollowUpScores = { ...current.followUpScores, [followUpId]: score }
+      const scenarioScore = current.selectedLevel
+        ? questions.find(q => q.id === questionId)?.scenarios.find(s => s.level === current.selectedLevel)?.score || 0
+        : 0
+      return {
+        ...prev,
+        [questionId]: {
+          ...current,
+          followUpScores: newFollowUpScores,
+          totalScore: scenarioScore + Object.values(newFollowUpScores).reduce((a, b) => a + b, 0)
+        }
+      }
+    })
+  }
+
+  // Calculate total score
+  const totalScore = Object.values(scores).reduce((sum, s) => sum + s.totalScore, 0)
+  const maxScore = Object.values(scores).reduce((sum, s) => sum + s.maxPossibleScore, 0)
+
+  // Selection Phase
+  if (phase === 'select') {
+    // Group questions by category
+    const questionsByCategory = questions.reduce((acc, q) => {
+      const cat = q.category || '기타'
+      if (!acc[cat]) acc[cat] = []
+      acc[cat].push(q)
+      return acc
+    }, {} as Record<string, InterviewQuestion[]>)
+
+    return (
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900">질문 선택</h3>
+              <p className="text-sm text-gray-500 mt-1">
+                면접에서 사용할 질문을 선택하세요. 선택된 질문: {selectedQuestions.size}개
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={selectAll}
+                className="px-3 py-1.5 text-sm font-medium text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
+              >
+                전체 선택
+              </button>
+              <button
+                onClick={startInterview}
+                disabled={selectedQuestions.size === 0}
+                className="px-4 py-1.5 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:bg-gray-300 rounded-lg transition-colors"
+              >
+                면접 시작 →
+              </button>
+            </div>
+          </div>
+
+          {/* Category Weights */}
+          {categoryWeights && (
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(categoryWeights).map(([cat, weight]) => (
+                <span key={cat} className="px-2 py-1 bg-indigo-50 text-indigo-700 text-xs rounded-full">
+                  {cat}: {Math.round(weight * 100)}%
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Questions by Category */}
+        {Object.entries(questionsByCategory).map(([category, categoryQuestions]) => (
+          <div key={category} className="space-y-3">
+            <h4 className="text-sm font-semibold text-gray-700 uppercase tracking-wide flex items-center gap-2">
+              {category}
+              <span className="text-xs font-normal text-gray-400">
+                ({categoryQuestions.filter(q => selectedQuestions.has(q.id)).length}/{categoryQuestions.length})
+              </span>
+            </h4>
+            {categoryQuestions.map((q) => (
+              <button
+                key={q.id}
+                onClick={() => toggleQuestion(q.id)}
+                className={`w-full text-left p-4 rounded-xl border transition-all ${
+                  selectedQuestions.has(q.id)
+                    ? 'bg-indigo-50 border-indigo-300 ring-1 ring-indigo-200'
+                    : 'bg-white border-gray-200 hover:border-gray-300'
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <div className={`flex-shrink-0 w-5 h-5 rounded border-2 flex items-center justify-center ${
+                    selectedQuestions.has(q.id)
+                      ? 'bg-indigo-600 border-indigo-600'
+                      : 'border-gray-300'
+                  }`}>
+                    {selectedQuestions.has(q.id) && (
+                      <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                      </svg>
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      {q.title && (
+                        <span className="font-semibold text-gray-900">{q.title}</span>
+                      )}
+                      {q.is_risk && (
+                        <span className="px-1.5 py-0.5 bg-red-100 text-red-700 text-xs rounded">위험</span>
+                      )}
+                      <span className={`px-1.5 py-0.5 text-xs rounded ${
+                        q.difficulty === 'Hard' ? 'bg-red-100 text-red-700' :
+                        q.difficulty === 'Medium' ? 'bg-amber-100 text-amber-700' :
+                        'bg-green-100 text-green-700'
+                      }`}>
+                        {q.difficulty}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-600 line-clamp-2">{q.question_text}</p>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  // Interview Phase
+  const currentQuestion = interviewQuestions[currentIndex]
+  const currentScore = scores[currentQuestion?.id]
+
+  if (!currentQuestion) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500">선택된 질문이 없습니다.</p>
+        <button
+          onClick={() => setPhase('select')}
+          className="mt-4 px-4 py-2 text-indigo-600 hover:bg-indigo-50 rounded-lg"
+        >
+          질문 선택으로 돌아가기
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Progress Bar */}
+      <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setPhase('select')}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              ← 질문 선택
+            </button>
+            <span className="text-gray-300">|</span>
+            <span className="text-sm font-medium text-gray-900">
+              질문 {currentIndex + 1} / {interviewQuestions.length}
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-500">총점:</span>
+            <span className="text-lg font-bold text-indigo-600">{totalScore}</span>
+            {maxScore > 0 && (
+              <span className="text-sm text-gray-400">/ {maxScore}</span>
+            )}
+          </div>
+        </div>
+        <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-indigo-500 transition-all"
+            style={{ width: `${((currentIndex + 1) / interviewQuestions.length) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Question Card */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+        {/* Question Header */}
+        <div className="mb-4">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-indigo-100 text-indigo-700 font-semibold">
+              {currentIndex + 1}
+            </span>
+            {currentQuestion.title && (
+              <span className="font-semibold text-gray-900">{currentQuestion.title}</span>
+            )}
+            {currentQuestion.is_risk && (
+              <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full">위험 검증</span>
+            )}
+          </div>
+          <p className="text-lg text-gray-900">{currentQuestion.question_text}</p>
+        </div>
+
+        {/* Why Matters & Listen For */}
+        <div className="grid sm:grid-cols-2 gap-4 mb-6">
+          {currentQuestion.why_matters && (
+            <div className="p-3 bg-blue-50 rounded-lg border border-blue-200">
+              <h5 className="text-xs font-semibold text-blue-700 uppercase mb-1">왜 중요한가</h5>
+              <p className="text-sm text-blue-800">{currentQuestion.why_matters}</p>
+            </div>
+          )}
+          {currentQuestion.listen_for && (
+            <div className="p-3 bg-green-50 rounded-lg border border-green-200">
+              <h5 className="text-xs font-semibold text-green-700 uppercase mb-1">들어볼 것</h5>
+              <p className="text-sm text-green-800">{currentQuestion.listen_for}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Answer Keywords */}
+        {currentQuestion.answer_keywords && currentQuestion.answer_keywords.length > 0 && (
+          <div className="mb-6">
+            <h5 className="text-sm font-semibold text-gray-700 mb-2">핵심 키워드</h5>
+            <div className="flex flex-wrap gap-2">
+              {currentQuestion.answer_keywords.map((kw, i) => (
+                <span
+                  key={i}
+                  className={`px-2 py-1 rounded-full text-xs font-medium ${
+                    kw.importance === 'must'
+                      ? 'bg-red-100 text-red-700 border border-red-200'
+                      : 'bg-gray-100 text-gray-700 border border-gray-200'
+                  }`}
+                  title={kw.explanation}
+                >
+                  {kw.keyword}
+                  {kw.importance === 'must' && ' *'}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Scenario Selection */}
+        <div className="mb-6">
+          <h5 className="text-sm font-semibold text-gray-700 mb-3">답변 수준 평가</h5>
+          <div className="grid sm:grid-cols-3 gap-3">
+            {currentQuestion.scenarios.map((scenario) => (
+              <button
+                key={scenario.level}
+                onClick={() => handleScenarioSelect(currentQuestion.id, scenario.level, scenario.score)}
+                className={`p-4 rounded-xl border-2 text-left transition-all ${
+                  currentScore?.selectedLevel === scenario.level
+                    ? 'border-indigo-500 bg-indigo-50 ring-2 ring-indigo-200'
+                    : 'border-gray-200 hover:border-gray-300'
+                }`}
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <span className={`font-semibold ${
+                    scenario.level === 'Expert' ? 'text-emerald-700' :
+                    scenario.level === 'Mid' ? 'text-amber-700' :
+                    'text-red-700'
+                  }`}>
+                    {scenario.level === 'Expert' ? '🌟 Expert' :
+                     scenario.level === 'Mid' ? '📊 Mid' : '📉 Low'}
+                  </span>
+                  <span className="text-lg font-bold text-indigo-600">{scenario.score}점</span>
+                </div>
+                <p className="text-sm text-gray-600 mb-2">{scenario.text}</p>
+                <p className="text-xs text-gray-500">{scenario.depth_expectations}</p>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Follow-up Questions (shown after scenario selection) */}
+        {currentScore?.selectedLevel && currentQuestion.follow_ups && currentQuestion.follow_ups.length > 0 && (
+          <div className="border-t border-gray-200 pt-6">
+            <h5 className="text-sm font-semibold text-gray-700 mb-3">꼬리 질문</h5>
+            <div className="space-y-4">
+              {currentQuestion.follow_ups
+                .filter(fu => fu.trigger === 'any' || fu.trigger === currentScore.selectedLevel)
+                .map((followUp) => (
+                  <div key={followUp.id} className="p-4 bg-gray-50 rounded-xl border border-gray-200">
+                    <p className="font-medium text-gray-900 mb-2">{followUp.question_text}</p>
+                    <div className="grid sm:grid-cols-2 gap-3 mb-3">
+                      <div className="p-2 bg-green-50 rounded-lg border border-green-200">
+                        <span className="text-xs font-semibold text-green-700">Good ({followUp.good.score}점)</span>
+                        <p className="text-sm text-green-800 mt-1">{followUp.good.text}</p>
+                      </div>
+                      <div className="p-2 bg-red-50 rounded-lg border border-red-200">
+                        <span className="text-xs font-semibold text-red-700">Poor ({followUp.poor.score}점)</span>
+                        <p className="text-sm text-red-800 mt-1">{followUp.poor.text}</p>
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => handleFollowUpScore(currentQuestion.id, followUp.id, followUp.good.score)}
+                        className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+                          currentScore.followUpScores[followUp.id] === followUp.good.score
+                            ? 'bg-green-600 text-white'
+                            : 'bg-green-100 text-green-700 hover:bg-green-200'
+                        }`}
+                      >
+                        Good +{followUp.good.score}
+                      </button>
+                      <button
+                        onClick={() => handleFollowUpScore(currentQuestion.id, followUp.id, followUp.poor.score)}
+                        className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+                          currentScore.followUpScores[followUp.id] === followUp.poor.score
+                            ? 'bg-red-600 text-white'
+                            : 'bg-red-100 text-red-700 hover:bg-red-200'
+                        }`}
+                      >
+                        Poor +{followUp.poor.score}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {/* Interviewer Note */}
+        {currentQuestion.interviewer_note && (
+          <div className="mt-6 p-4 bg-indigo-50 rounded-xl border border-indigo-200">
+            <h5 className="text-xs font-semibold text-indigo-700 uppercase mb-2">면접관 노트</h5>
+            {currentQuestion.interviewer_note.business_interpretation && (
+              <p className="text-sm text-indigo-800 mb-2">
+                <strong>비즈니스 해석:</strong> {currentQuestion.interviewer_note.business_interpretation}
+              </p>
+            )}
+            {currentQuestion.interviewer_note.daily_analogy && (
+              <p className="text-sm text-indigo-800 mb-2">
+                <strong>일상 비유:</strong> {currentQuestion.interviewer_note.daily_analogy}
+              </p>
+            )}
+            {currentQuestion.interviewer_note.level_expectation && (
+              <p className="text-sm text-indigo-800">
+                <strong>레벨 기대치:</strong> {currentQuestion.interviewer_note.level_expectation}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between">
+        <button
+          onClick={() => setCurrentIndex(Math.max(0, currentIndex - 1))}
+          disabled={currentIndex === 0}
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          ← 이전 질문
+        </button>
+        <button
+          onClick={() => setCurrentIndex(Math.min(interviewQuestions.length - 1, currentIndex + 1))}
+          disabled={currentIndex === interviewQuestions.length - 1}
+          className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          다음 질문 →
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/tabs/index.ts
+++ b/frontend/src/components/tabs/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Tab component exports
+ */
+export { IntelBriefTab } from './IntelBriefTab'
+export { DeepAnalysisTab } from './DeepAnalysisTab'
+export { LiveInterviewTab } from './LiveInterviewTab'
+export { DecisionTab } from './DecisionTab'

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { apiFetch } from '../lib/api'
+import type { InterviewScript, ResultTab, InterviewQuestion } from '../types/interview'
+import { IntelBriefTab, DeepAnalysisTab, LiveInterviewTab, DecisionTab } from '../components/tabs'
 import { QuestionCard, type Question } from '../components/QuestionCard'
 
 function downloadJSON(data: unknown, filename: string) {
@@ -14,108 +16,30 @@ function downloadJSON(data: unknown, filename: string) {
   URL.revokeObjectURL(url)
 }
 
-interface CandidateSummary {
-  candidate_overview?: {
-    name?: string
-    current_position?: string
-    primary_domain?: string
-    experience_years?: string
-    confidence_level?: string
-  }
-  key_strengths?: Array<{
-    strength: string
-    confidence: number
-    evidence?: Record<string, string | null>
-  }>
-  risk_flags?: Array<{
-    concern: string
-    severity: string
-    evidence?: string
-    mitigation_question?: string
-  }>
-  technical_expertise?: {
-    languages?: Array<{ skill: string; proficiency: string; confidence: number }>
-    frameworks?: Array<{ skill: string; proficiency: string; confidence: number }>
-    tools?: Array<{ tool: string; proficiency: string; confidence: number }>
-  }
-  notable_achievements?: Array<{
-    achievement: string
-    source: string
-    details?: string
-  }>
-  data_quality_assessment?: {
-    overall_confidence: number
-    document_quality: number
-    linkedin_quality: number
-    github_quality: number
-    recommendations?: string[]
-  }
-}
-
-interface InterviewerGuide {
-  interview_overview?: {
-    total_duration_minutes: number
-    question_count: number
-    experience_level: string
-    interview_style: string
-  }
-  interview_flow?: {
-    opening?: { script: string; duration_minutes: number }
-    main_body?: { recommended_order: string[]; transition_phrases: string[] }
-    closing?: { script: string; duration_minutes: number }
-  }
-  category_breakdown?: Array<{
-    category: string
-    question_count: number
-    time_allocation_minutes: number
-    evaluation_priority: string
-    focus_areas: string[]
-  }>
-  evaluation_matrix?: {
-    scoring_scale: string
-    passing_threshold: number
-    strong_hire_threshold: number
-    category_weights: Record<string, number>
-  }
-  red_flags_summary?: string[]
-  green_flags_summary?: string[]
-}
-
-interface InterviewScript {
-  metadata?: {
-    language?: string
-    total_questions?: number
-    experience_level?: string
-    has_linkedin_data?: boolean
-  }
-  questions: Question[]
-  candidate_summary?: CandidateSummary
-  interviewer_guide?: InterviewerGuide
-  decision_guide?: Record<string, unknown>
-  full_glossary?: Array<Record<string, string>>
-  linkedin_profile?: {
-    name?: string
-    headline?: string
-    current_company?: string
-    profile_url?: string
-    projects?: Array<{ title: string; description?: string }>
-    honors_and_awards?: Array<{ title: string; issuer?: string; description?: string }>
-  }
-  generated_at?: string
-}
-
 export function ResultPage() {
   const { t } = useTranslation()
   const { jobId } = useParams<{ jobId: string }>()
   const [script, setScript] = useState<InterviewScript | null>(null)
-  const [activeTab, setActiveTab] = useState<'questions' | 'summary' | 'guide'>('questions')
+  const [activeTab, setActiveTab] = useState<ResultTab | 'questions' | 'summary' | 'guide'>('intel')
   const [scores, setScores] = useState<Record<number, number>>({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  // Determine if we have v2 data
+  const hasV2Data = script?.intel || script?.analysis || script?.decision
+  const questions = script?.questions || []
+
+  // Fallback to v1 tabs if no v2 data
+  useEffect(() => {
+    if (script && !hasV2Data) {
+      setActiveTab('questions')
+    }
+  }, [script, hasV2Data])
+
   useEffect(() => {
     if (!jobId) return
-    apiFetch(`/jobs/${jobId}/result`)
+    // Request v2 format by default
+    apiFetch(`/jobs/${jobId}/result?version=v2`)
       .then(setScript)
       .catch((err) => {
         setError(String(err))
@@ -165,10 +89,6 @@ export function ResultPage() {
     )
   }
 
-  const questions = script.questions || []
-  const summary = script.candidate_summary
-  const guide = script.interviewer_guide
-
   const handleScoreChange = (index: number, score: number) => {
     setScores((prev) => ({ ...prev, [index]: score }))
   }
@@ -176,6 +96,10 @@ export function ResultPage() {
   const totalScore = Object.values(scores).reduce((sum, s) => sum + s, 0)
   const maxScore = Object.keys(scores).length * 5
   const scorePercent = maxScore > 0 ? Math.round((totalScore / maxScore) * 100) : 0
+
+  // Legacy data for fallback
+  const summary = script.candidate_summary
+  const guide = script.interviewer_guide
 
   return (
     <div className="space-y-6">
@@ -250,399 +174,481 @@ export function ResultPage() {
       </div>
 
       {/* Tab Navigation */}
-      <div className="flex gap-1 p-1 bg-gray-100 rounded-xl no-print">
-        <button
-          onClick={() => setActiveTab('questions')}
-          className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-            activeTab === 'questions'
-              ? 'bg-white text-indigo-700 shadow-sm'
-              : 'text-gray-600 hover:text-gray-900'
-          }`}
-        >
-          질문 목록 ({questions.length})
-        </button>
-        <button
-          onClick={() => setActiveTab('summary')}
-          className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-            activeTab === 'summary'
-              ? 'bg-white text-indigo-700 shadow-sm'
-              : 'text-gray-600 hover:text-gray-900'
-          }`}
-        >
-          후보자 분석
-        </button>
-        <button
-          onClick={() => setActiveTab('guide')}
-          className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-            activeTab === 'guide'
-              ? 'bg-white text-indigo-700 shadow-sm'
-              : 'text-gray-600 hover:text-gray-900'
-          }`}
-        >
-          면접관 가이드
-        </button>
-      </div>
-
-      {/* Questions Tab */}
-      {activeTab === 'questions' && (
-        <div className="space-y-4">
-          {questions.length === 0 ? (
-            <div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-gray-50 py-12">
-              <svg className="h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              <p className="mt-3 text-sm text-gray-500">생성된 질문이 없습니다</p>
-            </div>
-          ) : (
-            questions.map((q, i) => (
-              <QuestionCard
-                key={i}
-                question={q}
-                index={i}
-                onScoreChange={handleScoreChange}
-              />
-            ))
-          )}
+      {hasV2Data ? (
+        // v2 4-tab navigation
+        <div className="flex gap-1 p-1 bg-gray-100 rounded-xl no-print">
+          <button
+            onClick={() => setActiveTab('intel')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+              activeTab === 'intel'
+                ? 'bg-white text-indigo-700 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            🔍 Intel Brief
+          </button>
+          <button
+            onClick={() => setActiveTab('analysis')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+              activeTab === 'analysis'
+                ? 'bg-white text-indigo-700 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            📊 Deep Analysis
+          </button>
+          <button
+            onClick={() => setActiveTab('interview')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+              activeTab === 'interview'
+                ? 'bg-white text-indigo-700 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            🎯 Live Interview ({questions.length})
+          </button>
+          <button
+            onClick={() => setActiveTab('decision')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+              activeTab === 'decision'
+                ? 'bg-white text-indigo-700 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            ✅ Decision
+          </button>
+        </div>
+      ) : (
+        // v1 3-tab navigation (fallback)
+        <div className="flex gap-1 p-1 bg-gray-100 rounded-xl no-print">
+          <button
+            onClick={() => setActiveTab('questions')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+              activeTab === 'questions'
+                ? 'bg-white text-indigo-700 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            질문 목록 ({questions.length})
+          </button>
+          <button
+            onClick={() => setActiveTab('summary')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+              activeTab === 'summary'
+                ? 'bg-white text-indigo-700 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            후보자 분석
+          </button>
+          <button
+            onClick={() => setActiveTab('guide')}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
+              activeTab === 'guide'
+                ? 'bg-white text-indigo-700 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            면접관 가이드
+          </button>
         </div>
       )}
 
-      {/* Candidate Summary Tab */}
-      {activeTab === 'summary' && summary && (
-        <div className="space-y-6">
-          {/* Candidate Overview */}
-          {summary.candidate_overview && (
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-                <svg className="h-5 w-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                </svg>
-                후보자 개요
-              </h2>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {summary.candidate_overview.name && (
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">이름</dt>
-                    <dd className="mt-1 text-lg font-semibold text-gray-900">{summary.candidate_overview.name}</dd>
-                  </div>
-                )}
-                {summary.candidate_overview.current_position && (
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">현재 직책</dt>
-                    <dd className="mt-1 text-gray-900">{summary.candidate_overview.current_position}</dd>
-                  </div>
-                )}
-                {summary.candidate_overview.primary_domain && (
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">주요 도메인</dt>
-                    <dd className="mt-1 text-gray-900">{summary.candidate_overview.primary_domain}</dd>
-                  </div>
-                )}
-                {summary.candidate_overview.experience_years && (
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">경력</dt>
-                    <dd className="mt-1 text-gray-900">{summary.candidate_overview.experience_years}</dd>
-                  </div>
-                )}
-              </div>
-            </div>
+      {/* V2 Tabs */}
+      {hasV2Data && (
+        <>
+          {activeTab === 'intel' && script.intel && (
+            <IntelBriefTab intel={script.intel} candidate={script.candidate} />
           )}
 
-          {/* Key Strengths */}
-          {summary.key_strengths && summary.key_strengths.length > 0 && (
-            <div className="rounded-xl border border-green-200 bg-green-50 p-6">
-              <h2 className="text-lg font-semibold text-green-900 mb-4 flex items-center gap-2">
-                <svg className="h-5 w-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                주요 강점
-              </h2>
-              <div className="space-y-3">
-                {summary.key_strengths.map((item, i) => (
-                  <div key={i} className="bg-white rounded-lg p-4 border border-green-200">
-                    <div className="flex items-center justify-between mb-2">
-                      <span className="font-medium text-green-900">{item.strength}</span>
-                      <span className="text-sm text-green-600">신뢰도: {Math.round(item.confidence * 100)}%</span>
-                    </div>
-                    {item.evidence && (
-                      <div className="text-sm text-green-700 space-y-1">
-                        {item.evidence.resume && <p>📄 이력서: {item.evidence.resume}</p>}
-                        {item.evidence.linkedin && <p>💼 LinkedIn: {item.evidence.linkedin}</p>}
-                        {item.evidence.github && <p>🔗 GitHub: {item.evidence.github}</p>}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
+          {activeTab === 'analysis' && script.analysis && (
+            <DeepAnalysisTab analysis={script.analysis} />
           )}
 
-          {/* Risk Flags */}
-          {summary.risk_flags && summary.risk_flags.length > 0 && (
-            <div className="rounded-xl border border-red-200 bg-red-50 p-6">
-              <h2 className="text-lg font-semibold text-red-900 mb-4 flex items-center gap-2">
-                <svg className="h-5 w-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                </svg>
-                위험 요소
-              </h2>
-              <div className="space-y-3">
-                {summary.risk_flags.map((item, i) => (
-                  <div key={i} className="bg-white rounded-lg p-4 border border-red-200">
-                    <div className="flex items-center justify-between mb-2">
-                      <span className="font-medium text-red-900">{item.concern}</span>
-                      <span className={`text-xs px-2 py-1 rounded-full ${
-                        item.severity === 'high' ? 'bg-red-200 text-red-800' :
-                        item.severity === 'medium' ? 'bg-yellow-200 text-yellow-800' :
-                        'bg-gray-200 text-gray-800'
-                      }`}>
-                        {item.severity}
-                      </span>
-                    </div>
-                    {item.evidence && <p className="text-sm text-red-700 mb-2">{item.evidence}</p>}
-                    {item.mitigation_question && (
-                      <p className="text-sm text-red-800 bg-red-100 p-2 rounded">
-                        💡 확인 질문: {item.mitigation_question}
-                      </p>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
+          {activeTab === 'interview' && (
+            <LiveInterviewTab
+              questions={questions as InterviewQuestion[]}
+              categoryWeights={script.category_weights}
+            />
           )}
 
-          {/* Technical Expertise */}
-          {summary.technical_expertise && (
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-                <svg className="h-5 w-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-                </svg>
-                기술 역량
-              </h2>
-              <div className="space-y-4">
-                {summary.technical_expertise.languages && summary.technical_expertise.languages.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-500 mb-2">프로그래밍 언어</h3>
-                    <div className="flex flex-wrap gap-2">
-                      {summary.technical_expertise.languages.map((lang, i) => (
-                        <span key={i} className="px-3 py-1 rounded-full bg-purple-100 text-purple-700 text-sm">
-                          {lang.skill} ({lang.proficiency})
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {summary.technical_expertise.frameworks && summary.technical_expertise.frameworks.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-500 mb-2">프레임워크</h3>
-                    <div className="flex flex-wrap gap-2">
-                      {summary.technical_expertise.frameworks.map((fw, i) => (
-                        <span key={i} className="px-3 py-1 rounded-full bg-blue-100 text-blue-700 text-sm">
-                          {fw.skill} ({fw.proficiency})
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {summary.technical_expertise.tools && summary.technical_expertise.tools.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-500 mb-2">도구</h3>
-                    <div className="flex flex-wrap gap-2">
-                      {summary.technical_expertise.tools.map((tool, i) => (
-                        <span key={i} className="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
-                          {tool.tool} ({tool.proficiency})
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
+          {activeTab === 'decision' && script.decision && (
+            <DecisionTab
+              decision={script.decision}
+              candidate={script.candidate}
+              categoryWeights={script.category_weights}
+              totalScore={totalScore}
+              maxScore={maxScore || 100}
+            />
           )}
-
-          {/* Data Quality Assessment */}
-          {summary.data_quality_assessment && (
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">데이터 품질 평가</h2>
-              <div className="grid gap-4 sm:grid-cols-4">
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
-                  <div className="text-2xl font-bold text-indigo-600">
-                    {Math.round(summary.data_quality_assessment.overall_confidence * 100)}%
-                  </div>
-                  <div className="text-sm text-gray-500">전체 신뢰도</div>
-                </div>
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
-                  <div className="text-2xl font-bold text-blue-600">
-                    {Math.round(summary.data_quality_assessment.document_quality * 100)}%
-                  </div>
-                  <div className="text-sm text-gray-500">문서 품질</div>
-                </div>
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
-                  <div className="text-2xl font-bold text-green-600">
-                    {Math.round(summary.data_quality_assessment.linkedin_quality * 100)}%
-                  </div>
-                  <div className="text-sm text-gray-500">LinkedIn</div>
-                </div>
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
-                  <div className="text-2xl font-bold text-purple-600">
-                    {Math.round(summary.data_quality_assessment.github_quality * 100)}%
-                  </div>
-                  <div className="text-sm text-gray-500">GitHub</div>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
+        </>
       )}
 
-      {/* Interviewer Guide Tab */}
-      {activeTab === 'guide' && guide && (
-        <div className="space-y-6">
-          {/* Interview Overview */}
-          {guide.interview_overview && (
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">면접 개요</h2>
-              <div className="grid gap-4 sm:grid-cols-4">
-                <div className="text-center p-3 bg-indigo-50 rounded-lg">
-                  <div className="text-2xl font-bold text-indigo-600">
-                    {guide.interview_overview.total_duration_minutes}분
-                  </div>
-                  <div className="text-sm text-gray-500">총 소요시간</div>
+      {/* V1 Tabs (Fallback) */}
+      {!hasV2Data && (
+        <>
+          {/* Questions Tab */}
+          {activeTab === 'questions' && (
+            <div className="space-y-4">
+              {questions.length === 0 ? (
+                <div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-gray-50 py-12">
+                  <svg className="h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  <p className="mt-3 text-sm text-gray-500">생성된 질문이 없습니다</p>
                 </div>
-                <div className="text-center p-3 bg-indigo-50 rounded-lg">
-                  <div className="text-2xl font-bold text-indigo-600">
-                    {guide.interview_overview.question_count}개
-                  </div>
-                  <div className="text-sm text-gray-500">질문 수</div>
-                </div>
-                <div className="text-center p-3 bg-indigo-50 rounded-lg">
-                  <div className="text-lg font-bold text-indigo-600">
-                    {guide.interview_overview.experience_level}
-                  </div>
-                  <div className="text-sm text-gray-500">경력 수준</div>
-                </div>
-                <div className="text-center p-3 bg-indigo-50 rounded-lg">
-                  <div className="text-lg font-bold text-indigo-600">
-                    {guide.interview_overview.interview_style}
-                  </div>
-                  <div className="text-sm text-gray-500">면접 스타일</div>
-                </div>
-              </div>
+              ) : (
+                questions.map((q, i) => (
+                  <QuestionCard
+                    key={i}
+                    question={q as Question}
+                    index={i}
+                    onScoreChange={handleScoreChange}
+                  />
+                ))
+              )}
             </div>
           )}
 
-          {/* Interview Flow */}
-          {guide.interview_flow && (
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">면접 진행 순서</h2>
-              <div className="space-y-4">
-                {guide.interview_flow.opening && (
-                  <div className="p-4 bg-green-50 rounded-lg border border-green-200">
-                    <h3 className="font-medium text-green-900 mb-2">
-                      🎬 오프닝 ({guide.interview_flow.opening.duration_minutes}분)
-                    </h3>
-                    <p className="text-sm text-green-800">{guide.interview_flow.opening.script}</p>
-                  </div>
-                )}
-                {guide.interview_flow.main_body && (
-                  <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
-                    <h3 className="font-medium text-blue-900 mb-2">📋 본 면접</h3>
-                    <p className="text-sm text-blue-800 mb-2">
-                      진행 순서: {guide.interview_flow.main_body.recommended_order?.join(' → ')}
-                    </p>
-                    {guide.interview_flow.main_body.transition_phrases && (
-                      <div className="text-sm text-blue-700">
-                        <p className="font-medium mb-1">전환 문구:</p>
-                        <ul className="list-disc list-inside">
-                          {guide.interview_flow.main_body.transition_phrases.map((phrase, i) => (
-                            <li key={i}>{phrase}</li>
-                          ))}
-                        </ul>
+          {/* Candidate Summary Tab */}
+          {activeTab === 'summary' && summary && (
+            <div className="space-y-6">
+              {/* Candidate Overview */}
+              {summary.candidate_overview && (
+                <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                    <svg className="h-5 w-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                    </svg>
+                    후보자 개요
+                  </h2>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    {summary.candidate_overview.name && (
+                      <div>
+                        <dt className="text-sm font-medium text-gray-500">이름</dt>
+                        <dd className="mt-1 text-lg font-semibold text-gray-900">{summary.candidate_overview.name}</dd>
+                      </div>
+                    )}
+                    {summary.candidate_overview.current_position && (
+                      <div>
+                        <dt className="text-sm font-medium text-gray-500">현재 직책</dt>
+                        <dd className="mt-1 text-gray-900">{summary.candidate_overview.current_position}</dd>
+                      </div>
+                    )}
+                    {summary.candidate_overview.primary_domain && (
+                      <div>
+                        <dt className="text-sm font-medium text-gray-500">주요 도메인</dt>
+                        <dd className="mt-1 text-gray-900">{summary.candidate_overview.primary_domain}</dd>
+                      </div>
+                    )}
+                    {summary.candidate_overview.experience_years && (
+                      <div>
+                        <dt className="text-sm font-medium text-gray-500">경력</dt>
+                        <dd className="mt-1 text-gray-900">{summary.candidate_overview.experience_years}</dd>
                       </div>
                     )}
                   </div>
-                )}
-                {guide.interview_flow.closing && (
-                  <div className="p-4 bg-amber-50 rounded-lg border border-amber-200">
-                    <h3 className="font-medium text-amber-900 mb-2">
-                      🏁 클로징 ({guide.interview_flow.closing.duration_minutes}분)
-                    </h3>
-                    <p className="text-sm text-amber-800">{guide.interview_flow.closing.script}</p>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
+                </div>
+              )}
 
-          {/* Evaluation Matrix */}
-          {guide.evaluation_matrix && (
-            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">평가 기준</h2>
-              <div className="grid gap-4 sm:grid-cols-3 mb-4">
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
-                  <div className="text-lg font-bold text-gray-900">
-                    {guide.evaluation_matrix.scoring_scale}
-                  </div>
-                  <div className="text-sm text-gray-500">점수 범위</div>
-                </div>
-                <div className="text-center p-3 bg-green-50 rounded-lg">
-                  <div className="text-lg font-bold text-green-600">
-                    ≥ {guide.evaluation_matrix.passing_threshold}
-                  </div>
-                  <div className="text-sm text-gray-500">합격 기준</div>
-                </div>
-                <div className="text-center p-3 bg-indigo-50 rounded-lg">
-                  <div className="text-lg font-bold text-indigo-600">
-                    ≥ {guide.evaluation_matrix.strong_hire_threshold}
-                  </div>
-                  <div className="text-sm text-gray-500">Strong Hire</div>
-                </div>
-              </div>
-              {guide.evaluation_matrix.category_weights && (
-                <div>
-                  <h3 className="text-sm font-medium text-gray-500 mb-2">카테고리별 가중치</h3>
-                  <div className="flex flex-wrap gap-2">
-                    {Object.entries(guide.evaluation_matrix.category_weights).map(([cat, weight]) => (
-                      <span key={cat} className="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
-                        {cat}: {Math.round(Number(weight) * 100)}%
-                      </span>
+              {/* Key Strengths */}
+              {summary.key_strengths && summary.key_strengths.length > 0 && (
+                <div className="rounded-xl border border-green-200 bg-green-50 p-6">
+                  <h2 className="text-lg font-semibold text-green-900 mb-4 flex items-center gap-2">
+                    <svg className="h-5 w-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    주요 강점
+                  </h2>
+                  <div className="space-y-3">
+                    {summary.key_strengths.map((item, i) => (
+                      <div key={i} className="bg-white rounded-lg p-4 border border-green-200">
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="font-medium text-green-900">{item.strength}</span>
+                          <span className="text-sm text-green-600">신뢰도: {Math.round(item.confidence * 100)}%</span>
+                        </div>
+                        {item.evidence && (
+                          <div className="text-sm text-green-700 space-y-1">
+                            {item.evidence.resume && <p>📄 이력서: {item.evidence.resume}</p>}
+                            {item.evidence.linkedin && <p>💼 LinkedIn: {item.evidence.linkedin}</p>}
+                            {item.evidence.github && <p>🔗 GitHub: {item.evidence.github}</p>}
+                          </div>
+                        )}
+                      </div>
                     ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Risk Flags */}
+              {summary.risk_flags && summary.risk_flags.length > 0 && (
+                <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+                  <h2 className="text-lg font-semibold text-red-900 mb-4 flex items-center gap-2">
+                    <svg className="h-5 w-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                    위험 요소
+                  </h2>
+                  <div className="space-y-3">
+                    {summary.risk_flags.map((item, i) => (
+                      <div key={i} className="bg-white rounded-lg p-4 border border-red-200">
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="font-medium text-red-900">{item.concern}</span>
+                          <span className={`text-xs px-2 py-1 rounded-full ${
+                            item.severity === 'high' ? 'bg-red-200 text-red-800' :
+                            item.severity === 'medium' ? 'bg-yellow-200 text-yellow-800' :
+                            'bg-gray-200 text-gray-800'
+                          }`}>
+                            {item.severity}
+                          </span>
+                        </div>
+                        {item.evidence && <p className="text-sm text-red-700 mb-2">{item.evidence}</p>}
+                        {item.mitigation_question && (
+                          <p className="text-sm text-red-800 bg-red-100 p-2 rounded">
+                            💡 확인 질문: {item.mitigation_question}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Technical Expertise */}
+              {summary.technical_expertise && (
+                <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+                    <svg className="h-5 w-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                    </svg>
+                    기술 역량
+                  </h2>
+                  <div className="space-y-4">
+                    {summary.technical_expertise.languages && summary.technical_expertise.languages.length > 0 && (
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-500 mb-2">프로그래밍 언어</h3>
+                        <div className="flex flex-wrap gap-2">
+                          {summary.technical_expertise.languages.map((lang, i) => (
+                            <span key={i} className="px-3 py-1 rounded-full bg-purple-100 text-purple-700 text-sm">
+                              {lang.skill} ({lang.proficiency})
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    {summary.technical_expertise.frameworks && summary.technical_expertise.frameworks.length > 0 && (
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-500 mb-2">프레임워크</h3>
+                        <div className="flex flex-wrap gap-2">
+                          {summary.technical_expertise.frameworks.map((fw, i) => (
+                            <span key={i} className="px-3 py-1 rounded-full bg-blue-100 text-blue-700 text-sm">
+                              {fw.skill} ({fw.proficiency})
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    {summary.technical_expertise.tools && summary.technical_expertise.tools.length > 0 && (
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-500 mb-2">도구</h3>
+                        <div className="flex flex-wrap gap-2">
+                          {summary.technical_expertise.tools.map((tool, i) => (
+                            <span key={i} className="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
+                              {tool.tool} ({tool.proficiency})
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Data Quality Assessment */}
+              {summary.data_quality_assessment && (
+                <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4">데이터 품질 평가</h2>
+                  <div className="grid gap-4 sm:grid-cols-4">
+                    <div className="text-center p-3 bg-gray-50 rounded-lg">
+                      <div className="text-2xl font-bold text-indigo-600">
+                        {Math.round(summary.data_quality_assessment.overall_confidence * 100)}%
+                      </div>
+                      <div className="text-sm text-gray-500">전체 신뢰도</div>
+                    </div>
+                    <div className="text-center p-3 bg-gray-50 rounded-lg">
+                      <div className="text-2xl font-bold text-blue-600">
+                        {Math.round(summary.data_quality_assessment.document_quality * 100)}%
+                      </div>
+                      <div className="text-sm text-gray-500">문서 품질</div>
+                    </div>
+                    <div className="text-center p-3 bg-gray-50 rounded-lg">
+                      <div className="text-2xl font-bold text-green-600">
+                        {Math.round(summary.data_quality_assessment.linkedin_quality * 100)}%
+                      </div>
+                      <div className="text-sm text-gray-500">LinkedIn</div>
+                    </div>
+                    <div className="text-center p-3 bg-gray-50 rounded-lg">
+                      <div className="text-2xl font-bold text-purple-600">
+                        {Math.round(summary.data_quality_assessment.github_quality * 100)}%
+                      </div>
+                      <div className="text-sm text-gray-500">GitHub</div>
+                    </div>
                   </div>
                 </div>
               )}
             </div>
           )}
 
-          {/* Red/Green Flags */}
-          <div className="grid gap-6 sm:grid-cols-2">
-            {guide.green_flags_summary && guide.green_flags_summary.length > 0 && (
-              <div className="rounded-xl border border-green-200 bg-green-50 p-6">
-                <h2 className="text-lg font-semibold text-green-900 mb-3">✅ Green Flags</h2>
-                <ul className="space-y-2">
-                  {guide.green_flags_summary.map((flag, i) => (
-                    <li key={i} className="text-sm text-green-800 flex items-start gap-2">
-                      <span className="text-green-500">•</span>
-                      {flag}
-                    </li>
-                  ))}
-                </ul>
+          {/* Interviewer Guide Tab */}
+          {activeTab === 'guide' && guide && (
+            <div className="space-y-6">
+              {/* Interview Overview */}
+              {guide.interview_overview && (
+                <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4">면접 개요</h2>
+                  <div className="grid gap-4 sm:grid-cols-4">
+                    <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                      <div className="text-2xl font-bold text-indigo-600">
+                        {guide.interview_overview.total_duration_minutes}분
+                      </div>
+                      <div className="text-sm text-gray-500">총 소요시간</div>
+                    </div>
+                    <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                      <div className="text-2xl font-bold text-indigo-600">
+                        {guide.interview_overview.question_count}개
+                      </div>
+                      <div className="text-sm text-gray-500">질문 수</div>
+                    </div>
+                    <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                      <div className="text-lg font-bold text-indigo-600">
+                        {guide.interview_overview.experience_level}
+                      </div>
+                      <div className="text-sm text-gray-500">경력 수준</div>
+                    </div>
+                    <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                      <div className="text-lg font-bold text-indigo-600">
+                        {guide.interview_overview.interview_style}
+                      </div>
+                      <div className="text-sm text-gray-500">면접 스타일</div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Interview Flow */}
+              {guide.interview_flow && (
+                <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4">면접 진행 순서</h2>
+                  <div className="space-y-4">
+                    {guide.interview_flow.opening && (
+                      <div className="p-4 bg-green-50 rounded-lg border border-green-200">
+                        <h3 className="font-medium text-green-900 mb-2">
+                          🎬 오프닝 ({guide.interview_flow.opening.duration_minutes}분)
+                        </h3>
+                        <p className="text-sm text-green-800">{guide.interview_flow.opening.script}</p>
+                      </div>
+                    )}
+                    {guide.interview_flow.main_body && (
+                      <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
+                        <h3 className="font-medium text-blue-900 mb-2">📋 본 면접</h3>
+                        <p className="text-sm text-blue-800 mb-2">
+                          진행 순서: {guide.interview_flow.main_body.recommended_order?.join(' → ')}
+                        </p>
+                        {guide.interview_flow.main_body.transition_phrases && (
+                          <div className="text-sm text-blue-700">
+                            <p className="font-medium mb-1">전환 문구:</p>
+                            <ul className="list-disc list-inside">
+                              {guide.interview_flow.main_body.transition_phrases.map((phrase, i) => (
+                                <li key={i}>{phrase}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                    {guide.interview_flow.closing && (
+                      <div className="p-4 bg-amber-50 rounded-lg border border-amber-200">
+                        <h3 className="font-medium text-amber-900 mb-2">
+                          🏁 클로징 ({guide.interview_flow.closing.duration_minutes}분)
+                        </h3>
+                        <p className="text-sm text-amber-800">{guide.interview_flow.closing.script}</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Evaluation Matrix */}
+              {guide.evaluation_matrix && (
+                <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4">평가 기준</h2>
+                  <div className="grid gap-4 sm:grid-cols-3 mb-4">
+                    <div className="text-center p-3 bg-gray-50 rounded-lg">
+                      <div className="text-lg font-bold text-gray-900">
+                        {guide.evaluation_matrix.scoring_scale}
+                      </div>
+                      <div className="text-sm text-gray-500">점수 범위</div>
+                    </div>
+                    <div className="text-center p-3 bg-green-50 rounded-lg">
+                      <div className="text-lg font-bold text-green-600">
+                        ≥ {guide.evaluation_matrix.passing_threshold}
+                      </div>
+                      <div className="text-sm text-gray-500">합격 기준</div>
+                    </div>
+                    <div className="text-center p-3 bg-indigo-50 rounded-lg">
+                      <div className="text-lg font-bold text-indigo-600">
+                        ≥ {guide.evaluation_matrix.strong_hire_threshold}
+                      </div>
+                      <div className="text-sm text-gray-500">Strong Hire</div>
+                    </div>
+                  </div>
+                  {guide.evaluation_matrix.category_weights && (
+                    <div>
+                      <h3 className="text-sm font-medium text-gray-500 mb-2">카테고리별 가중치</h3>
+                      <div className="flex flex-wrap gap-2">
+                        {Object.entries(guide.evaluation_matrix.category_weights).map(([cat, weight]) => (
+                          <span key={cat} className="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
+                            {cat}: {Math.round(Number(weight) * 100)}%
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Red/Green Flags */}
+              <div className="grid gap-6 sm:grid-cols-2">
+                {guide.green_flags_summary && guide.green_flags_summary.length > 0 && (
+                  <div className="rounded-xl border border-green-200 bg-green-50 p-6">
+                    <h2 className="text-lg font-semibold text-green-900 mb-3">✅ Green Flags</h2>
+                    <ul className="space-y-2">
+                      {guide.green_flags_summary.map((flag, i) => (
+                        <li key={i} className="text-sm text-green-800 flex items-start gap-2">
+                          <span className="text-green-500">•</span>
+                          {flag}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {guide.red_flags_summary && guide.red_flags_summary.length > 0 && (
+                  <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+                    <h2 className="text-lg font-semibold text-red-900 mb-3">🚩 Red Flags</h2>
+                    <ul className="space-y-2">
+                      {guide.red_flags_summary.map((flag, i) => (
+                        <li key={i} className="text-sm text-red-800 flex items-start gap-2">
+                          <span className="text-red-500">•</span>
+                          {flag}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </div>
-            )}
-            {guide.red_flags_summary && guide.red_flags_summary.length > 0 && (
-              <div className="rounded-xl border border-red-200 bg-red-50 p-6">
-                <h2 className="text-lg font-semibold text-red-900 mb-3">🚩 Red Flags</h2>
-                <ul className="space-y-2">
-                  {guide.red_flags_summary.map((flag, i) => (
-                    <li key={i} className="text-sm text-red-800 flex items-start gap-2">
-                      <span className="text-red-500">•</span>
-                      {flag}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </div>
-        </div>
+            </div>
+          )}
+        </>
       )}
 
       {/* Glossary (shown on all tabs) */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Type exports
+ */
+export * from './interview'

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -1,0 +1,427 @@
+/**
+ * Interview Script v2 TypeScript Interfaces
+ *
+ * Comprehensive type definitions for the 4-tab interview UI:
+ * - Intel Brief: JD analysis, competency matching, GitHub/LinkedIn data
+ * - Deep Analysis: Radar charts, engineering DNA, skill matching
+ * - Live Interview: Questions with scenarios and follow-ups
+ * - Decision: JD competency achievement and hiring recommendation
+ */
+
+// =============================================================================
+// INTEL BRIEF TAB
+// =============================================================================
+
+/** JD requirement with match status */
+export interface RequirementMatch {
+  text: string
+  desc: string
+  matched: boolean
+}
+
+/** JD summary for Intel Brief */
+export interface JDSummary {
+  title: string
+  subtitle: string
+  requirements: RequirementMatch[]
+  success_metrics: string[]
+}
+
+/** Competency match levels */
+export type CompetencyMatchLevel = 'strong' | 'match' | 'partial' | 'unknown' | 'none'
+
+/** JD competency vs candidate matching */
+export interface CompetencyMatch {
+  name: string
+  match: CompetencyMatchLevel
+  match_label: string
+  desc: string
+  why: string
+  color: 'emerald' | 'amber' | 'red' | 'gray'
+  icon: string
+}
+
+/** GitHub contribution summary */
+export interface GitHubSummary {
+  contributions: number
+  repos: number
+  main_languages: string
+  tech_match: string
+  tech_match_note?: string
+  tenure_pattern: string
+  tenure_note?: string
+  activity_gap?: string
+  chart_data: number[]
+}
+
+/** LinkedIn position entry */
+export interface LinkedInPosition {
+  initial: string
+  title: string
+  company: string
+  detail: string
+}
+
+/** Intel Brief tab data */
+export interface IntelBrief {
+  jd_summary: JDSummary
+  jd_full?: string
+  competencies: CompetencyMatch[]
+  github?: GitHubSummary
+  linkedin?: LinkedInPosition[]
+  linkedin_warning?: string
+}
+
+// =============================================================================
+// DEEP ANALYSIS TAB
+// =============================================================================
+
+/** Engineering DNA item for progress bars */
+export interface EngineeringDNAItem {
+  label: string
+  value: number
+  display: string
+  color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray'
+  note?: string
+  tooltip?: string
+}
+
+/** Risk flag identified in analysis */
+export interface RiskFlag {
+  label: string
+  detail: string
+}
+
+/** Skill matching types */
+export type SkillMatchType = 'exact' | 'similar' | 'partial' | 'none'
+
+/** Skill match row for table */
+export interface SkillMatchRow {
+  skill: string
+  candidate: string
+  type: SkillMatchType
+  evidence: string
+  confidence: number
+}
+
+/** Deep Analysis tab data */
+export interface DeepAnalysis {
+  radar_candidate: number[]
+  radar_required: number[]
+  engineering_dna: EngineeringDNAItem[]
+  risk_flags: RiskFlag[]
+  skill_table: SkillMatchRow[]
+  overall_match?: number
+}
+
+// =============================================================================
+// LIVE INTERVIEW TAB - QUESTIONS
+// =============================================================================
+
+/** Answer keyword with importance */
+export interface AnswerKeyword {
+  keyword: string
+  importance: 'must' | 'good_to_have'
+  explanation: string
+}
+
+/** Scenario level (v2 structure) */
+export type ScenarioLevelType = 'Expert' | 'Mid' | 'Low'
+
+export interface ScenarioLevel {
+  level: ScenarioLevelType
+  score: number
+  text: string
+  depth_expectations: string
+}
+
+/** Follow-up response (good/poor) */
+export interface FollowUpResponse {
+  text: string
+  score: number
+}
+
+/** Follow-up question trigger */
+export type FollowUpTrigger = 'Expert' | 'Mid' | 'Low' | 'any'
+
+/** Follow-up question (v2 structure) */
+export interface FollowUpQuestion {
+  id: string
+  trigger: FollowUpTrigger
+  question_text: string
+  why_matters: string
+  listen_for: string
+  good: FollowUpResponse
+  poor: FollowUpResponse
+}
+
+/** Terminology entry */
+export interface TerminologyEntry {
+  term: string
+  definition?: string
+  plain_language_explanation?: string
+  business_context?: string
+}
+
+/** Interviewer note with business interpretation */
+export interface InterviewerNote {
+  business_interpretation: string
+  daily_analogy: string
+  level_expectation: string
+}
+
+/** Interview Question (v2 structure) */
+export interface InterviewQuestion {
+  id: string
+  title: string
+  category: string
+  difficulty: 'Easy' | 'Medium' | 'Hard'
+  question_text: string
+  why_matters: string
+  listen_for: string
+
+  // v2 structure
+  answer_keywords: AnswerKeyword[]
+  scenarios: ScenarioLevel[]
+  follow_ups: FollowUpQuestion[]
+
+  // Optional fields
+  terminology?: TerminologyEntry[]
+  interviewer_note?: InterviewerNote
+  is_risk?: boolean
+  time_allocation_minutes?: number
+  code_reference?: {
+    file?: string
+    lines?: string
+    snippet?: string
+  }
+
+  // Legacy v1 fields (for backward compatibility)
+  evaluation_scenarios?: {
+    expert?: Record<string, unknown>
+    mid?: Record<string, unknown>
+    low?: Record<string, unknown>
+  }
+  follow_up_questions?: Array<Record<string, unknown>>
+
+  // Finalization output fields
+  revised_question?: string
+  original_question?: string
+  revision_type?: string
+  revision_rationale?: string
+  new_confidence_score?: number
+  new_evidence_reference?: string
+  original_index?: number
+}
+
+// =============================================================================
+// DECISION TAB
+// =============================================================================
+
+/** Resume-based tip */
+export interface ResumeTip {
+  section: string
+  insight: string
+  question_link?: string
+}
+
+/** Cover letter insight */
+export interface CoverLetterInsight {
+  highlight: string
+  interpretation: string
+  follow_up_opportunity?: string
+}
+
+/** Decision summary */
+export interface DecisionSummary {
+  experience: string
+  jd_match: string
+  level: string
+  strengths: string[]
+  concerns: string[]
+}
+
+/** Interviewer guide tips */
+export interface InterviewerGuideTips {
+  interview_flow: string
+  time_allocation: Record<string, string>
+  resume_based_tips: ResumeTip[]
+  cover_letter_insights: CoverLetterInsight[]
+  red_flags_to_watch: string[]
+  positive_signals: string[]
+}
+
+/** JD competency weight */
+export interface JDCompetencyWeight {
+  competency: string
+  weight: number
+  related_questions: number[]
+}
+
+/** Decision Support tab data */
+export interface DecisionSupport {
+  summary: DecisionSummary
+  interviewer_guide: InterviewerGuideTips
+  jd_competency_map: JDCompetencyWeight[]
+}
+
+// =============================================================================
+// CANDIDATE INFO
+// =============================================================================
+
+/** Candidate basic info */
+export interface Candidate {
+  name: string
+  initials?: string
+  role?: string
+  company_context?: string
+  experience?: string
+  jd_match?: string
+  level?: string
+  current_title?: string
+}
+
+// =============================================================================
+// MAIN INTERVIEW SCRIPT
+// =============================================================================
+
+/** Category weights for scoring */
+export type CategoryWeights = Record<string, number>
+
+/** Candidate summary (legacy structure) */
+export interface CandidateSummary {
+  candidate_overview?: {
+    name?: string
+    current_position?: string
+    primary_domain?: string
+    experience_years?: string
+    confidence_level?: string
+  }
+  key_strengths?: Array<{
+    strength: string
+    confidence: number
+    evidence?: Record<string, string | null>
+  }>
+  risk_flags?: Array<{
+    concern: string
+    severity: string
+    evidence?: string
+    mitigation_question?: string
+  }>
+  technical_expertise?: {
+    languages?: Array<{ skill: string; proficiency: string; confidence: number }>
+    frameworks?: Array<{ skill: string; proficiency: string; confidence: number }>
+    tools?: Array<{ tool: string; proficiency: string; confidence: number }>
+  }
+  notable_achievements?: Array<{
+    achievement: string
+    source: string
+    details?: string
+  }>
+  data_quality_assessment?: {
+    overall_confidence: number
+    document_quality: number
+    linkedin_quality: number
+    github_quality: number
+    recommendations?: string[]
+  }
+}
+
+/** Interviewer guide (legacy structure) */
+export interface InterviewerGuide {
+  interview_overview?: {
+    total_duration_minutes: number
+    question_count: number
+    experience_level: string
+    interview_style: string
+  }
+  interview_flow?: {
+    opening?: { script: string; duration_minutes: number }
+    main_body?: { recommended_order: string[]; transition_phrases: string[] }
+    closing?: { script: string; duration_minutes: number }
+  }
+  category_breakdown?: Array<{
+    category: string
+    question_count: number
+    time_allocation_minutes: number
+    evaluation_priority: string
+    focus_areas: string[]
+  }>
+  evaluation_matrix?: {
+    scoring_scale: string
+    passing_threshold: number
+    strong_hire_threshold: number
+    category_weights: Record<string, number>
+  }
+  red_flags_summary?: string[]
+  green_flags_summary?: string[]
+}
+
+/** LinkedIn profile (legacy structure) */
+export interface LinkedInProfile {
+  name?: string
+  headline?: string
+  current_company?: string
+  profile_url?: string
+  projects?: Array<{ title: string; description?: string }>
+  honors_and_awards?: Array<{ title: string; issuer?: string; description?: string }>
+}
+
+/** Interview script metadata */
+export interface InterviewScriptMetadata {
+  language?: string
+  total_questions?: number
+  experience_level?: string
+  has_linkedin_data?: boolean
+}
+
+/** Complete Interview Script (v2) */
+export interface InterviewScript {
+  // Core fields
+  job_id?: string
+  generated_at?: string
+  output_language?: string
+
+  // Questions
+  questions: InterviewQuestion[]
+
+  // v2 new fields
+  candidate?: Candidate
+  intel?: IntelBrief
+  analysis?: DeepAnalysis
+  decision?: DecisionSupport
+  category_weights?: CategoryWeights
+
+  // Legacy fields (v1 compatibility)
+  metadata?: InterviewScriptMetadata
+  candidate_summary?: CandidateSummary
+  interviewer_guide?: InterviewerGuide
+  decision_guide?: Record<string, unknown>
+  full_glossary?: TerminologyEntry[]
+  linkedin_profile?: LinkedInProfile
+}
+
+// =============================================================================
+// SCORING STATE FOR LIVE INTERVIEW
+// =============================================================================
+
+/** Score state for a single question */
+export interface QuestionScoreState {
+  selectedLevel?: ScenarioLevelType
+  followUpScores: Record<string, number>
+  totalScore: number
+  maxPossibleScore: number
+}
+
+/** All scores state */
+export type ScoresState = Record<string, QuestionScoreState>
+
+// =============================================================================
+// TAB TYPES
+// =============================================================================
+
+/** Available tabs in the result page */
+export type ResultTab = 'intel' | 'analysis' | 'interview' | 'decision'
+
+/** Interview phase in Live Interview tab */
+export type InterviewPhase = 'select' | 'interview'


### PR DESCRIPTION
## 요약
데모 UI 구조(Intel Brief → Deep Analysis → Live Interview → Decision)에 맞춰 백엔드 LLM 출력 구조와 프론트엔드 UI를 전면 개편했습니다.

### 백엔드 변경사항
- 새 데이터 모델 추가: `IntelBrief`, `DeepAnalysis`, `DecisionSupport`
- `Question` 모델 v2 필드 추가: `title`, `scenarios[]`, `answer_keywords`, `follow_ups`
- Temporal Activity 추가: `generate_intel_brief`, `generate_deep_analysis`
- API 버전 파라미터 추가 (`?version=v1/v2`)
- v1/v2 변환기 구현으로 하위 호환성 유지

### 프론트엔드 변경사항
- TypeScript 인터페이스 생성 (`interview.ts`)
- 차트 컴포넌트: `RadarChart`, `ContributionChart`, `ProgressBar` (SVG 기반, 외부 의존성 없음)
- 4개 탭 컴포넌트: `IntelBriefTab`, `DeepAnalysisTab`, `LiveInterviewTab`, `DecisionTab`
- `ResultPage` 전면 개편: 4탭 v2 구조 + v1 fallback
- E2E 테스트 추가 (Playwright)

## 테스트 계획
- [x] TypeScript 빌드 확인 (`npm run build`)
- [x] E2E 테스트 작성 (Playwright)
- [ ] 실제 데이터로 4탭 UI 검증
- [ ] v1 fallback 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)