### PR TITLE
fix: 워크플로우 Activity 오류 수정 및 Langfuse 3.x 호환성 개선

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ tunnel-logs:
 # Main Services
 # ============================================
 up:
-	docker compose up -d
+	docker compose --profile worker up -d
 	@echo "Services starting..."
 	@echo "Backend:     http://localhost:8000"
 	@echo "Temporal UI: http://localhost:8080"
@@ -26,7 +26,7 @@ up:
 	@echo "API Docs:    http://localhost:8000/docs"
 
 down:
-	docker compose down
+	docker compose --profile worker down
 
 logs:
 	docker compose logs -f $(service)
@@ -38,6 +38,6 @@ shell:
 	docker compose exec backend bash
 
 rebuild:
-	docker compose down -v
+	docker compose --profile worker down -v
 	docker compose build --no-cache
-	docker compose up -d
+	docker compose --profile worker up -d

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -56,13 +56,16 @@ def setup_langfuse() -> bool:
     try:
         import litellm
 
-        litellm.success_callback = ["langfuse"]
-        litellm.failure_callback = ["langfuse"]
+        # Langfuse 3.x 호환을 위해 langfuse_otel (OpenTelemetry 기반) 사용
+        # 참고: https://docs.litellm.ai/docs/observability/langfuse_otel_integration
+        litellm.callbacks = ["langfuse_otel"]
 
         # LiteLLM reads these env vars automatically, but set explicitly
         os.environ.setdefault("LANGFUSE_PUBLIC_KEY", settings.LANGFUSE_PUBLIC_KEY)
         os.environ.setdefault("LANGFUSE_SECRET_KEY", settings.LANGFUSE_SECRET_KEY)
         os.environ.setdefault("LANGFUSE_HOST", settings.LANGFUSE_HOST)
+        # langfuse_otel은 LANGFUSE_OTEL_HOST 환경 변수 사용
+        os.environ.setdefault("LANGFUSE_OTEL_HOST", settings.LANGFUSE_HOST)
 
         # Initialize Langfuse client for @observe decorator
         get_langfuse_client()

--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -162,8 +162,18 @@ def _build_skill_table(
     rows = []
 
     jd_requirements = jd_analysis.get("requirements", [])
-    candidate_skills = document_analysis.get("profile", {}).get("skills", [])
-    code_skills = code_analysis.get("tech_stack", []) if code_analysis else []
+    raw_candidate_skills = document_analysis.get("profile", {}).get("skills", [])
+    raw_code_skills = code_analysis.get("tech_stack", []) if code_analysis else []
+
+    # skills가 dict인 경우 키만 추출 (list/dict 모두 지원)
+    candidate_skills = (
+        list(raw_candidate_skills.keys()) if isinstance(raw_candidate_skills, dict)
+        else list(raw_candidate_skills) if raw_candidate_skills else []
+    )
+    code_skills = (
+        list(raw_code_skills.keys()) if isinstance(raw_code_skills, dict)
+        else list(raw_code_skills) if raw_code_skills else []
+    )
 
     all_candidate_skills = set(s.lower() for s in candidate_skills + code_skills)
 

--- a/backend/app/workflows/activities/decision_generation.py
+++ b/backend/app/workflows/activities/decision_generation.py
@@ -55,7 +55,13 @@ def _extract_decision_summary(
 
     # 강점 추출
     strengths = []
-    key_skills = profile.get("skills", [])[:3]
+    raw_skills = profile.get("skills", [])
+    # skills가 dict인 경우 키만 추출 (list/dict 모두 지원)
+    skill_list = (
+        list(raw_skills.keys()) if isinstance(raw_skills, dict)
+        else list(raw_skills) if raw_skills else []
+    )
+    key_skills = skill_list[:3]
     for skill in key_skills:
         strengths.append(f"{skill} (이력서)")
 


### PR DESCRIPTION
## 요약

워크플로우 실행 시 발생하던 치명적 오류 수정 및 Langfuse 3.x 호환성 문제 해결

## 변경 사항

### 🔴 치명적 오류 수정

**1. `generate_deep_analysis` Activity 실패**
- **파일**: `analysis_generation.py:168`
- **오류**: `TypeError: unsupported operand type(s) for +: 'dict' and 'list'`
- **원인**: `skills`가 dict인데 list로 가정하고 `+` 연산
- **해결**: dict/list 모두 처리하도록 타입 체크 추가

**2. `generate_decision_support` Activity 실패**
- **파일**: `decision_generation.py:58`
- **오류**: `TypeError: unhashable type: 'slice'`
- **원인**: `skills`가 dict인데 `[:3]` 슬라이싱 시도
- **해결**: dict → list 변환 후 슬라이싱

### 🟡 Langfuse 3.x 호환성 개선

**LiteLLM + Langfuse 연동 오류**
- **오류**: `Langfuse.__init__() got an unexpected keyword argument 'sdk_integration'`
- **원인**: LiteLLM 1.81.x의 `langfuse` 콜백이 Langfuse 3.x SDK와 비호환
- **해결**: `langfuse_otel` (OpenTelemetry 기반) 콜백으로 변경
- **참고**: [LiteLLM 공식 권장](https://docs.litellm.ai/docs/observability/langfuse_otel_integration)

### 🟢 개발 편의성 개선

**Makefile worker profile 포함**
- `make up/down/rebuild`에 `--profile worker` 추가
- worker 컨테이너가 기본 명령과 함께 시작/종료

## 테스트 계획

- [ ] 워크플로우 재실행하여 Activity 오류 해결 확인
- [ ] Langfuse 대시보드에서 트레이스 정상 기록 확인
- [ ] `make up` / `make down` 시 worker 컨테이너 포함 확인

🤖 Generated with [Claude Code](https://claude.ai/code)