### PR TITLE
fix: Decision 탭 필드명 불일치 수정 — 프론트엔드/백엔드 정합성 확보

### DIFF
--- a/backend/app/models/decision.py
+++ b/backend/app/models/decision.py
@@ -16,15 +16,16 @@ class DecisionSummary(BaseModel):
 
 class ResumeTip(BaseModel):
     """이력서 기반 확인 포인트"""
-    area: str
-    detail: str
-    source: str
+    section: str
+    insight: str
+    question_link: str | None = None
 
 
 class CoverLetterInsight(BaseModel):
     """커버레터 검증 포인트"""
-    claim: str
-    verify_with: str
+    highlight: str
+    interpretation: str
+    follow_up_opportunity: str | None = None
 
 
 class InterviewerGuideTips(BaseModel):

--- a/backend/app/prompts/v2_generation.yaml
+++ b/backend/app/prompts/v2_generation.yaml
@@ -207,10 +207,10 @@ prompts:
         "interview_flow": "카테고리1(시간) → 카테고리2(시간) → ...",
         "time_allocation": {{"category": "시간"}},
         "resume_based_tips": [
-          {{"area": "검증 영역", "detail": "구체적 확인 방법", "source": "이력서|GitHub|커버레터"}}
+          {{"section": "검증 영역", "insight": "구체적 확인 방법", "question_link": "관련 질문 참조 (예: Q1, Q3) 또는 null"}}
         ],
         "cover_letter_insights": [
-          {{"claim": "커버레터 주장", "verify_with": "검증 질문"}}
+          {{"highlight": "커버레터 핵심 주장", "interpretation": "검증 질문", "follow_up_opportunity": "추가 확인 기회 (없으면 null)"}}
         ],
         "red_flags_to_watch": ["주의사항1", "주의사항2"],
         "positive_signals": ["긍정 신호1 (후보자 맞춤)", "긍정 신호2"]

--- a/backend/app/workflows/activities/decision_generation.py
+++ b/backend/app/workflows/activities/decision_generation.py
@@ -120,9 +120,9 @@ async def _llm_generate_interviewer_tips(
         for tip in result.get("resume_based_tips", [])[:5]:
             if isinstance(tip, dict):
                 resume_tips.append(ResumeTip(
-                    area=tip.get("area", ""),
-                    detail=tip.get("detail", ""),
-                    source=tip.get("source", "이력서"),
+                    section=tip.get("section", ""),
+                    insight=tip.get("insight", ""),
+                    question_link=tip.get("question_link"),
                 ))
 
         # cover_letter_insights 변환
@@ -130,8 +130,9 @@ async def _llm_generate_interviewer_tips(
         for ins in result.get("cover_letter_insights", [])[:3]:
             if isinstance(ins, dict):
                 cl_insights.append(CoverLetterInsight(
-                    claim=ins.get("claim", ""),
-                    verify_with=ins.get("verify_with", ""),
+                    highlight=ins.get("highlight", ""),
+                    interpretation=ins.get("interpretation", ""),
+                    follow_up_opportunity=ins.get("follow_up_opportunity"),
                 ))
 
         tips = InterviewerGuideTips(
@@ -273,9 +274,9 @@ def _build_interviewer_tips(
                     related_q_ids.append(i + 1)
 
             resume_tips.append(ResumeTip(
-                area=f"{role} @ {company}",
-                detail=f"해당 경력 관련 구체적 성과와 역할 확인",
-                source="이력서",
+                section=f"{role} @ {company}",
+                insight="해당 경력 관련 구체적 성과와 역할 확인",
+                question_link=f"Q{',Q'.join(str(q) for q in related_q_ids)}" if related_q_ids else None,
             ))
 
     # 커버레터 인사이트 (있는 경우)
@@ -286,8 +287,9 @@ def _build_interviewer_tips(
         for m in motivations[:2]:
             if isinstance(m, str):
                 cover_letter_insights.append(CoverLetterInsight(
-                    claim=m,
-                    verify_with="관련 경험 구체적 사례 요청",
+                    highlight=m,
+                    interpretation="관련 경험 구체적 사례 요청",
+                    follow_up_opportunity="해당 주장을 뒷받침하는 구체적 사례를 요청하세요",
                 ))
 
     # Red flags


### PR DESCRIPTION
## Summary
- Decision 탭의 ResumeTip, CoverLetterInsight 모델 필드명이 프론트엔드 TypeScript 타입과 불일치하여 런타임에 `undefined`가 렌더링되던 문제 수정
- 백엔드 Pydantic 모델, Activity 로직, LLM 프롬프트 출력 포맷을 프론트엔드 계약에 맞춰 일괄 변경

## 변경 내역

### ResumeTip (3개 필드 전부 변경)
| 기존 (백엔드) | 변경 후 (프론트엔드 일치) |
|--------------|----------------------|
| `area` | `section` |
| `detail` | `insight` |
| `source` | `question_link` (nullable, 관련 질문 번호 연결) |

### CoverLetterInsight (2개 변경 + 1개 추가)
| 기존 (백엔드) | 변경 후 (프론트엔드 일치) |
|--------------|----------------------|
| `claim` | `highlight` |
| `verify_with` | `interpretation` |
| _(없음)_ | `follow_up_opportunity` (nullable, 추가 확인 안내) |

### 수정 파일
- `backend/app/models/decision.py` — Pydantic 모델 필드명 변경
- `backend/app/workflows/activities/decision_generation.py` — LLM 경로 + fallback 경로 모두 새 필드명
- `backend/app/prompts/v2_generation.yaml` — LLM 출력 JSON 예시 업데이트

## Test plan
- [x] Decision 관련 13개 테스트 전부 통과
- [x] 프론트엔드 `tsc --noEmit` 통과
- [x] 프론트엔드 `npm run build` 성공
- [x] Pydantic 모델 직렬화 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)