### PR TITLE
fix: 보안 강화 — 시크릿 검증, Redis 인증, 내부 API 인증, LLM 캐시 환경변수

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ ENV=local
 # Database
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/vantict
 REDIS_URL=redis://localhost:6379
+REDIS_PASSWORD=your_strong_password_here
+POSTGRES_PASSWORD=your_strong_password_here
 TEMPORAL_HOST=localhost:7233
 STORAGE_BACKEND=local
 
@@ -44,6 +46,12 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 # GitHub OAuth (https://github.com/settings/developers)
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
+
+# Internal API
+INTERNAL_API_TOKEN=generate-a-random-token-here
+
+# LLM Cache
+LLM_CACHE_ENABLED=true
 
 # URLs
 FRONTEND_URL=http://localhost:5173

--- a/backend/app/api/routes/internal.py
+++ b/backend/app/api/routes/internal.py
@@ -5,14 +5,27 @@ Internal API - Activity에서 사용하는 내부 엔드포인트
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_db
+from app.core.config import settings
 from app.services.analysis_log_service import AnalysisLogService
 
 router = APIRouter(prefix="/api/internal", tags=["internal"])
+
+
+async def verify_internal_token(
+    x_internal_token: str | None = Header(None, alias="X-Internal-Token"),
+) -> None:
+    """Worker → Backend 내부 API 인증"""
+    if not settings.is_local:
+        if not x_internal_token or x_internal_token != settings.INTERNAL_API_TOKEN:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Invalid internal API token",
+            )
 logger = logging.getLogger(__name__)
 
 
@@ -41,6 +54,7 @@ class CreateAnalysisLogResponse(BaseModel):
 async def create_analysis_log(
     request: CreateAnalysisLogRequest,
     db: AsyncSession = Depends(get_db),
+    _auth: None = Depends(verify_internal_token),
 ):
     """Activity에서 분석 로그를 기록하는 내부 엔드포인트.
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,9 +87,17 @@ class Settings(BaseSettings):
     BACKEND_URL: str = "http://localhost:8000"
     # Worker → Backend 내부 통신용 URL (Docker: http://backend:8000)
     INTERNAL_API_URL: str = "http://backend:8000"
+    INTERNAL_API_TOKEN: str = "dev-internal-token"  # Worker↔Backend 내부 인증 토큰
+
+    # LLM Cache
+    LLM_CACHE_ENABLED: bool = True  # False면 LLM 응답 캐싱 비활성화
 
     # Embedding
     EMBEDDING_DIMENSION: int = 1536
+
+    # DB Pool
+    DB_POOL_SIZE: int = 10
+    DB_MAX_OVERFLOW: int = 20
 
     # 기타
     LOG_LEVEL: str = "INFO"
@@ -98,6 +106,18 @@ class Settings(BaseSettings):
     @property
     def is_local(self) -> bool:
         return self.ENV == "local"
+
+    @property
+    def has_secure_secrets(self) -> bool:
+        """프로덕션 환경에서 기본 시크릿 사용 여부 검증"""
+        dev_defaults = [
+            "dev-secret-change-in-production",
+            "dev-session-secret-change-in-production",
+        ]
+        return (
+            self.JWT_SECRET not in dev_defaults
+            and self.SESSION_SECRET not in dev_defaults
+        )
 
     @property
     def r2_endpoint(self) -> str | None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,14 @@ async def lifespan(app: FastAPI):
     # --- Startup ---
     from app.core.observability import setup_langfuse
     setup_langfuse()
+
+    # 프로덕션 환경 시크릿 검증
+    if not settings.is_local and not settings.has_secure_secrets:
+        logger.warning(
+            "SECURITY WARNING: Default development secrets detected in non-local environment. "
+            "Set JWT_SECRET and SESSION_SECRET to secure values."
+        )
+
     logger.info("Vantict Sniper v4.0.0 started")
 
     yield

--- a/backend/app/services/activity_logger.py
+++ b/backend/app/services/activity_logger.py
@@ -58,10 +58,12 @@ class ActivityLogger:
         }
 
         try:
+            headers = {"X-Internal-Token": settings.INTERNAL_API_TOKEN}
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.post(
                     f"{self.base_url}/api/internal/analysis-logs",
                     json=payload,
+                    headers=headers,
                 )
                 if response.status_code != 201:
                     logger.warning(f"Failed to post log: {response.status_code} - {response.text}")
@@ -166,10 +168,12 @@ class SyncActivityLogger:
         }
 
         try:
+            headers = {"X-Internal-Token": settings.INTERNAL_API_TOKEN}
             with httpx.Client(timeout=5.0) as client:
                 response = client.post(
                     f"{self.base_url}/api/internal/analysis-logs",
                     json=payload,
+                    headers=headers,
                 )
                 if response.status_code != 201:
                     logger.warning(f"Failed to post log: {response.status_code}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     environment:
       - ENV=local
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/vantict
-      - REDIS_URL=redis://redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-redis_dev_password}@redis:6379
       - TEMPORAL_HOST=temporal:7233
       - STORAGE_BACKEND=local
       - LOCAL_STORAGE_PATH=/app/data
@@ -61,6 +61,8 @@ services:
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:5173}
       - BACKEND_URL=${BACKEND_URL:-http://localhost:8000}
+      - INTERNAL_API_TOKEN=${INTERNAL_API_TOKEN:-dev-internal-token}
+      - LLM_CACHE_ENABLED=${LLM_CACHE_ENABLED:-true}
       - PHOENIX_COLLECTOR_ENDPOINT=http://phoenix:6006
     volumes:
       - ./backend:/app
@@ -92,7 +94,7 @@ services:
     environment:
       - ENV=local
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/vantict
-      - REDIS_URL=redis://redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-redis_dev_password}@redis:6379
       - TEMPORAL_HOST=temporal:7233
       - STORAGE_BACKEND=local
       - LOCAL_STORAGE_PATH=/app/data
@@ -111,6 +113,8 @@ services:
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}
       - INTERNAL_API_URL=http://backend:8000
+      - INTERNAL_API_TOKEN=${INTERNAL_API_TOKEN:-dev-internal-token}
+      - LLM_CACHE_ENABLED=${LLM_CACHE_ENABLED:-true}
       - PHOENIX_COLLECTOR_ENDPOINT=http://phoenix:6006
     volumes:
       - ./backend:/app
@@ -134,9 +138,9 @@ services:
     container_name: iaas-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: vantict
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-vantict}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init.sql
@@ -156,7 +160,7 @@ services:
     restart: unless-stopped
     volumes:
       - redis_data:/data
-    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
+    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru --requirepass ${REDIS_PASSWORD:-redis_dev_password}
     networks:
       - iaas_internal
     ports:
@@ -173,8 +177,8 @@ services:
     environment:
       - DB=postgresql
       - DB_PORT=5432
-      - POSTGRES_USER=postgres
-      - POSTGRES_PWD=postgres
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PWD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRES_SEEDS=postgres
       - DYNAMIC_CONFIG_FILE_PATH=/etc/temporal/config/dynamicconfig/development.yaml
     depends_on:


### PR DESCRIPTION
## Summary
- `config.py`에 `LLM_CACHE_ENABLED`, `DB_POOL_SIZE`, `DB_MAX_OVERFLOW`, `INTERNAL_API_TOKEN` 환경변수 추가
- 프로덕션 환경에서 기본 시크릿 사용 시 경고하는 `has_secure_secrets` 프로퍼티 추가
- 내부 API(`/api/internal/*`)에 `X-Internal-Token` 헤더 기반 인증 추가 (비-local 환경)
- Worker의 `ActivityLogger`에서 내부 API 호출 시 인증 토큰 전송
- Docker Compose: Redis `--requirepass`, PostgreSQL 환경변수화, 신규 환경변수 전파
- `.env.example`: 신규 환경변수 문서화

## Test plan
- [x] `config.py` 설정 로딩 검증 (LLM_CACHE_ENABLED, has_secure_secrets, INTERNAL_API_TOKEN)
- [x] 기존 테스트 스위트 통과 확인 (pre-existing failures 제외)
- [ ] Docker Compose 환경에서 Redis 인증 + 내부 API 인증 E2E 검증

Closes #77 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)