### PR TITLE
feat: Knowledge Graph 워크플로우 통합 - 분석 후 그래프 자동 구축

### DIFF
--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -37,6 +37,7 @@ with workflow.unsafe.imports_passed_through():
     from app.workflows.activities.intel_generation import generate_intel_brief
     from app.workflows.activities.analysis_generation import generate_deep_analysis
     from app.workflows.activities.decision_generation import generate_decision_support
+    from app.workflows.activities.knowledge_graph_activities import build_knowledge_graph
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +170,26 @@ class InterviewGenerationWorkflow:
                 idx += 1
             if phases.get("code_analysis") and code_analysis_result:
                 analysis["code_analysis"] = code_analysis_result
+
+            # Phase 2.5: Knowledge Graph 구축 (non-blocking)
+            # 분석 데이터를 기반으로 KG를 구축하여 질문 생성에 활용
+            linkedin_profile = enriched.get("linkedin_profile", {})
+            try:
+                await workflow.execute_activity(
+                    build_knowledge_graph,
+                    args=[
+                        job_id,
+                        linkedin_profile,
+                        analysis.get("code_analysis"),
+                        analysis.get("jd_analysis", {}),
+                    ],
+                    start_to_close_timeout=timedelta(minutes=3),
+                    heartbeat_timeout=timedelta(seconds=60),
+                    retry_policy=DEFAULT_RETRY,
+                )
+                logger.info("Knowledge Graph built successfully")
+            except Exception as kg_err:
+                logger.warning(f"KG build failed (non-fatal): {kg_err}")
 
             # Phase 3: Question Generation
             self._update_status(JobStatus.GENERATING, "Phase 3: Generation", 60)

--- a/backend/tests/test_knowledge_graph.py
+++ b/backend/tests/test_knowledge_graph.py
@@ -379,6 +379,31 @@ class TestKGActivities:
 
 
 # ============================================================
+# Workflow Integration Tests
+# ============================================================
+
+class TestWorkflowKGIntegration:
+    def test_workflow_imports_build_knowledge_graph(self):
+        """워크플로우에서 build_knowledge_graph를 import하는지 확인"""
+        import inspect
+        from app.workflows import interview_workflow
+
+        source = inspect.getsource(interview_workflow)
+        assert "build_knowledge_graph" in source
+
+    def test_workflow_calls_build_knowledge_graph(self):
+        """워크플로우에서 build_knowledge_graph를 호출하는지 확인"""
+        import inspect
+        from app.workflows.interview_workflow import InterviewGenerationWorkflow
+
+        source = inspect.getsource(InterviewGenerationWorkflow.run)
+        # Phase 2.5에서 KG 빌드 호출이 존재해야 함
+        assert "build_knowledge_graph" in source
+        # non-blocking (try/except)로 감싸져 있어야 함
+        assert "KG build failed (non-fatal)" in source
+
+
+# ============================================================
 # Worker Registration Tests
 # ============================================================
 


### PR DESCRIPTION
## Summary
- Phase 2 분석 완료 후 `build_knowledge_graph` Activity를 워크플로우에서 자동 호출
- non-blocking 처리 (KG 실패 시 워크플로우 정상 진행)
- 기존 `select_topics`의 KG 쿼리 코드가 실제 데이터를 조회할 수 있게 됨

## Test plan
- [x] `test_knowledge_graph.py` 전체 통과 (45 tests)
- [x] 워크플로우 KG import 검증
- [x] 워크플로우 KG 호출 및 non-blocking 처리 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)