### PR TITLE
fix: 코드 분석 Activity 타임아웃 문제 해결

### DIFF
--- a/backend/app/services/code_analyzer.py
+++ b/backend/app/services/code_analyzer.py
@@ -74,12 +74,26 @@ class CodeAnalyzer:
         total_deletions = 0
 
         try:
+            # Heartbeat helper (Activity 컨텍스트에서만 동작)
+            def _heartbeat(msg: str):
+                try:
+                    from temporalio import activity
+                    activity.heartbeat(msg)
+                except Exception:
+                    pass  # Activity 외부 호출 시 무시
+
+            commit_count = 0
             for commit in Repository(
                 repo_url,
                 since=since,
                 only_authors=[author] if author else None,
                 only_modifications_with_file_types=file_types,
             ).traverse_commits():
+                # 20개 커밋마다 heartbeat (Temporal 타임아웃 방지)
+                commit_count += 1
+                if commit_count % 20 == 0:
+                    _heartbeat(f"PyDriller: processed {commit_count} commits...")
+
                 commits.append({
                     "hash": commit.hash[:8],
                     "msg": commit.msg[:200],
@@ -416,6 +430,13 @@ class CodeAnalyzer:
             "3. Top question candidates for technical interview\n\n"
             + "\n\n".join(context_parts)
         )
+
+        # Heartbeat before LLM call (long-running operation)
+        try:
+            from temporalio import activity
+            activity.heartbeat("LLM analyze_code starting...")
+        except Exception:
+            pass
 
         result = await llm.run(prompt, activity_name="analyze_code")
         if isinstance(result, dict):

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -160,8 +160,12 @@ async def analyze_code(
         all_notables.extend(repo.get("notable_implementations", []))
 
     # Build code analysis result
+    # target_repos 포함: 워크플로우에서 병렬 처리 활성화 기반
     code_analysis_result = {
         "repositories": repositories,
+        "target_repos": target_repos,  # Step 2 병렬 처리용
+        "jd_tech_stack": jd_tech_stack,
+        "candidate_username": candidate_username,
         "combined_tech_stack": list(set(tech for repo in repositories for tech in repo.get("analysis", {}).get("tech_stack", []))),
         "total_patterns": sum(len(repo.get("analysis", {}).get("patterns", [])) for repo in repositories),
         "total_notable_implementations": len(all_notables),

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -498,24 +498,33 @@ class InterviewGenerationWorkflow:
         if not github_urls:
             return {"repositories": [], "top_question_candidates": []}
 
-        # Step 1: Manager가 레포 필터링
+        # Step 1: Manager가 레포 필터링 + 분석
+        # 타임아웃 증가: 여러 레포 분석 시 5분 초과 가능
         manager_result = await workflow.execute_activity(
             analyze_code,
             args=[github_urls, raw_input, execution_plan],
-            start_to_close_timeout=timedelta(minutes=5),
-            heartbeat_timeout=timedelta(seconds=60),
+            start_to_close_timeout=timedelta(minutes=15),
+            heartbeat_timeout=timedelta(seconds=120),
             retry_policy=EXTERNAL_API_RETRY,
         )
 
         target_repos = manager_result.get("target_repos", [])
+        repositories = manager_result.get("repositories", [])
+
+        # Case 1: 분석 결과가 이미 있으면 바로 반환 (analyze_code가 완료한 경우)
+        if repositories:
+            logger.info(f"Code analysis already completed with {len(repositories)} repos")
+            return manager_result
+
+        # Case 2: target_repos가 없으면 빈 결과 반환
         if not target_repos:
-            # Fallback: 기존 방식의 결과 사용
+            logger.info("No target repos found for parallel analysis")
             return manager_result
 
         jd_tech_stack = manager_result.get("jd_tech_stack", [])
         candidate_username = manager_result.get("candidate_username")
 
-        # Step 2: 각 레포 병렬 분석 (Sub-Agents)
+        # Step 2: 각 레포 병렬 분석 (Sub-Agents) - repositories가 없을 때만 실행
         repo_tasks = []
         for repo in target_repos:
             task = workflow.execute_activity(


### PR DESCRIPTION
## 문제

`analyze_code` Activity가 여러 GitHub 레포를 분석할 때 **5분 타임아웃을 초과**하여 워크플로우가 실패하는 문제

### 오류 로그
```
WARNING:temporalio.activity:Completing activity as failed
asyncio.exceptions.CancelledError
{"error": "Activity task timed out"}
```

## 원인 분석

1. **타임아웃 부족**: PyDriller 클론 + AST 분석 + LLM 호출이 5분 초과
2. **Heartbeat 미흡**: 긴 작업 중 Temporal에게 활성 상태 알림 부족
3. **순차 분석**: 여러 레포를 순차적으로 분석하여 시간 누적

## 해결책

### Phase 1: 타임아웃 증가
- `start_to_close_timeout`: 5분 → **15분**
- `heartbeat_timeout`: 60초 → **120초**

### Phase 2: Heartbeat 강화
- **PyDriller 커밋 순회**: 20개 커밋마다 heartbeat
- **LLM 호출 전**: heartbeat 추가

### Phase 3: 아키텍처 개선
- `analyze_code`에서 `target_repos` 반환 추가
- 중복 분석 방지: `repositories`가 이미 있으면 Step 2 스킵

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `interview_workflow.py` | 타임아웃 증가 + 중복 분석 방지 로직 |
| `code_analyzer.py` | PyDriller/LLM heartbeat 추가 |
| `code_analysis.py` | target_repos 반환 추가 |

## 테스트

- [ ] 기존 실패 Job 재실행 확인
- [ ] 다중 레포 분석 시 타임아웃 없이 완료 확인
- [ ] Langfuse에서 heartbeat 로깅 확인

🤖 Generated with [Claude Code](https://claude.ai/code)