### PR TITLE
feat: v2 프롬프트 최적화 - Few-shot + Anti-Hallucination 적용

### DIFF
--- a/backend/app/prompts/finalization.yaml
+++ b/backend/app/prompts/finalization.yaml
@@ -362,3 +362,432 @@ prompts:
       - If >20% of questions flagged: ready_for_delivery = false
 
       REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
+
+  generate_intel_brief:
+    description: "v2 Intel Brief 생성 - JD 분석 + 역량 매칭 + GitHub/LinkedIn 요약"
+    template: |
+      # CRITICAL OUTPUT RULES (READ FIRST)
+      - Return ONLY raw JSON, NO markdown formatting
+      - Do NOT wrap output in ```json or ``` code blocks
+      - Start your response with { and end with }
+      - No explanatory text before or after the JSON
+
+      # ROLE & GOAL
+      Generate an Intel Brief for non-technical interviewers. This provides a clear overview
+      of the candidate's fit with the JD requirements, GitHub activity, and LinkedIn history.
+
+      # INPUTS
+      JD Analysis: {{jd_analysis}}
+      Document Analysis: {{document_analysis}}
+      GitHub Analysis: {{github_analysis}}
+      LinkedIn Profile: {{linkedin_profile}}
+
+      # ANTI-HALLUCINATION RULES (CRITICAL)
+      1. ONLY use information explicitly present in the inputs
+      2. For competency matching, match_label MUST reflect actual evidence:
+         - "strong" = Evidence in 2+ sources with concrete examples
+         - "match" = Evidence in 1 source with specific details
+         - "partial" = Mentioned but not demonstrated
+         - "unknown" = No evidence either way
+         - "none" = Evidence suggests lack of skill
+      3. GitHub chart_data MUST come from actual github_analysis, NOT fabricated
+      4. LinkedIn positions MUST match linkedin_profile exactly
+
+      # OUTPUT FORMAT (v2 IntelBrief)
+      ```json
+      {
+        "jd_summary": {
+          "title": "직책명",
+          "subtitle": "회사/부서",
+          "requirements": [
+            {
+              "text": "요구사항 (JD 원문)",
+              "desc": "비개발자용 설명",
+              "matched": true|false
+            }
+          ],
+          "success_metrics": ["성공 지표 1", "성공 지표 2"]
+        },
+        "competencies": [
+          {
+            "name": "역량명",
+            "match": "strong|match|partial|unknown|none",
+            "match_label": "매칭 레이블 (강점/일치/부분/미확인/미달)",
+            "desc": "비개발자용 역량 설명",
+            "why": "이 역량이 왜 필요한지",
+            "color": "emerald|green|amber|gray|red",
+            "icon": "✅|⚠️|❌|❓"
+          }
+        ],
+        "github": {
+          "contributions": number,
+          "repos": number,
+          "main_languages": "주요 언어들",
+          "tech_match": "높음|중간|낮음",
+          "tech_match_note": "기술 매칭 설명",
+          "tenure_pattern": "안정적|보통|잦은이동",
+          "tenure_note": "재직 패턴 설명",
+          "activity_gap": "공백 기간 설명 또는 null",
+          "chart_data": [12개월 기여도 숫자 배열]
+        },
+        "linkedin": [
+          {
+            "company": "회사명",
+            "role": "직책",
+            "period": "기간"
+          }
+        ],
+        "linkedin_warning": "LinkedIn 주의사항 또는 null"
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE
+      Inputs:
+      - JD: "AI 엔지니어, Python 3년 이상, LLM 경험"
+      - Document: "홍길동, Python 5년, GPT-4 기반 서비스 개발"
+      - GitHub: "contributions: 1234, repos: 45, main_languages: Python"
+      - LinkedIn: "ABC Corp AI Engineer 2022-현재"
+
+      Good Output:
+      ```json
+      {
+        "jd_summary": {
+          "title": "AI 엔지니어",
+          "subtitle": "TechCorp",
+          "requirements": [
+            {"text": "Python 3년 이상", "desc": "백엔드 개발 언어", "matched": true},
+            {"text": "LLM 경험", "desc": "대규모 언어 모델 활용", "matched": true}
+          ],
+          "success_metrics": ["AI 서비스 런칭", "모델 성능 개선"]
+        },
+        "competencies": [
+          {
+            "name": "Python 개발",
+            "match": "strong",
+            "match_label": "강점",
+            "desc": "5년 경력으로 JD 요구사항(3년) 초과",
+            "why": "AI 서비스 개발의 핵심 언어",
+            "color": "emerald",
+            "icon": "✅"
+          },
+          {
+            "name": "LLM 활용",
+            "match": "match",
+            "match_label": "일치",
+            "desc": "GPT-4 기반 서비스 개발 경험",
+            "why": "AI 서비스 핵심 역량",
+            "color": "green",
+            "icon": "✅"
+          }
+        ],
+        "github": {
+          "contributions": 1234,
+          "repos": 45,
+          "main_languages": "Python",
+          "tech_match": "높음",
+          "tech_match_note": "JD 요구 기술과 높은 일치도",
+          "tenure_pattern": "안정적",
+          "tenure_note": "평균 2년 이상 재직",
+          "activity_gap": null,
+          "chart_data": [50, 60, 45, 80, 90, 100, 75, 85, 95, 88, 92, 78]
+        },
+        "linkedin": [
+          {"company": "ABC Corp", "role": "AI Engineer", "period": "2022-현재"}
+        ],
+        "linkedin_warning": null
+      }
+      ```
+
+      # BAD EXAMPLE (Hallucination - DO NOT DO THIS)
+      ```json
+      {
+        "competencies": [
+          {
+            "name": "Kubernetes",
+            "match": "strong",
+            "match_label": "강점"
+          }
+        ]
+      }
+      ```
+      WHY BAD: Kubernetes was NEVER mentioned in any input. This is hallucination.
+
+      REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
+
+  generate_deep_analysis:
+    description: "v2 Deep Analysis 생성 - 레이더 차트 + Engineering DNA + 스킬 테이블"
+    template: |
+      # CRITICAL OUTPUT RULES (READ FIRST)
+      - Return ONLY raw JSON, NO markdown formatting
+      - Do NOT wrap output in ```json or ``` code blocks
+      - Start your response with { and end with }
+      - No explanatory text before or after the JSON
+
+      # ROLE & GOAL
+      Generate a Deep Analysis with radar chart scores, engineering DNA metrics,
+      and skill matching table. All scores MUST be evidence-based.
+
+      # INPUTS
+      JD Analysis: {{jd_analysis}}
+      Code Analysis: {{code_analysis}}
+      Candidate Profile: {{candidate_profile}}
+
+      # SCORING METHODOLOGY (CRITICAL - Prevent Hallucination)
+
+      ## Radar Chart Axes (0-100 scale)
+      Calculate based on ACTUAL evidence only:
+      - **role_fit**: JD requirements matched / total requirements * 100
+      - **technical**: Technical skills demonstrated / required skills * 100
+      - **execution**: Projects completed / projects mentioned * 100
+      - **communication**: Documentation quality, PR descriptions (if GitHub available)
+      - **risk**: 100 - (risk_flags_count * 20), minimum 0
+
+      ## Engineering DNA Scoring
+      Only populate if GitHub analysis is available:
+      - **Test Coverage**: From code_analysis.test_coverage OR "미확인"
+      - **Code Review**: From PR review participation OR "미확인"
+      - **Documentation**: From README quality OR "미확인"
+      - **CI/CD**: From pipeline usage OR "미확인"
+      - **Code Quality**: From linting/complexity metrics OR "미확인"
+
+      # OUTPUT FORMAT (v2 DeepAnalysis)
+      ```json
+      {
+        "radar_candidate": [role_fit, technical, execution, communication, risk],
+        "radar_required": [JD_role_fit, JD_technical, JD_execution, JD_communication, JD_risk],
+        "engineering_dna": [
+          {
+            "label": "메트릭 이름",
+            "value": 0-100,
+            "display": "표시 값 (82%, 우수, 미확인 등)",
+            "color": "emerald|blue|amber|red|gray",
+            "note": "추가 설명",
+            "tooltip": "마우스오버 설명"
+          }
+        ],
+        "risk_flags": [
+          {
+            "flag": "위험 신호",
+            "severity": "high|medium|low",
+            "evidence": "근거"
+          }
+        ],
+        "skill_table": [
+          {
+            "skill": "JD 요구 스킬",
+            "candidate": "후보자 보유 스킬",
+            "type": "exact|similar|partial|none",
+            "evidence": "증거 출처",
+            "confidence": 0-100
+          }
+        ],
+        "overall_match": 0-100
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE
+      Inputs:
+      - JD: "Python, FastAPI, PostgreSQL 필수"
+      - Code Analysis: "test_coverage: 82%, main_languages: Python, frameworks: FastAPI"
+      - Candidate: "5년 Python, FastAPI 프로젝트 3개"
+
+      Good Output:
+      ```json
+      {
+        "radar_candidate": [85, 80, 75, 70, 90],
+        "radar_required": [80, 75, 70, 75, 80],
+        "engineering_dna": [
+          {
+            "label": "테스트 커버리지",
+            "value": 82,
+            "display": "82%",
+            "color": "emerald",
+            "note": "우수",
+            "tooltip": "단위 테스트 커버리지 비율"
+          },
+          {
+            "label": "코드 문서화",
+            "value": 65,
+            "display": "65%",
+            "color": "amber",
+            "note": "보통",
+            "tooltip": "README 및 코드 주석 품질"
+          }
+        ],
+        "risk_flags": [],
+        "skill_table": [
+          {
+            "skill": "Python",
+            "candidate": "Python 5년",
+            "type": "exact",
+            "evidence": "이력서 + GitHub",
+            "confidence": 95
+          },
+          {
+            "skill": "FastAPI",
+            "candidate": "FastAPI",
+            "type": "exact",
+            "evidence": "GitHub repos",
+            "confidence": 90
+          },
+          {
+            "skill": "PostgreSQL",
+            "candidate": "PostgreSQL",
+            "type": "exact",
+            "evidence": "이력서",
+            "confidence": 80
+          }
+        ],
+        "overall_match": 85
+      }
+      ```
+
+      # ANTI-HALLUCINATION CHECKLIST
+      Before outputting, verify:
+      - [ ] All radar scores have clear calculation basis
+      - [ ] Engineering DNA metrics are from actual code_analysis, not assumed
+      - [ ] Skill table matches actual candidate skills, not inferred
+      - [ ] Risk flags are from documented concerns, not speculated
+
+      REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
+
+  generate_decision_support:
+    description: "v2 Decision Support 생성 - 채용 의사결정 지원"
+    template: |
+      # CRITICAL OUTPUT RULES (READ FIRST)
+      - Return ONLY raw JSON, NO markdown formatting
+      - Do NOT wrap output in ```json or ``` code blocks
+      - Start your response with { and end with }
+      - No explanatory text before or after the JSON
+
+      # ROLE & GOAL
+      Generate decision support data for hiring committee. Summarize candidate strengths,
+      concerns, and provide interviewer guidance. All content MUST be grounded in evidence.
+
+      # INPUTS
+      Candidate Summary: {{candidate_summary}}
+      Questions: {{questions}}
+      JD Analysis: {{jd_analysis}}
+
+      # ANTI-HALLUCINATION RULES
+      1. Strengths MUST come from documented evidence in candidate_summary
+      2. Concerns MUST be documented risk flags, NOT speculated
+      3. Interviewer tips MUST reference actual resume/cover letter content
+      4. JD competency weights MUST match actual JD requirements
+
+      # OUTPUT FORMAT (v2 DecisionSupport)
+      ```json
+      {
+        "summary": {
+          "experience": "경력 요약",
+          "jd_match": "높음|중간|낮음",
+          "level": "Junior|Mid|Senior|Lead",
+          "strengths": ["강점1 (출처)", "강점2 (출처)"],
+          "concerns": ["우려사항1 (출처)", "우려사항2 (출처)"]
+        },
+        "interviewer_guide": {
+          "interview_flow": "면접 진행 순서",
+          "time_allocation": {
+            "기술 심층": "분",
+            "행동 면접": "분",
+            "문화 적합": "분"
+          },
+          "resume_based_tips": [
+            {
+              "section": "이력서 섹션",
+              "insight": "인사이트",
+              "question_link": "관련 질문 번호"
+            }
+          ],
+          "cover_letter_insights": [
+            {
+              "highlight": "주목할 부분",
+              "interpretation": "해석",
+              "follow_up_opportunity": "후속 기회"
+            }
+          ],
+          "red_flags_to_watch": ["주의 신호1", "주의 신호2"],
+          "positive_signals": ["긍정 신호1", "긍정 신호2"]
+        },
+        "jd_competency_map": [
+          {
+            "competency": "JD 역량",
+            "weight": 0.0-1.0,
+            "related_questions": [질문 번호 배열]
+          }
+        ]
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE
+      Inputs:
+      - Candidate: "홍길동, 5년 Python, ABC Corp 시니어 개발자"
+      - JD: "Python 필수, FastAPI 우대, 팀 리딩 경험"
+      - Questions: 25개 질문 (category별 5개씩)
+
+      Good Output:
+      ```json
+      {
+        "summary": {
+          "experience": "5년 (Python 백엔드)",
+          "jd_match": "높음",
+          "level": "Senior",
+          "strengths": [
+            "Python 전문성 (GitHub 2000+ commits, 이력서 5년 경력)",
+            "팀 협업 경험 (이력서: 5명 팀 리드)"
+          ],
+          "concerns": [
+            "FastAPI 경험 불명확 (이력서 미언급, GitHub 미확인)"
+          ]
+        },
+        "interviewer_guide": {
+          "interview_flow": "기술 심층(40분) → 행동 면접(15분) → 문화 적합(5분)",
+          "time_allocation": {
+            "기술 심층": "40분",
+            "행동 면접": "15분",
+            "문화 적합": "5분"
+          },
+          "resume_based_tips": [
+            {
+              "section": "ABC Corp 경력",
+              "insight": "팀 리딩 경험 구체적 확인 필요",
+              "question_link": "Q5 참조"
+            }
+          ],
+          "cover_letter_insights": [],
+          "red_flags_to_watch": [
+            "FastAPI 질문에 모호한 답변 시 실제 경험 부족 가능"
+          ],
+          "positive_signals": [
+            "구체적 수치 기반 성과 설명",
+            "팀 협업 사례 언급"
+          ]
+        },
+        "jd_competency_map": [
+          {
+            "competency": "Python 개발",
+            "weight": 0.35,
+            "related_questions": [1, 2, 7, 12, 18]
+          },
+          {
+            "competency": "팀 리딩",
+            "weight": 0.25,
+            "related_questions": [5, 10, 15]
+          }
+        ]
+      }
+      ```
+
+      # BAD EXAMPLE (Hallucination - DO NOT DO THIS)
+      ```json
+      {
+        "summary": {
+          "strengths": [
+            "Kubernetes 운영 경험"
+          ]
+        }
+      }
+      ```
+      WHY BAD: Kubernetes was never mentioned in any input. This is hallucination.
+
+      REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.

--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -153,7 +153,7 @@ prompts:
       REMINDER: Return raw JSON array only. Do NOT use markdown code blocks. Start with [ and end with ].
 
   craft_question:
-    description: "개별 면접 질문 생성 - 증거 기반 (Few-shot Enhanced)"
+    description: "개별 면접 질문 생성 - v2 포맷 (scenarios 배열, answer_keywords, good/poor follow_ups)"
     template: |
       # CRITICAL OUTPUT RULES (READ FIRST)
       - Return ONLY raw JSON, NO markdown formatting
@@ -163,7 +163,7 @@ prompts:
 
       # ROLE & GOAL
       You are an expert interview question crafter. Generate a detailed interview question
-      in {{output_language}} that is GROUNDED in documented evidence.
+      in {{output_language}} using the v2 output format with scenarios array and structured follow-ups.
 
       # WHAT YOU WILL SEE
       - Topic with source attribution
@@ -175,112 +175,326 @@ prompts:
       Category: {{category}}
       Difficulty: {{difficulty}}
 
-      # DETAILED GOAL
-      Create a question that:
-      1. Directly references documented evidence
-      2. Has clear evaluation criteria
-      3. Includes follow-up questions for depth
-      4. Provides interviewer guidance
-
-      # OUTPUT FORMAT (JSON)
+      # OUTPUT FORMAT (v2 JSON)
       ```json
       {
+        "title": "짧은 제목 (2-4 단어)",
         "question_text": "Main question in {{output_language}}",
-        "question_rationale": "Why this question based on evidence",
-        "evidence_reference": "Specific evidence this question is based on",
-        "alternative_phrasings": [
-          "Alternative way to ask 1",
-          "Alternative way to ask 2"
-        ],
-        "expected_answer": {
-          "expert": {
-            "description": "What an expert-level answer looks like",
-            "key_indicators": ["specific technical terms", "depth of understanding"],
-            "example_response": "Brief example of expert answer"
-          },
-          "mid_level": {
-            "description": "What an adequate answer looks like",
-            "key_indicators": ["basic understanding", "practical experience"],
-            "example_response": "Brief example of mid-level answer"
-          },
-          "low_level": {
-            "description": "What an insufficient answer looks like",
-            "key_indicators": ["vague responses", "lack of specifics"],
-            "example_response": "Brief example of weak answer"
-          }
-        },
-        "follow_up_questions": [
+        "why_matters": "이 질문이 중요한 이유 (비즈니스 관점)",
+        "listen_for": "핵심 키워드와 개념",
+        "is_risk": false,
+        "answer_keywords": [
           {
-            "trigger": "expert|mid|low",
-            "question": "Follow-up question text",
-            "purpose": "What this follow-up aims to uncover"
+            "keyword": "핵심 키워드",
+            "importance": "must|good_to_have",
+            "explanation": "이 키워드가 중요한 이유"
           }
         ],
-        "evaluation_criteria": {
-          "technical_accuracy": "How to assess technical correctness",
-          "depth_of_experience": "How to assess real-world experience",
-          "communication_clarity": "How to assess explanation ability"
-        },
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "전문가 수준 답변 예시",
+            "depth_expectations": "기대하는 깊이와 구체성"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "중급 수준 답변 예시",
+            "depth_expectations": "적절한 이해도와 경험"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "부족한 답변 예시",
+            "depth_expectations": "개선이 필요한 부분"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert|Mid|Low|any",
+            "question_text": "꼬리질문",
+            "why_matters": "이 꼬리질문이 중요한 이유",
+            "listen_for": "들어볼 핵심 내용",
+            "good": {
+              "text": "좋은 답변 예시",
+              "score": 8
+            },
+            "poor": {
+              "text": "부족한 답변 예시",
+              "score": 2
+            }
+          }
+        ],
+        "terminology": [
+          {
+            "term": "전문 용어",
+            "definition": "비개발자용 쉬운 설명",
+            "pronunciation": "발음 가이드 (선택)"
+          }
+        ],
         "interviewer_note": {
-          "what_to_listen_for": "Key phrases or concepts",
-          "red_flags": ["Warning signs in answer"],
-          "green_flags": ["Positive indicators in answer"],
-          "time_allocation_minutes": 5
-        },
-        "confidence_score": 0.0-1.0
+          "business_interpretation": "비즈니스 관점에서 이 질문이 의미하는 바",
+          "daily_analogy": "일상생활 비유로 설명",
+          "level_expectation": "레벨별 기대치 요약"
+        }
       }
       ```
 
-      # SUCCESSFUL EXAMPLE
-      Topic: "FastAPI 비동기 처리 경험" (from resume: "FastAPI 기반 API 개발")
+      # FEW-SHOT EXAMPLE 1: 기술 심층 질문 (Technical Depth)
+      Topic: "FastAPI 비동기 처리 및 성능 최적화" (from GitHub: 50+ commits, Resume: 일일 100만 요청 처리)
       Category: technical_depth
-      Difficulty: Medium
+      Difficulty: Hard
 
-      Good Question:
       ```json
       {
-        "question_text": "이력서에 FastAPI 기반 API 개발 경험이 있으시다고 하셨는데, 비동기 처리가 필요한 상황에서 어떻게 구현하셨나요?",
-        "question_rationale": "Resume explicitly mentions FastAPI; probing async understanding is appropriate for Mid level",
-        "evidence_reference": "Resume: 'FastAPI 기반 API 개발'",
-        "alternative_phrasings": [
-          "FastAPI에서 async/await를 사용한 구체적인 사례를 설명해주세요",
-          "FastAPI 프로젝트에서 동시성 처리를 어떻게 다루셨나요?"
-        ],
-        "expected_answer": {
-          "expert": {
-            "description": "async/await 패턴, 이벤트 루프, 동시성 제어 설명",
-            "key_indicators": ["asyncio", "await", "concurrent.futures", "background tasks"],
-            "example_response": "저는 외부 API 호출이 많은 서비스에서 httpx의 AsyncClient를 사용해..."
-          },
-          "mid_level": {
-            "description": "기본적인 async 함수 사용 경험",
-            "key_indicators": ["async def", "await", "비동기 함수"],
-            "example_response": "async def로 함수를 정의하고 await로 호출했습니다"
-          },
-          "low_level": {
-            "description": "비동기 개념 이해 부족",
-            "key_indicators": ["잘 모르겠다", "동기적으로 처리"],
-            "example_response": "그냥 함수로 작성했는데 특별히 비동기는..."
-          }
-        },
-        "follow_up_questions": [
+        "title": "비동기 성능 최적화",
+        "question_text": "이력서에 일일 100만 요청을 처리하는 시스템을 구축하셨다고 하셨는데, FastAPI에서 비동기 처리를 통해 어떻게 이런 성능을 달성하셨나요?",
+        "why_matters": "대규모 트래픽 처리 능력은 서비스 확장성의 핵심 지표입니다",
+        "listen_for": "asyncio, httpx, 동시성 제어, 커넥션 풀, 배치 처리",
+        "is_risk": false,
+        "answer_keywords": [
           {
-            "trigger": "expert",
-            "question": "동시에 여러 외부 API를 호출할 때 에러 처리는 어떻게 하셨나요?",
-            "purpose": "Advanced error handling in async contexts"
+            "keyword": "async/await",
+            "importance": "must",
+            "explanation": "FastAPI 비동기 처리의 기본 문법"
           },
           {
-            "trigger": "mid",
-            "question": "비동기 처리의 장점이 무엇이라고 생각하시나요?",
-            "purpose": "Verify conceptual understanding"
+            "keyword": "커넥션 풀",
+            "importance": "must",
+            "explanation": "대규모 요청 처리에 필수적인 리소스 관리"
           },
           {
-            "trigger": "low",
-            "question": "동기와 비동기의 차이점을 설명해주실 수 있나요?",
-            "purpose": "Assess baseline knowledge"
+            "keyword": "asyncio.gather",
+            "importance": "good_to_have",
+            "explanation": "병렬 처리 최적화 기법"
           }
         ],
-        "confidence_score": 0.9
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 25,
+            "text": "httpx AsyncClient와 커넥션 풀을 사용하고, asyncio.gather로 병렬 처리하며, 백프레셔 패턴으로 과부하를 방지했습니다. 모니터링 메트릭을 기반으로 동시성 제한을 조정했습니다.",
+            "depth_expectations": "구체적 수치, 병목 현상 해결 과정, 모니터링 전략까지 설명"
+          },
+          {
+            "level": "Mid",
+            "score": 15,
+            "text": "async def로 함수를 정의하고 await로 외부 API를 호출했습니다. 동시에 여러 요청을 처리할 수 있어서 성능이 좋았습니다.",
+            "depth_expectations": "기본 비동기 패턴 이해, 성능 개선 인식"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "FastAPI가 자동으로 비동기 처리를 해줘서 특별히 신경 쓰지 않았습니다.",
+            "depth_expectations": "비동기 개념 이해 부족, 수동적 접근"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q1-f1",
+            "trigger": "Expert",
+            "question_text": "비동기 처리 중 에러가 발생했을 때 어떻게 처리하셨나요? 특히 부분 실패 상황에서요.",
+            "why_matters": "실제 프로덕션 환경에서의 에러 처리 능력 검증",
+            "listen_for": "try/except, 타임아웃, 재시도, 서킷브레이커",
+            "good": {
+              "text": "asyncio.gather의 return_exceptions 옵션을 사용하고, 부분 실패 시 성공한 결과는 캐시하고 실패한 요청만 재시도했습니다.",
+              "score": 10
+            },
+            "poor": {
+              "text": "그냥 try/except로 잡아서 로그만 남겼습니다.",
+              "score": 3
+            }
+          },
+          {
+            "id": "q1-f2",
+            "trigger": "Mid",
+            "question_text": "비동기 처리의 장점이 구체적으로 무엇이라고 생각하시나요?",
+            "why_matters": "개념적 이해도 확인",
+            "listen_for": "I/O 바운드, 블로킹, 동시성",
+            "good": {
+              "text": "I/O 대기 시간에 다른 작업을 처리할 수 있어서 같은 리소스로 더 많은 요청을 처리할 수 있습니다.",
+              "score": 6
+            },
+            "poor": {
+              "text": "그냥 빨라서요.",
+              "score": 2
+            }
+          },
+          {
+            "id": "q1-f3",
+            "trigger": "Low",
+            "question_text": "동기와 비동기의 차이점을 설명해주실 수 있나요?",
+            "why_matters": "기본 개념 이해도 확인",
+            "listen_for": "대기, 순차, 병렬",
+            "good": {
+              "text": "동기는 한 작업이 끝날 때까지 기다리고, 비동기는 기다리는 동안 다른 작업을 할 수 있습니다.",
+              "score": 4
+            },
+            "poor": {
+              "text": "잘 모르겠습니다.",
+              "score": 0
+            }
+          }
+        ],
+        "terminology": [
+          {
+            "term": "비동기 처리 (Async)",
+            "definition": "여러 요청을 동시에 처리하는 방식. 식당에서 주문 받고 요리 나올 때까지 다른 손님 주문을 받는 것과 같음",
+            "pronunciation": "어싱크"
+          },
+          {
+            "term": "커넥션 풀",
+            "definition": "미리 만들어둔 연결 모음. 매번 새로 연결하지 않고 재사용해서 빠르게 처리",
+            "pronunciation": "커넥션 풀"
+          }
+        ],
+        "interviewer_note": {
+          "business_interpretation": "대규모 트래픽을 안정적으로 처리하면 서버 비용 절감과 사용자 경험 개선으로 이어집니다",
+          "daily_analogy": "패스트푸드점에서 주문을 받고 음식이 나올 때까지 다음 손님 주문을 받는 것과 같습니다",
+          "level_expectation": "시니어: 구체적 수치와 최적화 경험, 주니어: 기본 개념 이해와 학습 의지"
+        }
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE 2: 행동 면접 질문 (Behavioral)
+      Topic: "첫 90일 온보딩 전략" (from Resume: 팀 리딩 경험)
+      Category: role_fit
+      Difficulty: Medium
+
+      ```json
+      {
+        "title": "첫 90일 우선순위",
+        "question_text": "새로운 팀에 합류하신다면 첫 90일 동안 어떤 우선순위로 업무를 진행하시겠습니까?",
+        "why_matters": "온보딩 역량과 전략적 사고력을 평가합니다",
+        "listen_for": "체계적 계획, 팀 이해, 작은 성과, 관계 구축",
+        "is_risk": false,
+        "answer_keywords": [
+          {
+            "keyword": "팀/문화 이해",
+            "importance": "must",
+            "explanation": "효과적인 협업의 기반"
+          },
+          {
+            "keyword": "Quick Win",
+            "importance": "good_to_have",
+            "explanation": "초기 신뢰 구축에 중요"
+          }
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "첫 30일: 팀원 1:1 미팅, 코드베이스 파악, 작은 버그 수정으로 신뢰 구축. 31-60일: 중요 프로젝트 참여, 프로세스 개선점 제안. 61-90일: 주도적 기능 개발, 온보딩 문서 보완.",
+            "depth_expectations": "단계별 목표, 구체적 액션, 측정 가능한 성과"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "먼저 팀원들과 친해지고 코드를 파악한 뒤, 할당된 업무를 열심히 하겠습니다.",
+            "depth_expectations": "일반적인 계획, 수동적 자세"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "시키는 일을 열심히 하겠습니다.",
+            "depth_expectations": "계획 부재, 주도성 부족"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q2-f1",
+            "trigger": "Expert",
+            "question_text": "온보딩 과정에서 예상되는 어려움과 대응 전략은 무엇인가요?",
+            "why_matters": "리스크 관리 능력과 사전 계획 능력",
+            "listen_for": "기술 스택 차이, 문화 적응, 도메인 지식",
+            "good": {
+              "text": "새로운 기술 스택 학습이 필요할 수 있어서 미리 관련 문서를 요청하고, 멘토를 지정받아 질문할 수 있는 채널을 확보하겠습니다.",
+              "score": 8
+            },
+            "poor": {
+              "text": "특별히 어려움은 없을 것 같습니다.",
+              "score": 2
+            }
+          }
+        ],
+        "terminology": [],
+        "interviewer_note": {
+          "business_interpretation": "체계적인 온보딩은 생산성 도달 시간을 단축하고 조기 퇴사율을 낮춥니다",
+          "daily_analogy": "새 집으로 이사했을 때 동네 파악하고, 필요한 물건 정리하고, 이웃과 인사하는 것과 같습니다",
+          "level_expectation": "시니어: 구체적 주차별 계획과 성과 목표, 주니어: 학습 의지와 적극적 태도"
+        }
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE 3: 위험 신호 검증 질문 (Risk Flag)
+      Topic: "빈번한 이직 사유 확인" (from Resume: 3년간 3개 회사)
+      Category: risk_flags
+      Difficulty: Medium
+
+      ```json
+      {
+        "title": "이직 사유 확인",
+        "question_text": "이력서를 보니 최근 3년간 3개 회사에서 근무하셨네요. 각 이직 결정의 배경을 설명해주시겠어요?",
+        "why_matters": "잦은 이직이 우려되는 상황에서 실제 사유와 향후 안정성 판단",
+        "listen_for": "성장 동기, 객관적 사유, 다음 회사 선택 기준",
+        "is_risk": true,
+        "answer_keywords": [
+          {
+            "keyword": "성장 기회",
+            "importance": "good_to_have",
+            "explanation": "긍정적인 이직 동기"
+          },
+          {
+            "keyword": "회사 상황",
+            "importance": "good_to_have",
+            "explanation": "외부 요인으로 인한 이직"
+          }
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 18,
+            "text": "첫 회사는 스타트업 폐업, 두 번째는 기술 스택 성장 한계, 세 번째는 팀 해체였습니다. 저는 장기적으로 성장할 수 있는 환경을 찾고 있고, 이번에는 기술 비전이 명확한 회사를 선택하고자 합니다.",
+            "depth_expectations": "구체적 사유, 객관적 설명, 향후 기준 명확"
+          },
+          {
+            "level": "Mid",
+            "score": 10,
+            "text": "더 좋은 기회가 있어서 옮겼습니다. 이번에는 오래 다니고 싶습니다.",
+            "depth_expectations": "모호한 사유, 향후 계획 불명확"
+          },
+          {
+            "level": "Low",
+            "score": 3,
+            "text": "회사가 맞지 않았습니다.",
+            "depth_expectations": "부정적 표현, 책임 회피"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q3-f1",
+            "trigger": "any",
+            "question_text": "이번 회사에서는 어떤 조건이 충족되면 오래 근무하실 수 있을까요?",
+            "why_matters": "장기 근속 의지와 조건 확인",
+            "listen_for": "성장 기회, 팀 문화, 기술 비전",
+            "good": {
+              "text": "기술적으로 성장할 수 있는 환경과 명확한 커리어 패스가 있다면 오래 함께하고 싶습니다.",
+              "score": 6
+            },
+            "poor": {
+              "text": "급여가 좋으면요.",
+              "score": 1
+            }
+          }
+        ],
+        "terminology": [],
+        "interviewer_note": {
+          "business_interpretation": "잦은 이직은 채용 비용 증가와 팀 안정성 저하로 이어질 수 있습니다. 단, 외부 요인에 의한 이직은 감안해야 합니다.",
+          "daily_analogy": "자주 이사하는 사람에게 왜 이사를 많이 했는지, 이번에는 오래 살 계획인지 물어보는 것과 같습니다",
+          "level_expectation": "시니어: 객관적 사유와 명확한 향후 기준, 주니어: 성장 동기와 학습 의지"
+        }
       }
       ```
 
@@ -289,22 +503,51 @@ prompts:
       Category: technical_depth
       Difficulty: Hard
 
-      BAD Question:
+      BAD Output:
       ```json
       {
-        "question_text": "Django ORM에서 N+1 쿼리 문제를 어떻게 해결하셨나요?",
-        "evidence_reference": "Inferred from Python experience"
+        "title": "Django N+1 해결",
+        "question_text": "Django ORM에서 N+1 쿼리 문제를 어떻게 해결하셨나요?"
       }
       ```
       WHY BAD: Resume says "Python 개발자" but NEVER mentions Django. This assumes Django knowledge.
 
-      CORRECT Question:
+      CORRECT Output:
       ```json
       {
+        "title": "Python 문제 해결",
         "question_text": "Python 개발자로서 가장 복잡한 문제를 해결한 경험을 설명해주세요",
-        "question_rationale": "Resume only mentions 'Python 개발자' without specifics; open-ended question appropriate",
-        "evidence_reference": "Resume: 'Python 개발자'",
-        "confidence_score": 0.6
+        "why_matters": "문제 해결 능력과 기술적 깊이를 open-ended로 확인",
+        "listen_for": "문제 정의, 접근 방식, 결과",
+        "is_risk": false,
+        "answer_keywords": [],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "구체적인 기술적 문제, 체계적 접근, 측정 가능한 결과",
+            "depth_expectations": "실제 경험 기반 상세 설명"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "일반적인 문제 해결 경험",
+            "depth_expectations": "기본적인 문제 해결 프로세스 이해"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "모호한 답변, 경험 부족",
+            "depth_expectations": "구체성 부족"
+          }
+        ],
+        "follow_ups": [],
+        "terminology": [],
+        "interviewer_note": {
+          "business_interpretation": "증거가 부족하므로 open-ended 질문으로 후보자가 스스로 보여줄 기회 제공",
+          "daily_analogy": "이력서에 취미가 '운동'이라고만 적혀있어서 어떤 운동인지 물어보는 것",
+          "level_expectation": "모든 레벨: 본인의 경험을 구체적으로 설명할 수 있는지"
+        }
       }
       ```
 
@@ -313,11 +556,12 @@ prompts:
       - NEVER create questions about skills inferred from general categories
       - NEVER ask about specific versions without evidence
       - If evidence is weak, craft open-ended questions that let candidate demonstrate
+      - ALWAYS use v2 format: scenarios array, answer_keywords, follow_ups with good/poor
 
       # DO NOT LIMIT YOURSELF
       - DO reference specific evidence in the question text
-      - DO create comprehensive follow-ups for all answer levels
-      - DO provide honest confidence scores
+      - DO create comprehensive follow-ups with good/poor examples
+      - DO provide interviewer_note with business_interpretation and daily_analogy
       - DO make questions conversational and respectful
 
       REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.

--- a/backend/scripts/upload_prompts_to_langfuse.py
+++ b/backend/scripts/upload_prompts_to_langfuse.py
@@ -45,7 +45,7 @@ ACTIVITY_MODEL_CONFIG = {
     "analyze_code": {"model": "openai:gpt-4o", "temperature": 0.5},
     "analyze_jd": {"model": "openai:gpt-4o-mini", "temperature": 0.3},
 
-    # Phase 3: Question Generation
+    # Phase 3: Question Generation (v2 format)
     "craft_question": {"model": "openai:gpt-4o", "temperature": 0.7},
     "enhance_terminology": {"model": "openai:gpt-4o-mini", "temperature": 0.5},
     "craft_evaluation_scenarios": {"model": "openai:gpt-4o", "temperature": 0.6},
@@ -58,6 +58,11 @@ ACTIVITY_MODEL_CONFIG = {
     "quality_review": {"model": "openai:gpt-4o", "temperature": 0.3},
     "finalize_candidate_summary": {"model": "openai:gpt-4o", "temperature": 0.5},
     "finalize_interviewer_guide": {"model": "openai:gpt-4o-mini", "temperature": 0.5},
+
+    # Phase 4c: v2 Intel/Analysis Generation
+    "generate_intel_brief": {"model": "openai:gpt-4o", "temperature": 0.5},
+    "generate_deep_analysis": {"model": "openai:gpt-4o", "temperature": 0.5},
+    "generate_decision_support": {"model": "openai:gpt-4o", "temperature": 0.5},
 }
 
 # YAML 키 → Activity 이름 매핑


### PR DESCRIPTION
## 요약
v2 출력 포맷에 맞춰 프롬프트를 최적화하고 최신 프롬프트 엔지니어링 기법을 적용했습니다.

### craft_question 프롬프트 개선
- **v2 출력 포맷 적용**: `scenarios[]` 배열, `answer_keywords`, `follow_ups` with `good/poor` 구조
- **3개 상세 Few-shot 예제**:
  - 기술 심층 질문 (비동기 성능 최적화)
  - 행동 면접 질문 (첫 90일 온보딩)
  - 위험 신호 검증 질문 (이직 사유)
- **interviewer_note 구조 개선**: `business_interpretation`, `daily_analogy`, `level_expectation`

### 신규 v2 프롬프트 추가
- `generate_intel_brief`: Intel Brief 탭용 JD 역량 매칭, GitHub 차트 데이터
- `generate_deep_analysis`: Deep Analysis 탭용 레이더 차트, Engineering DNA
- `generate_decision_support`: Decision 탭용 채용 의사결정 지원

### Anti-Hallucination 기법 적용
- 모든 프롬프트에 **CRITICAL OUTPUT RULES** 섹션
- 증거 기반 **scoring methodology** 명시
- **BAD EXAMPLE + WHY BAD** 패턴으로 명시적 금지
- **ANTI-HALLUCINATION CHECKLIST** 추가

## Langfuse 업로드
- 18개 프롬프트 Langfuse에 업로드 완료 (v5)

## 테스트 계획
- [ ] 실제 후보자 데이터로 v2 출력 검증
- [ ] Hallucination 발생률 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)