### PR TITLE
feat: UI/UX 업그레이드 — 데모 기반 애니메이션, 탭 리디자인, 카드 인터랙션, 색상 통합

### DIFF
--- a/frontend/src/components/charts/ProgressBar.tsx
+++ b/frontend/src/components/charts/ProgressBar.tsx
@@ -10,7 +10,7 @@ interface ProgressBarProps {
   /** Display text (e.g., "82%", "우수", "미확인") */
   display: string
   /** Color variant */
-  color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray'
+  color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray' | 'slate'
   /** Optional note text */
   note?: string
   /** Optional tooltip text */
@@ -47,6 +47,12 @@ const colorMap = {
     fill: 'bg-gray-400',
     text: 'text-gray-600',
     border: 'border-gray-200'
+  },
+  slate: {
+    bg: 'bg-slate-100',
+    fill: 'bg-slate-500',
+    text: 'text-slate-700',
+    border: 'border-slate-200'
   }
 }
 
@@ -89,9 +95,9 @@ export function ProgressBar({
         <span className={`text-sm font-semibold ${colors.text}`}>{display}</span>
       </div>
 
-      <div className={`h-2.5 rounded-full ${colors.bg} overflow-hidden`}>
+      <div className={`h-2.5 rounded-full ${colors.bg} overflow-hidden group`}>
         <div
-          className={`h-full rounded-full ${colors.fill} transition-all duration-500 ease-out`}
+          className={`h-full rounded-full ${colors.fill} transition-all duration-500 ease-out hover:brightness-110`}
           style={{ width: `${Math.min(value, 100)}%` }}
         />
       </div>
@@ -114,7 +120,7 @@ interface ProgressBarGroupProps {
     label: string
     value: number
     display: string
-    color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray'
+    color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray' | 'slate'
     note?: string
     tooltip?: string
   }>

--- a/frontend/src/components/charts/RadarChart.tsx
+++ b/frontend/src/components/charts/RadarChart.tsx
@@ -104,6 +104,7 @@ export function RadarChart({
           stroke="#6366f1"
           strokeWidth={2}
           strokeDasharray="4 2"
+          style={{ transition: 'all 0.4s ease' }}
         />
 
         {/* Candidate polygon (foreground) */}
@@ -112,21 +113,37 @@ export function RadarChart({
           fill="rgba(16, 185, 129, 0.3)"
           stroke="#10b981"
           strokeWidth={2}
+          style={{ transition: 'all 0.4s ease' }}
         />
 
-        {/* Data points */}
+        {/* Data points with hover tooltip */}
         {candidateData.map((value, i) => {
           const point = getPoint(value, i)
           return (
-            <circle
-              key={i}
-              cx={point.x}
-              cy={point.y}
-              r={4}
-              fill="#10b981"
-              stroke="white"
-              strokeWidth={2}
-            />
+            <g key={i}>
+              {/* Larger invisible hit area for hover */}
+              <circle
+                cx={point.x}
+                cy={point.y}
+                r={10}
+                fill="transparent"
+                style={{ cursor: 'pointer' }}
+              >
+                <title>{labels[i]}: {value} (요구: {requiredData[i]})</title>
+              </circle>
+              <circle
+                cx={point.x}
+                cy={point.y}
+                r={4}
+                fill="#10b981"
+                stroke="white"
+                strokeWidth={2}
+                style={{ transition: 'r 0.2s ease' }}
+                className="hover:r-6"
+              >
+                <title>{labels[i]}: {value} (요구: {requiredData[i]})</title>
+              </circle>
+            </g>
           )
         })}
 

--- a/frontend/src/components/tabs/DecisionTab.tsx
+++ b/frontend/src/components/tabs/DecisionTab.tsx
@@ -1,6 +1,7 @@
 /**
  * DecisionTab - JD Competency Achievement + Hiring Recommendation
  */
+import { useState } from 'react'
 import type { DecisionSupport, Candidate, CategoryWeights } from '../../types/interview'
 
 interface DecisionTabProps {
@@ -30,6 +31,7 @@ export function DecisionTab({
   }
 
   const recommendation = getRecommendation()
+  const [guideExpanded, setGuideExpanded] = useState(false)
 
   return (
     <div className="space-y-6">
@@ -81,7 +83,7 @@ export function DecisionTab({
 
         <div className="grid sm:grid-cols-2 gap-6">
           {/* Strengths */}
-          <div className="p-4 bg-emerald-50 rounded-xl border border-emerald-200">
+          <div className="card-hover p-4 bg-emerald-50 rounded-xl border border-emerald-200">
             <h4 className="font-semibold text-emerald-900 mb-3 flex items-center gap-2">
               <span>✅</span> 강점
             </h4>
@@ -96,7 +98,7 @@ export function DecisionTab({
           </div>
 
           {/* Concerns */}
-          <div className="p-4 bg-amber-50 rounded-xl border border-amber-200">
+          <div className="card-hover p-4 bg-amber-50 rounded-xl border border-amber-200">
             <h4 className="font-semibold text-amber-900 mb-3 flex items-center gap-2">
               <span>⚠️</span> 우려 사항
             </h4>
@@ -124,7 +126,7 @@ export function DecisionTab({
 
           <div className="space-y-4">
             {jd_competency_map.map((comp, i) => (
-              <div key={i} className="p-4 bg-gray-50 rounded-lg">
+              <div key={i} className="card-hover p-4 bg-gray-50 rounded-lg">
                 <div className="flex items-center justify-between mb-2">
                   <span className="font-medium text-gray-900">{comp.competency}</span>
                   <span className="text-sm text-indigo-600 font-semibold">
@@ -172,14 +174,24 @@ export function DecisionTab({
       )}
 
       {/* Interviewer Guide Tips */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
+        <button
+          onClick={() => setGuideExpanded(!guideExpanded)}
+          className="w-full p-6 flex items-center justify-between text-left"
+        >
+          <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+            <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            면접관 가이드
+          </h3>
+          <svg className={`w-5 h-5 text-gray-400 transition-transform ${guideExpanded ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
-          면접관 가이드
-        </h3>
+        </button>
 
+        {guideExpanded && (
+        <div className="px-6 pb-6 space-y-6 animate-fadeIn">
         {/* Interview Flow */}
         {interviewer_guide.interview_flow && (
           <div className="mb-6 p-4 bg-indigo-50 rounded-lg border border-indigo-200">
@@ -268,6 +280,8 @@ export function DecisionTab({
             </div>
           )}
         </div>
+        </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -97,7 +97,7 @@ export function DeepAnalysisTab({ analysis }: DeepAnalysisTabProps) {
           </h3>
           <div className="space-y-3">
             {risk_flags.map((flag, i) => (
-              <div key={i} className="bg-white rounded-lg p-4 border border-red-200">
+              <div key={i} className="card-hover bg-white rounded-lg p-4 border border-red-200">
                 <div className="font-medium text-red-900">{flag.label}</div>
                 <div className="text-sm text-red-700 mt-1">{flag.detail}</div>
               </div>
@@ -129,7 +129,7 @@ export function DeepAnalysisTab({ analysis }: DeepAnalysisTabProps) {
               </thead>
               <tbody className="divide-y divide-gray-100">
                 {skill_table.map((row, i) => (
-                  <tr key={i} className="hover:bg-gray-50">
+                  <tr key={i} className="hover:bg-gray-50 transition-colors">
                     <td className="px-6 py-4 text-sm font-medium text-gray-900">{row.skill}</td>
                     <td className="px-6 py-4 text-sm text-gray-700">{row.candidate}</td>
                     <td className="px-6 py-4">

--- a/frontend/src/components/tabs/IntelBriefTab.tsx
+++ b/frontend/src/components/tabs/IntelBriefTab.tsx
@@ -56,7 +56,7 @@ export function IntelBriefTab({ intel, candidate }: IntelBriefTabProps) {
       )}
 
       {/* JD Summary */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm animate-fadeIn">
         <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
           <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -123,10 +123,11 @@ export function IntelBriefTab({ intel, candidate }: IntelBriefTabProps) {
           {competencies.map((comp, i) => (
             <div
               key={i}
-              className={`p-4 rounded-lg border ${
+              className={`card-hover p-4 rounded-lg border ${
                 comp.color === 'emerald' ? 'bg-emerald-50 border-emerald-200' :
                 comp.color === 'amber' ? 'bg-amber-50 border-amber-200' :
                 comp.color === 'red' ? 'bg-red-50 border-red-200' :
+                comp.color === 'slate' ? 'bg-slate-50 border-slate-200' :
                 'bg-gray-50 border-gray-200'
               }`}
             >
@@ -139,6 +140,7 @@ export function IntelBriefTab({ intel, candidate }: IntelBriefTabProps) {
                   comp.color === 'emerald' ? 'bg-emerald-200 text-emerald-800' :
                   comp.color === 'amber' ? 'bg-amber-200 text-amber-800' :
                   comp.color === 'red' ? 'bg-red-200 text-red-800' :
+                  comp.color === 'slate' ? 'bg-slate-200 text-slate-800' :
                   'bg-gray-200 text-gray-800'
                 }`}>
                   {comp.match_label}
@@ -149,6 +151,7 @@ export function IntelBriefTab({ intel, candidate }: IntelBriefTabProps) {
                 comp.color === 'emerald' ? 'text-emerald-700' :
                 comp.color === 'amber' ? 'text-amber-700' :
                 comp.color === 'red' ? 'text-red-700' :
+                comp.color === 'slate' ? 'text-slate-700' :
                 'text-gray-700'
               }`}>
                 💡 {comp.why}

--- a/frontend/src/components/tabs/LiveInterviewTab.tsx
+++ b/frontend/src/components/tabs/LiveInterviewTab.tsx
@@ -147,7 +147,7 @@ export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTa
               <button
                 key={q.id}
                 onClick={() => toggleQuestion(q.id)}
-                className={`w-full text-left p-4 rounded-xl border transition-all ${
+                className={`card-hover w-full text-left p-4 rounded-xl border transition-all ${
                   selectedQuestions.has(q.id)
                     ? 'bg-indigo-50 border-indigo-300 ring-1 ring-indigo-200'
                     : 'bg-white border-gray-200 hover:border-gray-300'
@@ -308,7 +308,7 @@ export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTa
               <button
                 key={scenario.level}
                 onClick={() => handleScenarioSelect(currentQuestion.id, scenario.level, scenario.score)}
-                className={`p-4 rounded-xl border-2 text-left transition-all ${
+                className={`card-hover p-4 rounded-xl border-2 text-left transition-all ${
                   currentScore?.selectedLevel === scenario.level
                     ? 'border-indigo-500 bg-indigo-50 ring-2 ring-indigo-200'
                     : 'border-gray-200 hover:border-gray-300'
@@ -340,7 +340,7 @@ export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTa
               {currentQuestion.follow_ups
                 .filter(fu => fu.trigger === 'any' || fu.trigger === currentScore.selectedLevel)
                 .map((followUp) => (
-                  <div key={followUp.id} className="p-4 bg-gray-50 rounded-xl border border-gray-200">
+                  <div key={followUp.id} className="card-hover p-4 bg-gray-50 rounded-xl border border-gray-200">
                     <p className="font-medium text-gray-900 mb-2">{followUp.question_text}</p>
                     <div className="grid sm:grid-cols-2 gap-3 mb-3">
                       <div className="p-2 bg-green-50 rounded-lg border border-green-200">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,6 +23,59 @@
   left: 0;
 }
 
+/* fadeIn animation */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.animate-fadeIn { animation: fadeIn 0.4s ease-out forwards; }
+
+/* Custom scrollbar */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #94a3b8; }
+
+/* Card hover effect */
+.card-hover {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.card-hover:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.08), 0 2px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+/* Tab underline animation */
+.tab-underline {
+  position: relative;
+}
+.tab-underline::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(to right, #6366f1, #8b5cf6);
+  transition: width 0.3s ease;
+  border-radius: 1px;
+}
+.tab-underline.active::after {
+  width: 100%;
+}
+
+/* Skeleton loading */
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+.skeleton {
+  background: linear-gradient(90deg, #f1f5f9 25%, #e2e8f0 50%, #f1f5f9 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 0.5rem;
+}
+
 @media print {
   body {
     background: white !important;

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -49,14 +49,20 @@ export function ResultPage() {
 
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center py-20">
-        <div className="relative">
-          <div className="h-16 w-16 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600"></div>
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="h-8 w-8 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600"></div>
+      <div className="space-y-6 py-6">
+        <div className="flex items-center gap-4">
+          <div className="skeleton h-14 w-14 rounded-2xl" />
+          <div className="space-y-2">
+            <div className="skeleton h-6 w-48" />
+            <div className="skeleton h-4 w-32" />
           </div>
         </div>
-        <p className="mt-4 text-sm font-medium text-gray-500">{t('loading')}</p>
+        <div className="skeleton h-12 w-full" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="skeleton h-40" />
+          <div className="skeleton h-40" />
+        </div>
+        <div className="skeleton h-60 w-full" />
       </div>
     )
   }
@@ -175,78 +181,76 @@ export function ResultPage() {
 
       {/* Tab Navigation */}
       {hasV2Data ? (
-        // v2 4-tab navigation
-        <div className="flex gap-1 p-1 bg-gray-100 rounded-xl no-print">
+        // v2 4-tab navigation (underline style)
+        <div className="flex border-b border-gray-200 no-print">
           <button
             onClick={() => setActiveTab('intel')}
-            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-              activeTab === 'intel'
-                ? 'bg-white text-indigo-700 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
+            className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'intel' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
           >
-            🔍 Intel Brief
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            Intel Brief
           </button>
           <button
             onClick={() => setActiveTab('analysis')}
-            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-              activeTab === 'analysis'
-                ? 'bg-white text-indigo-700 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
+            className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'analysis' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
           >
-            📊 Deep Analysis
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            Deep Analysis
           </button>
           <button
             onClick={() => setActiveTab('interview')}
-            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-              activeTab === 'interview'
-                ? 'bg-white text-indigo-700 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
+            className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'interview' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
           >
-            🎯 Live Interview ({questions.length})
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+            </svg>
+            Live Interview ({questions.length})
           </button>
           <button
             onClick={() => setActiveTab('decision')}
-            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-              activeTab === 'decision'
-                ? 'bg-white text-indigo-700 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
+            className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'decision' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
           >
-            ✅ Decision
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Decision
           </button>
         </div>
       ) : (
-        // v1 3-tab navigation (fallback)
-        <div className="flex gap-1 p-1 bg-gray-100 rounded-xl no-print">
+        // v1 3-tab navigation (underline style)
+        <div className="flex border-b border-gray-200 no-print">
           <button
             onClick={() => setActiveTab('questions')}
-            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-              activeTab === 'questions'
-                ? 'bg-white text-indigo-700 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
+            className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'questions' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
           >
             질문 목록 ({questions.length})
           </button>
           <button
             onClick={() => setActiveTab('summary')}
-            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-              activeTab === 'summary'
-                ? 'bg-white text-indigo-700 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
+            className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'summary' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
           >
             후보자 분석
           </button>
           <button
             onClick={() => setActiveTab('guide')}
-            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all ${
-              activeTab === 'guide'
-                ? 'bg-white text-indigo-700 shadow-sm'
-                : 'text-gray-600 hover:text-gray-900'
+            className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'guide' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
           >
             면접관 가이드
@@ -256,7 +260,7 @@ export function ResultPage() {
 
       {/* V2 Tabs */}
       {hasV2Data && (
-        <>
+        <div key={activeTab} className="animate-fadeIn">
           {activeTab === 'intel' && script.intel && (
             <IntelBriefTab intel={script.intel} candidate={script.candidate} />
           )}
@@ -281,7 +285,7 @@ export function ResultPage() {
               maxScore={maxScore || 100}
             />
           )}
-        </>
+        </div>
       )}
 
       {/* V1 Tabs (Fallback) */}

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -37,7 +37,7 @@ export interface CompetencyMatch {
   match_label: string
   desc: string
   why: string
-  color: 'emerald' | 'amber' | 'red' | 'gray'
+  color: 'emerald' | 'amber' | 'red' | 'gray' | 'slate'
   icon: string
 }
 
@@ -81,7 +81,7 @@ export interface EngineeringDNAItem {
   label: string
   value: number
   display: string
-  color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray'
+  color: 'emerald' | 'blue' | 'amber' | 'red' | 'gray' | 'slate'
   note?: string
   tooltip?: string
 }


### PR DESCRIPTION
## 요약
- 데모 `index.html`의 디자인 패턴을 프로덕션 프론트엔드에 적용
- 총 9개 파일 수정, 새 파일/외부 라이브러리 추가 없음

## 변경 사항

### CSS 기반 개선 (`index.css`)
- `fadeIn` 애니메이션 (탭 전환 시 부드러운 등장)
- 커스텀 스크롤바 (6px 슬림, slate 계열)
- `card-hover` 효과 (translateY + shadow 증가)
- `tab-underline` 애니메이션 (그라데이션 언더라인)
- `skeleton` 로딩 (shimmer 효과)

### 탭 네비게이션 리디자인 (`ResultPage.tsx`)
- pill 형태 → 언더라인 + SVG 아이콘 스타일
- 이모지(🔍📊🎯✅) → Heroicons SVG 인라인 아이콘
- 로딩 스피너 → 스켈레톤 UI
- 탭 전환 시 `fadeIn` 애니메이션 (`key={activeTab}` 리마운트)

### 탭 컴포넌트 폴리시
- **IntelBriefTab**: 역량 매칭 카드 `card-hover`, `slate` 색상 fallback
- **DeepAnalysisTab**: 위험 신호 카드 `card-hover`, 테이블 행 hover transition
- **LiveInterviewTab**: 질문 선택/시나리오/꼬리질문 카드 `card-hover`
- **DecisionTab**: 강점/우려/역량 카드 `card-hover`, 면접관 가이드 아코디언 접기

### 차트 개선
- **RadarChart**: SVG 폴리곤 CSS 트랜지션, 데이터 포인트 hover tooltip
- **ProgressBar**: `slate` 색상 추가, hover brightness 효과

### 색상 불일치 해결
- 백엔드 `slate` → 프론트엔드 TypeScript 타입 + 색상 매핑 추가
- `Competency.color`, `EngineeringDNA.color` 타입에 `'slate'` 추가

## 테스트 계획
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `npm run build` 프로덕션 빌드 성공
- [ ] 브라우저에서 탭 전환 애니메이션 확인
- [ ] 카드 hover 효과 확인
- [ ] 스켈레톤 로딩 확인
- [ ] 면접관 가이드 아코디언 접기/펼치기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)