### PR TITLE
fix: 백엔드 의존성 정리 — 버전 일치, DB 풀 확장, Redis 기반 Rate Limiting

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -11,8 +11,9 @@ from .config import settings
 engine = create_async_engine(
     settings.DATABASE_URL,
     echo=settings.is_local,
-    pool_size=5,
-    max_overflow=10,
+    pool_size=settings.DB_POOL_SIZE,
+    max_overflow=settings.DB_MAX_OVERFLOW,
+    pool_recycle=3600,
 )
 
 async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -6,6 +6,8 @@ from starlette.requests import Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+from app.core.config import settings
+
 
 def _get_rate_limit_key(request: Request) -> str:
     """사용자 인증 정보 기반 키, 미인증 시 IP 기반 키"""
@@ -27,7 +29,7 @@ def _get_rate_limit_key(request: Request) -> str:
 limiter = Limiter(
     key_func=_get_rate_limit_key,
     default_limits=["100/minute"],
-    storage_uri=None,  # in-memory (프로덕션에서는 Redis URI 사용)
+    storage_uri=settings.REDIS_URL,  # Redis 기반 분산 Rate Limiting
 )
 
 # 사용자 플랜별 Rate Limit 상수

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,7 +28,7 @@ temporalio>=1.6.0
 
 # LLM
 pydantic-ai>=0.0.36
-pydantic-ai-litellm>=0.2.0
+pydantic-ai-litellm>=0.2.3
 litellm>=1.40.0
 instructor>=1.3.0
 


### PR DESCRIPTION
## Summary
- `requirements.txt`: `pydantic-ai-litellm>=0.2.3`으로 `pyproject.toml`과 버전 일치
- `database.py`: DB 커넥션 풀 `pool_size=10, max_overflow=20` (config 기반), `pool_recycle=3600`
- `rate_limit.py`: in-memory → Redis 기반 분산 Rate Limiting

## Test plan
- [x] DB 풀 설정 로딩 검증 (pool_size=10, max_overflow=20)
- [x] 기존 테스트 통과 확인

Closes #77 (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)