### PR TITLE
feat: pydantic-ai-litellm 통합으로 Z.AI 모델 지원 추가 (#61)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,22 @@
-.PHONY: up down logs test shell rebuild
+.PHONY: up down logs test shell rebuild tunnel-up tunnel-down tunnel-logs
 
+# ============================================
+# Cloudflare Tunnel (별도 프로젝트로 관리)
+# ============================================
+tunnel-up:
+	docker compose -f docker-compose.tunnel.yml -p cloudflare up -d
+	@echo "Cloudflare Tunnel started"
+
+tunnel-down:
+	docker compose -f docker-compose.tunnel.yml -p cloudflare down
+	@echo "Cloudflare Tunnel stopped"
+
+tunnel-logs:
+	docker compose -f docker-compose.tunnel.yml -p cloudflare logs -f
+
+# ============================================
+# Main Services
+# ============================================
 up:
 	docker compose up -d
 	@echo "Services starting..."

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,14 @@ from app.api.routes.ws import router as ws_router
 from app.api.routes.upload import router as upload_router
 from app.api.routes.analysis_logs import router as analysis_logs_router
 from app.api.routes.internal import router as internal_router
-from app.api.routes.evals import router as evals_router
+
+# Phoenix evals (optional - requires arize-phoenix package)
+try:
+    from app.api.routes.evals import router as evals_router
+    EVALS_AVAILABLE = True
+except ImportError:
+    evals_router = None
+    EVALS_AVAILABLE = False
 
 logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL))
 logger = logging.getLogger(__name__)
@@ -115,7 +122,11 @@ app.include_router(ws_router)
 app.include_router(upload_router)
 app.include_router(analysis_logs_router)
 app.include_router(internal_router)
-app.include_router(evals_router)
+
+# Phoenix evals (optional)
+if EVALS_AVAILABLE and evals_router:
+    app.include_router(evals_router)
+    logger.info("Phoenix evals router enabled")
 
 
 @app.get("/")

--- a/backend/app/services/llm_config.py
+++ b/backend/app/services/llm_config.py
@@ -104,6 +104,25 @@ def get_model_for_activity(activity_name: str) -> str:
     return default_model
 
 
+def _is_native_pydantic_ai_model(model_name: str) -> bool:
+    """Check if model is natively supported by pydantic-ai.
+
+    Native models: openai, anthropic, gemini, groq, mistral, ollama, vertexai, bedrock
+    Non-native (requires LiteLLM bridge): zai (Z.AI/Zhipu), cohere, ai21, etc.
+    """
+    native_prefixes = (
+        "openai:", "openai/",
+        "anthropic:", "anthropic/",
+        "gemini:", "gemini/",
+        "groq:", "groq/",
+        "mistral:", "mistral/",
+        "ollama:", "ollama/",
+        "vertexai:", "vertexai/",
+        "bedrock:", "bedrock/",
+    )
+    return model_name.startswith(native_prefixes)
+
+
 def get_llm_agent(
     result_type: Any = None,
     system_prompt: str = "",
@@ -118,12 +137,33 @@ def get_llm_agent(
 
     Returns:
         pydantic_ai.Agent 인스턴스
+
+    Note:
+        - Native models (openai, anthropic, etc.): 직접 pydantic-ai Agent에 전달
+        - Non-native models (zai, cohere, etc.): LiteLLMModel wrapper 사용
     """
     from pydantic_ai import Agent
 
-    model = model or settings.LLM_MODEL  # e.g. "openai/gpt-4o"
+    model_name = model or settings.LLM_MODEL  # e.g. "openai/gpt-4o" or "zai/glm-4.5-flash"
 
-    kwargs = {"model": model}
+    # Determine model wrapper based on provider
+    if _is_native_pydantic_ai_model(model_name):
+        # Native pydantic-ai model - use directly
+        model_instance = model_name
+        logger.debug(f"Using native pydantic-ai model: {model_name}")
+    else:
+        # Non-native model (Z.AI, Cohere, etc.) - use LiteLLM bridge
+        try:
+            from pydantic_ai_litellm import LiteLLMModel
+            model_instance = LiteLLMModel(model_name=model_name)
+            logger.debug(f"Using LiteLLM bridge for non-native model: {model_name}")
+        except ImportError:
+            logger.warning(
+                f"pydantic-ai-litellm not installed. Falling back to native model handling for: {model_name}"
+            )
+            model_instance = model_name
+
+    kwargs = {"model": model_instance}
     if result_type:
         kwargs["result_type"] = result_type
     if system_prompt:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "temporalio>=1.6.0",
     # LLM
     "pydantic-ai>=0.0.36",
+    "pydantic-ai-litellm>=0.2.3",  # LiteLLM bridge for pydantic-ai (Z.AI, Cohere, etc.)
     "litellm>=1.40.0",
     "instructor>=1.3.0",
     # Document Parsing

--- a/docker-compose.tunnel.yml
+++ b/docker-compose.tunnel.yml
@@ -1,5 +1,5 @@
 # Cloudflare Tunnel 전용 Compose
-# 사용법: docker compose -f docker-compose.tunnel.yml up -d
+# 사용법: make tunnel-up (또는 docker compose -f docker-compose.tunnel.yml -p cloudflare up -d)
 # 주의: 메인 docker-compose.yml보다 먼저 실행하여 네트워크 생성
 
 services:
@@ -18,7 +18,8 @@ services:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
     networks:
       - cloudflare_tunnel
-    # 헬스체크: nginx가 준비될 때까지 재시도
+      - iaas_internal  # 메인 서비스(frontend, backend 등) 접근용
+    # 헬스체크
     healthcheck:
       test: ["CMD", "cloudflared", "tunnel", "info"]
       interval: 30s
@@ -30,3 +31,5 @@ networks:
   cloudflare_tunnel:
     name: cloudflare_tunnel
     driver: bridge
+  iaas_internal:
+    external: true  # 메인 docker-compose에서 생성된 네트워크 참조


### PR DESCRIPTION
## 요약
- pydantic-ai에서 Z.AI (Zhipu) 모델 사용을 위한 LiteLLM 브릿지 통합
- Cloudflare Tunnel을 별도 프로젝트로 분리하여 독립 실행 가능
- Phoenix Evals 선택적 로딩으로 의존성 유연화

## 변경 내용

### 1. pydantic-ai + Z.AI 통합
- `pydantic-ai-litellm>=0.2.3` 의존성 추가
- `get_llm_agent()` 함수에서 모델 타입별 자동 라우팅:
  - Native (openai, anthropic, gemini 등) → 직접 Agent에 전달
  - Non-native (zai, cohere 등) → LiteLLMModel wrapper 사용
- Z.AI 모델 지원:
  - `zai/glm-4.5-flash` (무료)
  - `zai/glm-4.7` (플래그십)

### 2. Cloudflare Tunnel 분리
- `docker-compose.tunnel.yml`을 별도 프로젝트 `-p cloudflare`로 분리
- Makefile 명령어 추가:
  - `make tunnel-up`: 터널 시작
  - `make tunnel-down`: 터널 중지
  - `make tunnel-logs`: 터널 로그 확인
- `iaas_internal` 네트워크 연결로 메인 서비스 접근

### 3. Phoenix Evals 선택적 로딩
- `arize-phoenix` 미설치 시에도 백엔드 정상 시작
- try/except로 evals 라우터 동적 로딩

## 테스트
```python
# Z.AI 모델 테스트 결과
✅ pydantic-ai-litellm imported successfully
✅ openai:gpt-4o is native: True
✅ zai/glm-4.5-flash is native: False
✅ Z.AI API 호출 성공!
   응답: 안녕하세요 (Annyeonghaseyo) / Hello
```

## 체크리스트
- [x] pydantic-ai-litellm 패키지 설치 확인
- [x] Z.AI API 호출 테스트 통과
- [x] Native 모델 (OpenAI) 정상 동작 확인
- [x] Cloudflare Tunnel 독립 실행 확인
- [x] 백엔드 정상 시작 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)