### PR TITLE
feat: 경험 레벨별 퍼센트 기반 질문 배분 시스템 도입

### DIFF
--- a/backend/app/models/input.py
+++ b/backend/app/models/input.py
@@ -40,7 +40,7 @@ class InputData(BaseModel):
     # 옵션
     experience_level: ExperienceLevel = Field(..., description="후보자 경험 레벨")
     language_config: LanguageConfig = Field(default_factory=LanguageConfig)
-    max_questions: int = Field(25, ge=5, le=25, description="생성할 질문 수")
+    max_questions: int = Field(20, description="생성할 질문 수 (퍼센트 기반 고정 20개)")
     include_expected_answers: bool = Field(True, description="예상 답변 포함 여부")
     focus_areas: list[str] | None = Field(None, description="집중할 기술 영역")
 

--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -1,6 +1,6 @@
 prompts:
   select_topics:
-    description: "면접 질문 토픽 25개 선정 - 다중 소스 기반 (Few-shot Enhanced)"
+    description: "면접 질문 토픽 20개 선정 - 퍼센트 기반 배분 (Few-shot Enhanced)"
     template: |
       # CRITICAL OUTPUT RULES (READ FIRST)
       - Return ONLY raw JSON, NO markdown formatting
@@ -45,18 +45,12 @@ prompts:
       # AVAILABLE TOPIC CANDIDATES
       {{candidates}}
 
-      # CATEGORY REQUIREMENTS
-      Distribute exactly 5 topics per category:
-      - **role_fit**: Culture fit, motivation, career goals
-      - **technical_depth**: Technical skills, problem-solving, architecture
-      - **execution_ownership**: Project delivery, ownership, impact
-      - **communication**: Collaboration, explanation ability, conflict resolution
-      - **risk_flags**: Gaps, concerns, areas needing clarification
+      # CATEGORY DISTRIBUTION (percentage-based, total {{max_questions}} topics)
+      # Distribution varies by experience level. Generate EXACTLY this many topics:
+      {{category_distribution}}
 
-      # DIFFICULTY DISTRIBUTION (per category)
-      - Easy: 2 topics (baseline verification questions)
-      - Medium: 2 topics (depth exploration questions)
-      - Hard: 1 topic (expertise probe questions)
+      # DIFFICULTY DISTRIBUTION
+      {{difficulty_distribution}}
 
       # OUTPUT FORMAT (JSON)
       ```json

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -3,6 +3,7 @@ backend/app/workflows/activities/question_generation.py
 질문 생성 Activities (토픽 선정 + 개별 질문 생성)
 """
 import logging
+import uuid
 
 from temporalio import activity
 
@@ -12,18 +13,95 @@ from app.workflows.utils import run_llm_with_heartbeat
 
 logger = logging.getLogger(__name__)
 
+# ── 경험 레벨별 퍼센트 기반 카테고리 배분 ──
+# 각 레벨에서 중요한 질문 유형에 더 높은 비율 할당
+TOTAL_QUESTIONS = 20
+
+CATEGORY_DISTRIBUTION: dict[str, dict[str, dict]] = {
+    # 신입: 기초 기술력 + 성장 가능성 + 커뮤니케이션 중심
+    "신입": {
+        "role_fit":             {"count": 6, "difficulty": ["Easy", "Easy", "Easy", "Medium", "Medium", "Hard"]},
+        "technical_depth":      {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
+        "execution_ownership":  {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Easy", "Easy", "Medium", "Hard"]},
+        "risk_flags":           {"count": 2, "difficulty": ["Easy", "Medium"]},
+    },
+    # 주니어: 성장 가능성 + 기초 기술력 중심
+    "주니어": {
+        "role_fit":             {"count": 6, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Medium", "Hard"]},
+        "technical_depth":      {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
+        "execution_ownership":  {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
+        "risk_flags":           {"count": 2, "difficulty": ["Easy", "Medium"]},
+    },
+    # 미들: 균형 잡힌 배분
+    "미들": {
+        "role_fit":             {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
+        "technical_depth":      {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
+        "execution_ownership":  {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
+        "risk_flags":           {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
+    },
+    # 시니어: 실행력 + 리스크 + 기술 깊이 중심
+    "시니어": {
+        "role_fit":             {"count": 3, "difficulty": ["Medium", "Medium", "Hard"]},
+        "technical_depth":      {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
+        "execution_ownership":  {"count": 5, "difficulty": ["Easy", "Medium", "Medium", "Hard", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
+        "risk_flags":           {"count": 4, "difficulty": ["Easy", "Medium", "Hard", "Hard"]},
+    },
+    # CTO/VP: 리더십 + 전략적 실행력 + 리스크 관리 중심
+    "CTO/VP": {
+        "role_fit":             {"count": 3, "difficulty": ["Medium", "Hard", "Hard"]},
+        "technical_depth":      {"count": 3, "difficulty": ["Medium", "Hard", "Hard"]},
+        "execution_ownership":  {"count": 5, "difficulty": ["Medium", "Medium", "Hard", "Hard", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
+        "risk_flags":           {"count": 5, "difficulty": ["Medium", "Medium", "Hard", "Hard", "Hard"]},
+    },
+}
+
+
+def _get_distribution(experience_level: str) -> dict[str, dict]:
+    """경험 레벨에 맞는 카테고리 배분 반환 (fallback: 미들)"""
+    return CATEGORY_DISTRIBUTION.get(experience_level, CATEGORY_DISTRIBUTION["미들"])
+
+
+def _format_distribution_for_prompt(dist: dict[str, dict]) -> tuple[str, str]:
+    """프롬프트용 카테고리 배분 + 난이도 배분 텍스트 생성"""
+    cat_lines = []
+    diff_lines = []
+    for cat, info in dist.items():
+        count = info["count"]
+        pct = round(count / TOTAL_QUESTIONS * 100)
+        cat_desc = {
+            "role_fit": "Culture fit, motivation, career goals, growth potential",
+            "technical_depth": "Technical skills, problem-solving, architecture",
+            "execution_ownership": "Project delivery, ownership, impact, leadership",
+            "communication": "Collaboration, explanation ability, conflict resolution",
+            "risk_flags": "Gaps, concerns, areas needing clarification",
+        }
+        cat_lines.append(f"- **{cat}** ({pct}%): {count} topics — {cat_desc.get(cat, '')}")
+
+        # 난이도 카운트
+        from collections import Counter
+        diff_count = Counter(info["difficulty"])
+        diff_str = ", ".join(f"{d}:{c}" for d, c in sorted(diff_count.items(), key=lambda x: ["Easy", "Medium", "Hard"].index(x[0])))
+        diff_lines.append(f"- **{cat}** ({count} topics): {diff_str}")
+
+    return "\n      ".join(cat_lines), "\n      ".join(diff_lines)
+
 
 @activity.defn
 @observe_activity(name="select_topics", phase="question_generation")
 async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None = None) -> list[dict]:
     """
-    25개 질문 토픽 선정 (5카테고리 × 5)
+    20개 질문 토픽 선정 — 경험 레벨별 퍼센트 기반 카테고리 배분
 
     선정 기준:
     1. Knowledge Graph 기반 후보 (skill_depth, gap_probe, conflict_probe, implementation_review)
     2. 코드에서 발견된 주목할 만한 구현
     3. JD 요구사항과의 매칭
-    4. 경험 레벨에 맞는 난이도
+    4. 경험 레벨에 맞는 카테고리 비율 + 난이도
     """
     from app.services.cached_llm import CachedLLMService
 
@@ -33,12 +111,14 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
     llm = CachedLLMService()
     raw_input = enriched_input.get("raw_input", {})
     experience_level = raw_input.get("experience_level", "미들")
-    max_questions = raw_input.get("max_questions", 25)
+    max_questions = TOTAL_QUESTIONS  # 고정 20개 (퍼센트 기반)
+    dist = _get_distribution(experience_level)
 
     if alog:
         await alog.start("Selecting question topics", {
             "experience_level": experience_level,
             "max_questions": max_questions,
+            "distribution": {cat: info["count"] for cat, info in dist.items()},
         })
 
     # 질문 후보 수집
@@ -118,12 +198,16 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
 
     activity.heartbeat(f"Selecting {max_questions} topics from {len(candidates)} candidates...")
 
+    cat_dist_text, diff_dist_text = _format_distribution_for_prompt(dist)
+
     from app.prompts import get_prompt
     prompt = get_prompt(
         "question_generation.yaml", "select_topics",
         max_questions=max_questions,
         experience_level=experience_level,
         candidates=_format_candidates(candidates),
+        category_distribution=cat_dist_text,
+        difficulty_distribution=diff_dist_text,
     )
 
     # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
@@ -134,31 +218,31 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
                 "topics_count": len(result[:max_questions]),
                 "candidates_considered": len(candidates),
             })
-        return result[:max_questions]
+        return result[:TOTAL_QUESTIONS]
 
-    # Fallback: generate placeholder topics from candidates
+    # Fallback: 경험 레벨별 배분에 따라 placeholder 토픽 생성
     topics = []
-    categories = ["role_fit", "technical_depth", "execution_ownership", "communication", "risk_flags"]
-    for i, cat in enumerate(categories):
-        for j in range(5):
-            idx = i * 5 + j
-            if idx < len(candidates):
+    candidate_idx = 0
+    for cat, info in dist.items():
+        for j in range(info["count"]):
+            if candidate_idx < len(candidates):
                 topics.append({
                     "category": cat,
-                    "topic": candidates[idx]["topic"],
-                    "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"][j],
-                    "source": candidates[idx]["source"],
+                    "topic": candidates[candidate_idx]["topic"],
+                    "difficulty": info["difficulty"][j] if j < len(info["difficulty"]) else "Medium",
+                    "source": candidates[candidate_idx]["source"],
                 })
+                candidate_idx += 1
             else:
                 topics.append({
                     "category": cat,
                     "topic": f"{cat}_topic_{j+1}",
-                    "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"][j],
+                    "difficulty": info["difficulty"][j] if j < len(info["difficulty"]) else "Medium",
                     "source": "generated",
                 })
     if alog:
         await alog.result("Topics selected (fallback)", {
-            "topics_count": len(topics[:max_questions]),
+            "topics_count": len(topics),
             "candidates_considered": len(candidates),
         })
     return topics[:max_questions]
@@ -243,6 +327,8 @@ async def craft_question(
     result = await run_llm_with_heartbeat(llm, prompt, "craft_question", interval=30.0)
 
     question = result if isinstance(result, dict) else {}
+    # 고유 ID 강제 할당 — LLM이 중복 ID를 생성하는 문제 방지
+    question["id"] = f"q-{topic.get('category', 'x')[:4]}-{uuid.uuid4().hex[:8]}"
     question.setdefault("question_text", f"[{topic.get('topic')}] 관련 질문")
     question.setdefault("category", topic.get("category", "technical_depth"))
     question.setdefault("difficulty", topic.get("difficulty", "Medium"))

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -398,14 +398,18 @@ class InterviewGenerationWorkflow:
                 final_script["intel"] = intel_brief
                 final_script["analysis"] = deep_analysis
                 final_script["decision"] = decision_support
-                # Category weights for scoring
-                final_script["category_weights"] = {
-                    "role_fit": 0.25,
-                    "technical_depth": 0.20,
-                    "execution_ownership": 0.20,
-                    "communication": 0.20,
-                    "risk_flags": 0.15,
+                # Category weights for scoring — 경험 레벨별 차등 배분
+                exp_level = input_data.get("input_data", {}).get("experience_level", "미들")
+                CATEGORY_WEIGHTS_BY_LEVEL = {
+                    "신입":   {"role_fit": 0.30, "technical_depth": 0.25, "execution_ownership": 0.15, "communication": 0.20, "risk_flags": 0.10},
+                    "주니어": {"role_fit": 0.30, "technical_depth": 0.25, "execution_ownership": 0.15, "communication": 0.20, "risk_flags": 0.10},
+                    "미들":   {"role_fit": 0.25, "technical_depth": 0.20, "execution_ownership": 0.20, "communication": 0.20, "risk_flags": 0.15},
+                    "시니어": {"role_fit": 0.15, "technical_depth": 0.20, "execution_ownership": 0.25, "communication": 0.20, "risk_flags": 0.20},
+                    "CTO/VP": {"role_fit": 0.15, "technical_depth": 0.15, "execution_ownership": 0.25, "communication": 0.20, "risk_flags": 0.25},
                 }
+                final_script["category_weights"] = CATEGORY_WEIGHTS_BY_LEVEL.get(
+                    exp_level, CATEGORY_WEIGHTS_BY_LEVEL["미들"]
+                )
 
             # DB에 결과 저장
             job_id = input_data.get("job_id")

--- a/frontend/src/components/tabs/LiveInterviewTab.tsx
+++ b/frontend/src/components/tabs/LiveInterviewTab.tsx
@@ -1,7 +1,7 @@
 /**
  * LiveInterviewTab - Question Selection → Interactive Scoring → Follow-up Branching
  */
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import type {
   InterviewQuestion,
   ScenarioLevelType,
@@ -15,13 +15,24 @@ interface LiveInterviewTabProps {
 }
 
 export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTabProps) {
+  // Deduplicate questions by ID — backend generates UUID-based IDs,
+  // but this safety net prevents selection bugs if duplicates slip through
+  const uniqueQuestions = useMemo(() => {
+    const seen = new Set<string>()
+    return questions.filter(q => {
+      if (seen.has(q.id)) return false
+      seen.add(q.id)
+      return true
+    })
+  }, [questions])
+
   const [phase, setPhase] = useState<'select' | 'interview'>('select')
   const [selectedQuestions, setSelectedQuestions] = useState<Set<string>>(new Set())
   const [currentIndex, setCurrentIndex] = useState(0)
   const [scores, setScores] = useState<ScoresState>({})
 
   // Get selected questions in order
-  const interviewQuestions = questions.filter(q => selectedQuestions.has(q.id))
+  const interviewQuestions = uniqueQuestions.filter(q => selectedQuestions.has(q.id))
 
   // Toggle question selection
   const toggleQuestion = (id: string) => {
@@ -36,7 +47,7 @@ export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTa
 
   // Select all questions
   const selectAll = () => {
-    setSelectedQuestions(new Set(questions.map(q => q.id)))
+    setSelectedQuestions(new Set(uniqueQuestions.map(q => q.id)))
   }
 
   // Start interview
@@ -87,7 +98,7 @@ export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTa
   // Selection Phase
   if (phase === 'select') {
     // Group questions by category
-    const questionsByCategory = questions.reduce((acc, q) => {
+    const questionsByCategory = uniqueQuestions.reduce((acc, q) => {
       const cat = q.category || '기타'
       if (!acc[cat]) acc[cat] = []
       acc[cat].push(q)

--- a/frontend/src/pages/CreateJobPage.tsx
+++ b/frontend/src/pages/CreateJobPage.tsx
@@ -139,7 +139,6 @@ export function CreateJobPage() {
   // 선택 필드
   const [linkedinUrl, setLinkedinUrl] = useState('')
   const [gitUrl, setGitUrl] = useState('')
-  const [maxQuestions, setMaxQuestions] = useState(25)
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -208,7 +207,6 @@ export function CreateJobPage() {
       const inputData: Record<string, unknown> = {
         jd_text: jdText,
         experience_level: experienceLevel,
-        max_questions: maxQuestions,
         language_config: {
           output_language: outputLanguage,
           terminology_languages: ['ko', 'en'],
@@ -405,31 +403,6 @@ export function CreateJobPage() {
               placeholder="https://github.com/username"
               className="w-full rounded-lg border border-gray-300 py-2.5 pl-10 pr-3 text-gray-900 transition-colors focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
             />
-          </div>
-        </SectionCard>
-
-        {/* Options */}
-        <SectionCard title={t('options')}>
-          <div>
-            <div className="mb-2 flex items-center justify-between">
-              <label className="text-sm font-medium text-gray-700">{t('max_questions')}</label>
-              <span className="rounded-full bg-indigo-100 px-2.5 py-0.5 text-sm font-semibold text-indigo-700">
-                {maxQuestions}개
-              </span>
-            </div>
-            <input
-              type="range"
-              min={5}
-              max={25}
-              value={maxQuestions}
-              onChange={(e) => setMaxQuestions(Number(e.target.value))}
-              className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-indigo-600"
-            />
-            <div className="mt-1 flex justify-between text-xs text-gray-400">
-              <span>5</span>
-              <span>15</span>
-              <span>25</span>
-            </div>
           </div>
         </SectionCard>
 


### PR DESCRIPTION
## Summary
- 질문 개수 슬라이더(5-25개) 제거 → 고정 20개 질문으로 변경
- 경험 레벨별(신입/주니어/미들/시니어/CTO·VP) 카테고리 배분 차등 적용
  - 신입/주니어: role_fit(30%) + technical(25%) 중심
  - 시니어: execution(25%) + risk(20%) 중심
  - CTO/VP: execution(25%) + risk(25%) 중심
- UUID 기반 질문 ID 생성으로 프론트엔드 "하나 선택 시 전부 선택" 버그 근본 해결
- category_weights 경험 레벨별 차등 배분
- LiveInterviewTab ID 중복 방지 useMemo 안전장치 추가

## 변경 파일 (6개)
| 파일 | 변경 내용 |
|------|----------|
| `backend/app/models/input.py` | max_questions 고정 20 |
| `backend/app/prompts/question_generation.yaml` | 동적 분배 템플릿 변수 |
| `backend/app/workflows/activities/question_generation.py` | CATEGORY_DISTRIBUTION + UUID ID |
| `backend/app/workflows/interview_workflow.py` | category_weights 레벨별 분리 |
| `frontend/src/pages/CreateJobPage.tsx` | 슬라이더 UI 제거 |
| `frontend/src/components/tabs/LiveInterviewTab.tsx` | useMemo 중복 방지 |

## Test plan
- [ ] TypeScript type check 통과 확인 (`npx tsc --noEmit`)
- [ ] Production build 성공 확인 (`npm run build`)
- [ ] 각 경험 레벨(신입~CTO)로 Job 생성 후 질문 카테고리 배분 확인
- [ ] 질문 선택 UI에서 개별 선택/해제 정상 동작 확인
- [ ] CreateJobPage에서 슬라이더가 제거되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)