### PR TITLE
fix: 워크플로우 Activity 데이터 흐름 버그 수정

### DIFF
--- a/backend/app/services/cached_llm.py
+++ b/backend/app/services/cached_llm.py
@@ -2,6 +2,7 @@
 backend/app/services/cached_llm.py
 CachedLLMService — Redis 기반 LLM 응답 캐시 + Langfuse 추적
 """
+import asyncio
 import hashlib
 import json
 import logging
@@ -73,7 +74,7 @@ def _log_llm_generation(
 
         # Langfuse SDK v3: start_generation으로 LLM 호출 기록
         # 현재 trace 컨텍스트 내에서 자동으로 연결됨
-        # NOTE: output은 end()에서 설정하여 정확한 기록 보장
+        output_str = str(output)[:5000] if output else None
         generation = client.start_generation(
             name=activity_name or "llm_call",
             model=model_name,
@@ -84,8 +85,9 @@ def _log_llm_generation(
                 "configured_model": model,
             },
         )
-        # output을 end()에서 명시적으로 설정 (버그 수정)
-        generation.end(output=str(output)[:5000] if output else None)
+        # Langfuse 3.x: output은 update()로 설정 후 end() 호출 (end()에 output 파라미터 없음)
+        generation.update(output=output_str)
+        generation.end()
 
         logger.info(
             f"Logged Langfuse generation: {activity_name}, "
@@ -214,17 +216,21 @@ class CachedLLMService:
         self._log_cache_event("miss", trace_meta)
 
         # LLM 호출 (폴백 체인: primary → fallback)
+        # asyncio.shield로 감싸서 Temporal Activity 취소로 인한 CancelledError 방지
         from app.services.llm_config import get_llm_agent
         try:
             agent = get_llm_agent(result_type=result_type, model=model)
-            run_result = await agent.run(prompt)
+            run_result = await asyncio.shield(agent.run(prompt))
+        except asyncio.CancelledError:
+            logger.warning(f"LLM call cancelled for model {model}")
+            raise
         except Exception as primary_err:
             fallback_model = settings.LLM_FALLBACK_MODEL
             if fallback_model and fallback_model != model:
                 logger.warning(f"Primary LLM ({model}) failed: {primary_err}. Trying fallback: {fallback_model}")
                 self._log_fallback_event(model, fallback_model, trace_meta)
                 agent = get_llm_agent(result_type=result_type, model=fallback_model)
-                run_result = await agent.run(prompt)
+                run_result = await asyncio.shield(agent.run(prompt))
             else:
                 raise
 
@@ -444,17 +450,21 @@ class CachedLLMService:
         self._log_cache_event("miss", trace_meta)
 
         # LLM 호출 (폴백 체인: primary → fallback)
+        # asyncio.shield로 감싸서 Temporal Activity 취소로 인한 CancelledError 방지
         from app.services.llm_config import get_llm_agent
         try:
             agent = get_llm_agent(result_type=result_type, model=model)
-            run_result = await agent.run(prompt)
+            run_result = await asyncio.shield(agent.run(prompt))
+        except asyncio.CancelledError:
+            logger.warning(f"LLM call cancelled for model {model}")
+            raise
         except Exception as primary_err:
             fallback_model = settings.LLM_FALLBACK_MODEL
             if fallback_model and fallback_model != model:
                 logger.warning(f"Primary LLM ({model}) failed: {primary_err}. Trying fallback: {fallback_model}")
                 self._log_fallback_event(model, fallback_model, trace_meta)
                 agent = get_llm_agent(result_type=result_type, model=fallback_model)
-                run_result = await agent.run(prompt)
+                run_result = await asyncio.shield(agent.run(prompt))
             else:
                 raise
 

--- a/backend/app/services/entity_extractors.py
+++ b/backend/app/services/entity_extractors.py
@@ -6,7 +6,7 @@ import logging
 import re
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +22,14 @@ class ExtractedEntity(BaseModel):
     properties: dict[str, Any] = Field(default_factory=dict)
     provenance: dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator("entity_type", "name", mode="before")
+    @classmethod
+    def ensure_string(cls, v):
+        """Ensure string fields are not None."""
+        if v is None:
+            return "Unknown"
+        return str(v)
+
 
 class ExtractedRelation(BaseModel):
     """Model for extracted KG relations."""
@@ -32,6 +40,14 @@ class ExtractedRelation(BaseModel):
     relation_type: str
     confidence: int = 100  # 0-100 scale
     properties: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("source_name", "source_type", "target_name", "target_type", "relation_type", mode="before")
+    @classmethod
+    def ensure_string(cls, v):
+        """Ensure string fields are not None."""
+        if v is None:
+            return "Unknown"
+        return str(v)
 
 
 class ExtractionResult(BaseModel):

--- a/backend/app/workflows/activities/finalization.py
+++ b/backend/app/workflows/activities/finalization.py
@@ -170,7 +170,8 @@ async def finalize_output(
     # 5. 저장 (local 또는 S3)
     from app.services.storage_service import get_storage
     storage = get_storage()
-    job_id = enriched_input.get("job_id", "unknown")
+    # job_id는 raw_input 안에 있음 (enrich_input이 raw_input을 포함하여 반환)
+    job_id = enriched_input.get("raw_input", {}).get("job_id", "unknown")
     storage_key = f"outputs/{job_id}/interview_script.json"
     output_path = storage.upload_json(storage_key, final_script)
 

--- a/backend/app/workflows/activities/input_enrichment.py
+++ b/backend/app/workflows/activities/input_enrichment.py
@@ -168,6 +168,10 @@ async def enrich_input(input_data: dict) -> dict:
     if personal_github_urls:
         available.append("code_analysis")
 
+    # Debug logging for troubleshooting
+    logger.info(f"[Enrichment] personal_github_urls: {personal_github_urls}")
+    logger.info(f"[Enrichment] available_analyses: {available}")
+
     return {
         "raw_input": input_data,
         "github_urls": personal_github_urls,  # 개인 레포만 (조직 레포 제외)

--- a/backend/app/workflows/activities/jd_analysis.py
+++ b/backend/app/workflows/activities/jd_analysis.py
@@ -37,10 +37,14 @@ async def analyze_jd(jd_text: str, job_id: str | None = None) -> dict:
     from app.prompts import get_prompt
     prompt = get_prompt("jd_analysis.yaml", "analyze", jd_text=jd_text)
 
+    activity.heartbeat("Starting JD analysis LLM call...")
+
     if alog:
         await alog.progress("Extracting requirements with LLM", {})
 
     result = await llm.run(prompt, activity_name="analyze_jd")
+
+    activity.heartbeat("JD analysis LLM call completed")
 
     jd_result = {}
     kg_entity_count = 0

--- a/backend/app/workflows/activities/planning.py
+++ b/backend/app/workflows/activities/planning.py
@@ -31,6 +31,11 @@ async def create_execution_plan(enriched_input: dict) -> dict:
     github_urls = enriched_input.get("github_urls", [])
     available = enriched_input.get("available_analyses", [])
 
+    # Debug logging for troubleshooting
+    logger.info(f"[Planning] Received github_urls: {github_urls}")
+    logger.info(f"[Planning] Received available_analyses: {available}")
+    logger.info(f"[Planning] code_analysis enabled: {'code_analysis' in available}")
+
     if alog:
         await alog.start("Creating execution plan", {
             "github_urls_count": len(github_urls),
@@ -57,6 +62,21 @@ async def create_execution_plan(enriched_input: dict) -> dict:
     # 사용 가능한 분석 목록
     available = enriched_input.get("available_analyses", [])
 
+    # JD text에서 기술 스택 추출 (code_analysis에서 사용)
+    jd_text = raw_input.get("jd_text", "")
+    jd_tech_stack = _extract_tech_stack_from_jd(jd_text)
+
+    # workload에서 수집된 언어들도 포함
+    repo_languages = set()
+    for w in workload.values():
+        repo_languages.update(w.get("languages", {}).keys())
+
+    # JD tech_stack과 repo languages 병합 (JD 우선)
+    if not jd_tech_stack and repo_languages:
+        jd_tech_stack = list(repo_languages)
+
+    logger.info(f"[Planning] Extracted jd_tech_stack: {jd_tech_stack}")
+
     plan = {
         "candidate_github_username": enriched_input.get("candidate_github_username"),
         "phases": [
@@ -69,6 +89,7 @@ async def create_execution_plan(enriched_input: dict) -> dict:
             w["estimated_time_seconds"] for w in workload.values()
         ) + 120,
         "raw_input": raw_input,
+        "jd_tech_stack": jd_tech_stack,  # ✅ code_analysis에서 사용
     }
 
     # Log final result
@@ -92,3 +113,52 @@ def _calculate_time(repo_info: dict) -> int:
     elif size < 100000:
         return 120
     return 300
+
+
+def _extract_tech_stack_from_jd(jd_text: str) -> list[str]:
+    """JD 텍스트에서 기술 스택 키워드 추출 (regex 기반)
+
+    code_analysis에서 레포 필터링에 사용됨.
+    """
+    import re
+
+    # 주요 프로그래밍 언어 및 기술 패턴
+    tech_patterns = {
+        # Languages (대소문자 무시)
+        r'\bPython\b': 'Python',
+        r'\bJavaScript\b': 'JavaScript',
+        r'\bTypeScript\b': 'TypeScript',
+        r'\bJava\b(?!\s*Script)': 'Java',  # JavaScript와 구분
+        r'\bGo\b(?:lang)?\b': 'Go',
+        r'\bRust\b': 'Rust',
+        r'\bC\+\+\b': 'C++',
+        r'\bC#\b': 'C#',
+        r'\bRuby\b': 'Ruby',
+        r'\bPHP\b': 'PHP',
+        r'\bSwift\b': 'Swift',
+        r'\bKotlin\b': 'Kotlin',
+        r'\bScala\b': 'Scala',
+        r'\bR\b(?:\s+language)?': 'R',
+        # Frameworks/Technologies (언어 추론)
+        r'\bReact\b': 'JavaScript',
+        r'\bVue\b': 'JavaScript',
+        r'\bAngular\b': 'TypeScript',
+        r'\bNode\.?js\b': 'JavaScript',
+        r'\bDjango\b': 'Python',
+        r'\bFlask\b': 'Python',
+        r'\bFastAPI\b': 'Python',
+        r'\bSpring\b': 'Java',
+        r'\bRails\b': 'Ruby',
+        r'\bLaravel\b': 'PHP',
+        r'\bNext\.?js\b': 'TypeScript',
+        r'\bNuxt\b': 'JavaScript',
+    }
+
+    found = set()
+    text_lower = jd_text
+
+    for pattern, language in tech_patterns.items():
+        if re.search(pattern, text_lower, re.IGNORECASE):
+            found.add(language)
+
+    return list(found)

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -130,8 +130,9 @@ class InterviewGenerationWorkflow:
             analysis_tasks.append(
                 workflow.execute_activity(
                     analyze_jd,
-                    raw_input.get("jd_text", ""),
-                    start_to_close_timeout=timedelta(minutes=3),
+                    args=[raw_input.get("jd_text", ""), job_id],
+                    start_to_close_timeout=timedelta(minutes=5),
+                    heartbeat_timeout=timedelta(seconds=120),
                     retry_policy=LLM_RETRY,
                 )
             )
@@ -175,7 +176,7 @@ class InterviewGenerationWorkflow:
             # 3a. 토픽 선정
             topics = await workflow.execute_activity(
                 select_topics,
-                args=[analysis, enriched],
+                args=[analysis, enriched, job_id],  # job_id 추가 (KG 기반 질문 후보 조회용)
                 start_to_close_timeout=timedelta(minutes=3),
                 retry_policy=LLM_RETRY,
             )
@@ -186,7 +187,7 @@ class InterviewGenerationWorkflow:
                 question_tasks.append(
                     workflow.execute_activity(
                         craft_question,
-                        args=[topic, analysis, enriched],
+                        args=[topic, analysis, enriched, job_id],  # job_id 추가 (KG evidence 조회용)
                         start_to_close_timeout=timedelta(minutes=2),
                         retry_policy=LLM_RETRY,
                     )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,6 +28,7 @@ temporalio>=1.6.0
 
 # LLM
 pydantic-ai>=0.0.36
+pydantic-ai-litellm>=0.2.0
 litellm>=1.40.0
 instructor>=1.3.0
 


### PR DESCRIPTION
## 개요
워크플로우 Activity 간 데이터 전달 과정에서 발생한 여러 버그를 수정합니다.

## 주요 수정 사항

### 🔴 Critical: `analyze_code` 빈 배열 반환 버그
**원인**: `create_execution_plan`에서 `jd_tech_stack`을 출력하지 않아 코드 분석 시 레포 필터링이 전부 실패

**수정**:
- `planning.py`에 JD 텍스트에서 기술 스택 추출 함수 추가
- workload에서 수집된 레포 언어 정보와 병합
- execution_plan에 `jd_tech_stack` 필드 추가

### 🟡 Medium: KG 기반 질문 생성 미작동
**원인**: `select_topics`와 `craft_question`에 `job_id` 미전달

**수정**:
- `interview_workflow.py`에서 두 Activity 호출 시 `job_id` 인자 추가

### 🟢 Low: 스토리지 경로 `unknown` 버그
**원인**: `finalize_output`에서 `job_id` 접근 경로 오류

**수정**:
- `enriched_input.get("raw_input", {}).get("job_id")` 로 수정

### 기타 안정성 개선
- `entity_extractors.py`: KG 추출 시 None 값 검증 오류 수정
- `cached_llm.py`: `asyncio.shield()` 추가로 CancelledError 방지
- `jd_analysis.py`: heartbeat 추가로 타임아웃 개선

## 변경 파일
- `backend/app/workflows/activities/planning.py` - jd_tech_stack 추출 추가
- `backend/app/workflows/interview_workflow.py` - job_id 전달 수정
- `backend/app/workflows/activities/finalization.py` - job_id 경로 수정
- `backend/app/services/entity_extractors.py` - None 검증 추가
- `backend/app/services/cached_llm.py` - asyncio.shield 추가
- `backend/app/workflows/activities/jd_analysis.py` - heartbeat 추가

## 테스트 계획
- [ ] 새 Job 생성 후 `analyze_code` 결과에 repositories 포함 확인
- [ ] Langfuse에서 `jd_tech_stack` 로깅 확인
- [ ] KG 기반 질문 후보가 `select_topics`에서 조회되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)