### PR TITLE
fix: 카테고리 가중치 경험 레벨 미적용 버그 수정

### DIFF
--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -399,7 +399,7 @@ class InterviewGenerationWorkflow:
                 final_script["analysis"] = deep_analysis
                 final_script["decision"] = decision_support
                 # Category weights for scoring — 경험 레벨별 차등 배분
-                exp_level = input_data.get("input_data", {}).get("experience_level", "미들")
+                exp_level = input_data.get("experience_level", "미들")
                 CATEGORY_WEIGHTS_BY_LEVEL = {
                     "신입":   {"role_fit": 0.30, "technical_depth": 0.25, "execution_ownership": 0.15, "communication": 0.20, "risk_flags": 0.10},
                     "주니어": {"role_fit": 0.30, "technical_depth": 0.25, "execution_ownership": 0.15, "communication": 0.20, "risk_flags": 0.10},


### PR DESCRIPTION
## Summary
- `interview_workflow.py`에서 `input_data.get("input_data", {}).get("experience_level", "미들")` → `input_data.get("experience_level", "미들")`로 수정
- `input_data`가 flat dict인데 이중 접근하여 항상 "미들" 기본값이 적용되던 버그 수정
- 시니어 레벨 Job에서 Decision 탭 카테고리 가중치가 미들 값(role_fit:25%)으로 표시되던 문제 해결

## Root Cause
- `input_data`는 `{"experience_level": "시니어", "jd_text": "...", ...}` 형태의 flat dict
- `input_data.get("input_data", {})` → `{}` (빈 dict) 반환 → `.get("experience_level", "미들")` → "미들"
- 모든 경험 레벨이 무시되고 항상 미들 가중치 적용

## Test plan
- [x] 시니어 레벨 Job 생성 후 Decision 탭에서 role_fit:15%, execution_ownership:25% 확인
- [x] Worker 컨테이너 재빌드/재시작 후 프로덕션 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)