### PR TITLE
fix: LLM 캐시 키 설계 개선 — Activity 컨텍스트 포함 + 환경변수 제어 + Redis 연결 풀링

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -75,12 +75,14 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Temporal shutdown error: {e}")
 
-    # Close Redis (CachedLLMService)
+    # Close Redis 연결 풀
     try:
-        from app.services.cached_llm import CachedLLMService
-        # CachedLLMService instances are per-use; just close any module-level redis
-    except Exception:
-        pass
+        from app.services.cached_llm import _redis_pool
+        if _redis_pool is not None:
+            await _redis_pool.aclose()
+            logger.info("Redis connection pool closed")
+    except Exception as e:
+        logger.warning(f"Redis shutdown error: {e}")
 
     logger.info("Shutdown complete")
 

--- a/backend/app/services/cached_llm.py
+++ b/backend/app/services/cached_llm.py
@@ -14,6 +14,22 @@ from app.core.observability import get_current_trace_metadata, is_langfuse_enabl
 
 logger = logging.getLogger(__name__)
 
+# 모듈 레벨 Redis 연결 풀 싱글톤
+_redis_pool = None
+
+
+async def _get_shared_redis():
+    """모듈 레벨 Redis 연결 풀 (싱글톤)"""
+    global _redis_pool
+    if _redis_pool is None:
+        import redis.asyncio as aioredis
+        _redis_pool = aioredis.from_url(
+            settings.REDIS_URL,
+            max_connections=20,
+            decode_responses=False,
+        )
+    return _redis_pool
+
 
 def _log_llm_generation(
     model: str,
@@ -168,17 +184,21 @@ class CachedLLMService:
 
     def __init__(self, ttl: int = 86400):
         self.ttl = ttl
-        self._redis = None
 
     async def _get_redis(self):
-        if self._redis is None:
-            import redis.asyncio as aioredis
-            self._redis = aioredis.from_url(settings.REDIS_URL)
-        return self._redis
+        return await _get_shared_redis()
 
-    def _cache_key(self, prompt: str, model: str) -> str:
+    def _cache_key(self, prompt: str, model: str, activity_name: str | None = None) -> str:
+        """Activity 컨텍스트를 포함한 캐시 키 생성
+
+        기존: llm_cache:SHA256(model:prompt)
+        개선: llm_cache:activity_name:SHA256(model:prompt)
+        """
         content = f"{model}:{prompt}"
-        return f"llm_cache:{hashlib.sha256(content.encode()).hexdigest()}"
+        hash_part = hashlib.sha256(content.encode()).hexdigest()
+        if activity_name:
+            return f"llm_cache:{activity_name}:{hash_part}"
+        return f"llm_cache:{hash_part}"
 
     async def run(
         self,
@@ -199,19 +219,20 @@ class CachedLLMService:
             from app.services.llm_config import get_model_for_activity
             model = get_model_for_activity(activity_name)
         model = model or settings.LLM_MODEL
-        key = self._cache_key(prompt, model)
+        key = self._cache_key(prompt, model, activity_name)
         trace_meta = get_current_trace_metadata()
 
-        # 캐시 조회
-        try:
-            redis = await self._get_redis()
-            cached = await redis.get(key)
-            if cached:
-                logger.debug(f"LLM cache hit: {key[:20]}...")
-                self._log_cache_event("hit", trace_meta)
-                return json.loads(cached)
-        except Exception as e:
-            logger.warning(f"Redis cache read failed: {e}")
+        # 캐시 조회 (LLM_CACHE_ENABLED일 때만)
+        if settings.LLM_CACHE_ENABLED:
+            try:
+                redis = await self._get_redis()
+                cached = await redis.get(key)
+                if cached:
+                    logger.debug(f"LLM cache hit: {key[:20]}...")
+                    self._log_cache_event("hit", trace_meta)
+                    return json.loads(cached)
+            except Exception as e:
+                logger.warning(f"Redis cache read failed: {e}")
 
         self._log_cache_event("miss", trace_meta)
 
@@ -254,12 +275,13 @@ class CachedLLMService:
             activity_name=activity_name,
         )
 
-        # 캐시 저장
-        try:
-            redis = await self._get_redis()
-            await redis.setex(key, self.ttl, json.dumps(data, default=str))
-        except Exception as e:
-            logger.warning(f"Redis cache write failed: {e}")
+        # 캐시 저장 (LLM_CACHE_ENABLED일 때만)
+        if settings.LLM_CACHE_ENABLED:
+            try:
+                redis = await self._get_redis()
+                await redis.setex(key, self.ttl, json.dumps(data, default=str))
+            except Exception as e:
+                logger.warning(f"Redis cache write failed: {e}")
 
         return data
 
@@ -317,10 +339,13 @@ class CachedLLMService:
             logger.warning(f"Cache invalidation failed for job {job_id}: {e}")
             return 0
 
-    def _job_cache_key(self, job_id: str, prompt: str, model: str) -> str:
+    def _job_cache_key(self, job_id: str, prompt: str, model: str, activity_name: str | None = None) -> str:
         """Job 단위 캐시 키 생성 (무효화 가능)"""
         content = f"{model}:{prompt}"
-        return f"llm_cache:job:{job_id}:{hashlib.sha256(content.encode()).hexdigest()}"
+        hash_part = hashlib.sha256(content.encode()).hexdigest()
+        if activity_name:
+            return f"llm_cache:job:{job_id}:{activity_name}:{hash_part}"
+        return f"llm_cache:job:{job_id}:{hash_part}"
 
     async def run_with_prompt_config(
         self,
@@ -339,8 +364,9 @@ class CachedLLMService:
         # Langfuse config의 model 사용, 없으면 fallback
         model = prompt_config.model or settings.LLM_MODEL
         temperature = prompt_config.temperature
+        prompt_name = prompt_config.name if prompt_config else None
 
-        key = self._cache_key(prompt, model)
+        key = self._cache_key(prompt, model, prompt_name)
         trace_meta = get_current_trace_metadata()
 
         # Langfuse 프롬프트 소스 정보 추가
@@ -349,16 +375,17 @@ class CachedLLMService:
         if prompt_config.version:
             trace_meta["prompt_version"] = prompt_config.version
 
-        # 캐시 조회
-        try:
-            redis = await self._get_redis()
-            cached = await redis.get(key)
-            if cached:
-                logger.debug(f"LLM cache hit: {key[:20]}... (prompt: {prompt_config.name})")
-                self._log_cache_event("hit", trace_meta)
-                return json.loads(cached)
-        except Exception as e:
-            logger.warning(f"Redis cache read failed: {e}")
+        # 캐시 조회 (LLM_CACHE_ENABLED일 때만)
+        if settings.LLM_CACHE_ENABLED:
+            try:
+                redis = await self._get_redis()
+                cached = await redis.get(key)
+                if cached:
+                    logger.debug(f"LLM cache hit: {key[:20]}... (prompt: {prompt_config.name})")
+                    self._log_cache_event("hit", trace_meta)
+                    return json.loads(cached)
+            except Exception as e:
+                logger.warning(f"Redis cache read failed: {e}")
 
         self._log_cache_event("miss", trace_meta)
 
@@ -400,15 +427,16 @@ class CachedLLMService:
             output=data,
             run_result=run_result,
             trace_meta=trace_meta,
-            activity_name=prompt_config.name if prompt_config else None,
+            activity_name=prompt_name,
         )
 
-        # 캐시 저장
-        try:
-            redis = await self._get_redis()
-            await redis.setex(key, self.ttl, json.dumps(data, default=str))
-        except Exception as e:
-            logger.warning(f"Redis cache write failed: {e}")
+        # 캐시 저장 (LLM_CACHE_ENABLED일 때만)
+        if settings.LLM_CACHE_ENABLED:
+            try:
+                redis = await self._get_redis()
+                await redis.setex(key, self.ttl, json.dumps(data, default=str))
+            except Exception as e:
+                logger.warning(f"Redis cache write failed: {e}")
 
         return data
 
@@ -433,19 +461,20 @@ class CachedLLMService:
             from app.services.llm_config import get_model_for_activity
             model = get_model_for_activity(activity_name)
         model = model or settings.LLM_MODEL
-        key = self._job_cache_key(job_id, prompt, model)
+        key = self._job_cache_key(job_id, prompt, model, activity_name)
         trace_meta = {**get_current_trace_metadata(), "job_id": job_id}
 
-        # 캐시 조회
-        try:
-            redis = await self._get_redis()
-            cached = await redis.get(key)
-            if cached:
-                logger.debug(f"LLM job cache hit: {key[:30]}...")
-                self._log_cache_event("hit", trace_meta)
-                return json.loads(cached)
-        except Exception as e:
-            logger.warning(f"Redis cache read failed: {e}")
+        # 캐시 조회 (LLM_CACHE_ENABLED일 때만)
+        if settings.LLM_CACHE_ENABLED:
+            try:
+                redis = await self._get_redis()
+                cached = await redis.get(key)
+                if cached:
+                    logger.debug(f"LLM job cache hit: {key[:30]}...")
+                    self._log_cache_event("hit", trace_meta)
+                    return json.loads(cached)
+            except Exception as e:
+                logger.warning(f"Redis cache read failed: {e}")
 
         self._log_cache_event("miss", trace_meta)
 
@@ -488,11 +517,12 @@ class CachedLLMService:
             activity_name=activity_name,
         )
 
-        # 캐시 저장
-        try:
-            redis = await self._get_redis()
-            await redis.setex(key, self.ttl, json.dumps(data, default=str))
-        except Exception as e:
-            logger.warning(f"Redis cache write failed: {e}")
+        # 캐시 저장 (LLM_CACHE_ENABLED일 때만)
+        if settings.LLM_CACHE_ENABLED:
+            try:
+                redis = await self._get_redis()
+                await redis.setex(key, self.ttl, json.dumps(data, default=str))
+            except Exception as e:
+                logger.warning(f"Redis cache write failed: {e}")
 
         return data

--- a/backend/tests/test_cache_and_quotas.py
+++ b/backend/tests/test_cache_and_quotas.py
@@ -41,6 +41,74 @@ class TestCachedLLMInvalidation:
         assert callable(svc.run_for_job)
 
 
+class TestCacheKeyWithActivityName:
+    """캐시 키에 activity_name 포함 테스트"""
+
+    def test_cache_key_includes_activity_name(self):
+        from app.services.cached_llm import CachedLLMService
+        svc = CachedLLMService()
+        key = svc._cache_key("prompt", "model", "analyze_jd")
+        assert "analyze_jd" in key
+        assert key.startswith("llm_cache:analyze_jd:")
+
+    def test_cache_key_without_activity_name(self):
+        from app.services.cached_llm import CachedLLMService
+        svc = CachedLLMService()
+        key = svc._cache_key("prompt", "model")
+        assert key.startswith("llm_cache:")
+        assert key.count(":") == 1  # llm_cache:hash
+
+    def test_different_activities_different_keys(self):
+        from app.services.cached_llm import CachedLLMService
+        svc = CachedLLMService()
+        k1 = svc._cache_key("same prompt", "model", "analyze_jd")
+        k2 = svc._cache_key("same prompt", "model", "craft_question")
+        assert k1 != k2
+
+    def test_job_cache_key_includes_activity(self):
+        from app.services.cached_llm import CachedLLMService
+        svc = CachedLLMService()
+        key = svc._job_cache_key("job-1", "prompt", "model", "analyze_jd")
+        assert "analyze_jd" in key
+        assert key.startswith("llm_cache:job:job-1:analyze_jd:")
+
+    def test_job_cache_key_without_activity(self):
+        from app.services.cached_llm import CachedLLMService
+        svc = CachedLLMService()
+        key = svc._job_cache_key("job-1", "prompt", "model")
+        assert key.startswith("llm_cache:job:job-1:")
+        assert "None" not in key
+
+
+class TestLLMCacheEnabled:
+    """LLM_CACHE_ENABLED 환경변수 테스트"""
+
+    def test_cache_enabled_setting_exists(self):
+        from app.core.config import settings
+        assert hasattr(settings, "LLM_CACHE_ENABLED")
+        assert isinstance(settings.LLM_CACHE_ENABLED, bool)
+
+    def test_cache_enabled_default_true(self):
+        from app.core.config import settings
+        assert settings.LLM_CACHE_ENABLED is True
+
+
+class TestRedisConnectionPool:
+    """Redis 연결 풀 싱글톤 테스트"""
+
+    def test_shared_redis_function_exists(self):
+        from app.services.cached_llm import _get_shared_redis
+        assert callable(_get_shared_redis)
+
+    def test_cached_llm_uses_shared_pool(self):
+        """CachedLLMService._get_redis()가 _get_shared_redis를 사용하는지 확인"""
+        from app.services.cached_llm import CachedLLMService
+        svc = CachedLLMService()
+        # _get_redis 메서드가 존재하는지 확인
+        assert hasattr(svc, "_get_redis")
+        assert callable(svc._get_redis)
+
+
 class TestRateLimitKeyFunc:
     def test_key_func_exists(self):
         from app.core.rate_limit import _get_rate_limit_key


### PR DESCRIPTION
## Summary
- 캐시 키에 `activity_name` 포함하여 서로 다른 Activity 간 캐시 충돌 방지
- `LLM_CACHE_ENABLED=false` 설정 시 Redis 캐시 읽기/쓰기 완전 스킵
- Redis 연결 풀을 모듈 레벨 싱글톤으로 전환 (max_connections=20)
- `run()`, `run_for_job()`, `run_with_prompt_config()` 모두 동일 패턴 적용

## Test plan
- [x] TestCacheKeyWithActivityName: 5개 테스트 통과
- [x] TestLLMCacheEnabled: 2개 테스트 통과
- [x] TestRedisConnectionPool: 2개 테스트 통과
- [x] 기존 TestCachedLLMInvalidation: 6개 테스트 통과 (하위 호환)

Closes #77 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)