### PR TITLE
fix: 인프라 강화 — Docker 헬스체크, 보안 헤더, 로깅 설정

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ FastAPI 애플리케이션
 """
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
@@ -114,6 +114,16 @@ app.add_middleware(
     SessionMiddleware,
     secret_key=settings.SESSION_SECRET,
 )
+
+# --- Security Headers ---
+
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next) -> Response:
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    return response
 
 # --- Error Handlers ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,16 @@ services:
       - VITE_BACKEND_URL=${FRONTEND_BACKEND_URL:-http://localhost:8000}
     depends_on:
       - backend
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "3"
     networks:
       - iaas_internal
       - cloudflare_tunnel  # Cloudflare 터널에서 접근 가능
@@ -76,6 +86,16 @@ services:
         condition: service_started
       phoenix:
         condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "3"
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     networks:
       - iaas_internal
@@ -123,6 +143,11 @@ services:
       - backend
       - temporal
       - phoenix
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "3"
     command: python -m app.worker
     networks:
       - iaas_internal
@@ -161,6 +186,16 @@ services:
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru --requirepass ${REDIS_PASSWORD:-redis_dev_password}
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-redis_dev_password}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "3"
     networks:
       - iaas_internal
     ports:
@@ -186,6 +221,16 @@ services:
         condition: service_healthy
     volumes:
       - ./config/temporal:/etc/temporal/config/dynamicconfig
+    healthcheck:
+      test: ["CMD", "temporal", "operator", "cluster", "health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "3"
     networks:
       - iaas_internal
     ports:
@@ -200,6 +245,11 @@ services:
       - TEMPORAL_CORS_ORIGINS=http://localhost:5173
     depends_on:
       - temporal
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "3"
     networks:
       - iaas_internal
     ports:
@@ -219,6 +269,11 @@ services:
       - PHOENIX_ENABLE_AUTH=false
     volumes:
       - phoenix_data:/data
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "3"
     networks:
       - iaas_internal
     ports:


### PR DESCRIPTION
## Summary
- **docker-compose.yml**: 모든 서비스에 healthcheck 추가 — frontend(curl), backend(curl), redis(redis-cli ping), temporal(cluster health)
- **docker-compose.yml**: 모든 서비스에 json-file 로깅 드라이버 + 로그 로테이션 (100MB x 3파일)으로 디스크 무한 증가 방지
- **main.py**: 보안 헤더 미들웨어 추가 — X-Content-Type-Options(nosniff), X-Frame-Options(DENY), X-XSS-Protection

## Test plan
- [x] `docker compose config` 설정 파일 유효성 검증 통과
- [x] `main.py` 구문 검증 통과
- [x] 기존 테스트 (15/15) 통과 확인

Resolves part of #77 (Phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)