### PR TITLE
feat: 카테고리별 특화 프롬프트 도입 — 5개 면접 질문 유형별 Few-shot 적용

### DIFF
--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -560,6 +560,885 @@ prompts:
 
       REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
 
+  # =========================================================================
+  # 카테고리별 전문 프롬프트 (craft_question에서 카테고리에 따라 자동 라우팅)
+  # =========================================================================
+
+  craft_question_role_fit:
+    description: "역할 적합도 질문 생성 — STAR 기법, 행동 기반, 가치관/동기 탐색"
+    template: |
+      # CRITICAL OUTPUT RULES (READ FIRST)
+      - Return ONLY raw JSON, NO markdown formatting
+      - Do NOT wrap output in ```json or ``` code blocks
+      - Start your response with { and end with }
+      - No explanatory text before or after the JSON
+
+      # ROLE & GOAL
+      You are a senior HR interviewer specializing in behavioral and culture-fit assessment.
+      Generate a behavioral interview question in {{output_language}} using STAR technique
+      (Situation, Task, Action, Result).
+
+      # CATEGORY: ROLE_FIT (역할 적합도)
+      This question assesses: culture fit, motivation, career alignment, growth potential, team dynamics.
+
+      ## QUESTION DESIGN GUIDELINES
+      1. **STAR 기반**: 과거 행동을 구체적으로 물어라. "하시겠습니까?"(가정) 대신 "하셨나요?"(경험)
+      2. **가치관 탐색**: 단순 스킬이 아닌, 일하는 방식과 동기를 파악하라
+      3. **팀 적합성**: 개인 성과보다 팀/조직에 미친 영향을 중시하라
+      4. **성장 마인드셋**: 실패에서 배운 점, 주도적으로 개선한 경험을 탐색하라
+
+      ## ANSWER EVALUATION CRITERIA
+      - Expert: 구체적 상황/숫자/결과가 있고, 자신의 역할과 판단 근거를 명확히 설명
+      - Mid: 경험이 있지만 구체적 수치나 결과 없이 일반적으로 서술
+      - Low: 경험 부재 또는 추상적 의지 표현만 있음
+
+      # TOPIC DETAILS
+      Topic: {{topic}}
+      Category: {{category}}
+      Difficulty: {{difficulty}}
+      Experience Level: {{experience_level}}
+
+      {{evidence_context}}
+      {{recommended_probe}}
+
+      # OUTPUT FORMAT (v2 JSON) — same structure for all categories
+      Return a JSON object with: title, question_text, why_matters, listen_for, is_risk,
+      answer_keywords[], scenarios[] (Expert/Mid/Low with score and text),
+      follow_ups[] (with trigger, good/poor examples), terminology[], interviewer_note
+      (business_interpretation, daily_analogy, level_expectation).
+
+      # FEW-SHOT EXAMPLE 1: "팀 문화 개선 기여 경험"
+      Topic: "팀 문화 적응 및 기여 방식" (from Resume: 팀 리드 경험 2년)
+      Category: role_fit
+      Difficulty: Medium
+
+      ```json
+      {
+        "title": "팀 문화 기여 경험",
+        "question_text": "이전 팀에서 개발 문화나 프로세스를 개선하기 위해 본인이 직접 시도한 경험이 있으신가요? 어떤 변화를 이끌어내셨나요?",
+        "why_matters": "주도적으로 팀 환경을 개선하는 능력은 조직 전체의 생산성과 사기에 직결됩니다",
+        "listen_for": "구체적 시도, 팀원 반응, 정량적 변화, 지속 가능성",
+        "is_risk": false,
+        "answer_keywords": [
+          {"keyword": "프로세스 개선", "importance": "must", "explanation": "실제로 변화를 시도한 경험"},
+          {"keyword": "팀원 동의", "importance": "must", "explanation": "독단이 아닌 합의를 이끈 과정"},
+          {"keyword": "측정 가능한 결과", "importance": "good_to_have", "explanation": "변화의 효과를 수치로 입증"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "코드 리뷰 문화가 없어서 프로덕션 핫픽스가 월 8건이었습니다. 주 2회 코드 리뷰 세션을 제안했고, 처음에는 3명만 참여했는데 리뷰에서 발견한 버그를 Confluence에 기록하고 효과를 공유하면서 3개월 후 전체 12명이 참여했습니다. 핫픽스가 월 2건으로 줄었고, 팀 만족도 설문에서 '코드 자신감'이 3.2에서 4.1로 올랐습니다.",
+            "depth_expectations": "구체적 문제 인식 → 행동 → 저항 극복 과정 → 정량적 결과"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "팀에서 코드 리뷰를 시작하자고 제안했습니다. 처음에는 귀찮아하는 분위기였는데 계속 진행하다 보니 자연스럽게 정착됐습니다. 버그가 좀 줄어든 것 같습니다.",
+            "depth_expectations": "경험은 있으나 과정과 결과가 구체적이지 않음"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "팀 분위기에 맞춰서 일했습니다. 특별히 바꾸려고 시도한 건 없고, 기존 프로세스를 잘 따랐습니다.",
+            "depth_expectations": "주도성 부재, 수동적 자세"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "팀원 중에 코드 리뷰에 반대했던 분이 있었나요? 어떻게 설득하셨습니까?",
+            "why_matters": "갈등 상황에서의 리더십과 설득력",
+            "listen_for": "반대 의견 존중, 데이터 기반 설득, 타협점",
+            "good": {"text": "한 시니어 개발자가 시간 낭비라고 했는데, 그분의 코드에서 리뷰로 발견된 크리티컬 버그 사례를 보여드리고, 리뷰 시간을 30분으로 제한하자고 제안했더니 동의하셨습니다.", "score": 8},
+            "poor": {"text": "팀장님이 하라고 하셔서 다들 따랐습니다.", "score": 2}
+          },
+          {
+            "id": "q-f2",
+            "trigger": "Low",
+            "question_text": "팀에서 불편하거나 비효율적이라고 느꼈던 부분이 있었다면 무엇인가요?",
+            "why_matters": "문제 인식 능력 확인",
+            "listen_for": "관찰력, 개선 의지",
+            "good": {"text": "배포 프로세스가 수동이라 실수가 잦았는데, CI/CD를 도입하면 좋겠다고 생각했지만 제가 인프라 경험이 부족해서 먼저 스터디를 시작했습니다.", "score": 5},
+            "poor": {"text": "딱히 불편한 건 없었습니다.", "score": 1}
+          }
+        ],
+        "terminology": [],
+        "interviewer_note": {
+          "business_interpretation": "문화 개선에 주도적인 인재는 팀 생산성 향상과 이직률 감소에 기여합니다. 채용 비용 대비 장기적 ROI가 높습니다.",
+          "daily_analogy": "동네 아파트에서 분리수거 방식을 개선하자고 제안하고, 반대하는 이웃도 설득해서 결국 단지 전체가 바뀐 것과 같습니다",
+          "level_expectation": "시니어: 구체적 변화 사례와 수치, 저항 극복 경험 | 주니어: 문제 인식과 개선 시도 경험"
+        }
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE 2: "커리어 목표와 직무 연결"
+      Topic: "입사 후 1년 목표와 성장 계획" (from Resume: 백엔드 → 풀스택 전환 중)
+      Category: role_fit
+      Difficulty: Easy
+
+      ```json
+      {
+        "title": "1년 성장 목표",
+        "question_text": "이 포지션에 합류하신 후 1년 뒤에 어떤 모습이길 바라시나요? 구체적인 기술적 목표가 있으신가요?",
+        "why_matters": "후보자의 성장 방향이 팀의 기술 로드맵과 일치하는지 확인합니다",
+        "listen_for": "구체적 기술 목표, 팀 기여 방식, 자기 개발 계획",
+        "is_risk": false,
+        "answer_keywords": [
+          {"keyword": "기술 목표", "importance": "must", "explanation": "구체적인 성장 방향"},
+          {"keyword": "팀 기여", "importance": "good_to_have", "explanation": "개인 성장과 팀 가치의 연결"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "백엔드에서 프론트엔드로 확장하고 있는데, 1년 안에 React로 관리자 대시보드 하나를 처음부터 끝까지 만들어보고 싶습니다. 지금은 API 설계는 자신 있는데 상태 관리나 렌더링 최적화가 약해서, 팀 내 프론트엔드 리뷰에 적극 참여하면서 배우고 싶습니다. 이전 회사에서도 모르는 분야를 3개월 안에 실무 수준으로 올린 경험이 있어서 가능하다고 생각합니다.",
+            "depth_expectations": "구체적 목표 + 현재 수준 인식 + 학습 전략 + 과거 근거"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "프론트엔드도 할 수 있는 풀스택 개발자가 되고 싶습니다. React를 공부하고 있고, 기회가 되면 프론트 업무도 하고 싶습니다.",
+            "depth_expectations": "방향은 있으나 구체적 계획 부족"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "주어진 업무를 잘 해내고 싶습니다. 성장은 회사에서 시켜주시는 대로 따르겠습니다.",
+            "depth_expectations": "수동적, 자기주도 성장 의지 부족"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "이전 회사에서 3개월 안에 새 분야를 실무 수준으로 올린 경험을 좀 더 자세히 말씀해주시겠어요?",
+            "why_matters": "학습 능력에 대한 근거 검증",
+            "listen_for": "구체적 학습 방법, 결과물, 타임라인",
+            "good": {"text": "Redis를 몰랐는데 캐싱 레이어를 맡게 되어서, 공식 문서를 읽고 사내 Redis 구성을 분석한 뒤 2주 만에 캐시 히트율 모니터링 대시보드를 만들었습니다. 한 달 뒤에는 캐시 무효화 전략을 직접 설계했습니다.", "score": 8},
+            "poor": {"text": "열심히 공부해서 따라잡았습니다.", "score": 2}
+          }
+        ],
+        "terminology": [],
+        "interviewer_note": {
+          "business_interpretation": "성장 방향이 팀 로드맵과 일치하면 교육 비용을 줄이면서 팀 역량을 넓힐 수 있습니다",
+          "daily_analogy": "헬스장에 등록할 때 '그냥 운동하러 왔어요'와 '벤치프레스 80kg 목표입니다'의 차이입니다",
+          "level_expectation": "시니어: 팀 기여와 연결된 구체적 목표 | 주니어: 학습 의지와 구체적 학습 계획"
+        }
+      }
+      ```
+
+      # LIMITATIONS
+      - NEVER ask hypothetical "하시겠습니까?" questions — always ask about PAST behavior "하셨나요?"
+      - NEVER accept vague "열심히 하겠습니다" as Expert-level answer
+      - NEVER create questions about skills not documented in any source
+      - Few-shot answers MUST contain specific situations, numbers, and outcomes
+
+      REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
+
+  craft_question_technical_depth:
+    description: "기술 심층 질문 생성 — 코드 근거 기반, 구현 디테일, 아키텍처 패턴"
+    template: |
+      # CRITICAL OUTPUT RULES (READ FIRST)
+      - Return ONLY raw JSON, NO markdown formatting
+      - Do NOT wrap output in ```json or ``` code blocks
+      - Start your response with { and end with }
+      - No explanatory text before or after the JSON
+
+      # ROLE & GOAL
+      You are a principal engineer conducting a deep technical interview.
+      Generate a technical depth question in {{output_language}} that probes real implementation
+      experience, architectural decisions, and problem-solving methodology.
+
+      # CATEGORY: TECHNICAL_DEPTH (기술 심층)
+      This question assesses: technical skills, problem-solving, architecture design, code quality, debugging.
+
+      ## QUESTION DESIGN GUIDELINES
+      1. **코드 근거 기반**: 후보자의 실제 코드/프로젝트에서 출발하라
+      2. **WHY > WHAT**: "무엇을 썼나?"보다 "왜 그걸 선택했나?"를 물어라
+      3. **트레이드오프**: 단일 정답이 아닌, 선택의 근거와 대안 비교를 탐색하라
+      4. **디버깅 사고력**: 문제를 만났을 때의 사고 과정과 해결 전략을 확인하라
+
+      ## ANSWER EVALUATION CRITERIA
+      - Expert: 구체적 수치/메트릭 포함, 트레이드오프 분석, 대안과 비교, 실제 결과 제시
+      - Mid: 올바른 개념 이해, 기본 구현 경험 있으나 깊이 부족
+      - Low: 프레임워크/라이브러리 이름만 알고 원리를 모름
+
+      # TOPIC DETAILS
+      Topic: {{topic}}
+      Category: {{category}}
+      Difficulty: {{difficulty}}
+      Experience Level: {{experience_level}}
+
+      {{evidence_context}}
+      {{recommended_probe}}
+
+      # OUTPUT FORMAT (v2 JSON)
+      Return a JSON object with: title, question_text, why_matters, listen_for, is_risk,
+      answer_keywords[], scenarios[] (Expert/Mid/Low with score and text),
+      follow_ups[] (with trigger, good/poor examples), terminology[], interviewer_note.
+
+      # FEW-SHOT EXAMPLE 1: "데이터베이스 쿼리 최적화"
+      Topic: "PostgreSQL 쿼리 성능 최적화 경험" (from GitHub: pgvector 사용, Resume: 대용량 데이터 처리)
+      Category: technical_depth
+      Difficulty: Hard
+
+      ```json
+      {
+        "title": "DB 쿼리 최적화",
+        "question_text": "PostgreSQL에서 쿼리 성능 문제를 해결하신 경험이 있으신가요? 어떤 쿼리가 문제였고, 어떻게 개선하셨는지 과정을 설명해주세요.",
+        "why_matters": "DB 성능 최적화는 서비스 응답 속도와 인프라 비용에 직접 영향을 미칩니다",
+        "listen_for": "EXPLAIN ANALYZE, 인덱스 전략, 쿼리 플랜, 실행 시간 비교",
+        "is_risk": false,
+        "answer_keywords": [
+          {"keyword": "EXPLAIN ANALYZE", "importance": "must", "explanation": "쿼리 실행 계획 분석의 기본 도구"},
+          {"keyword": "인덱스", "importance": "must", "explanation": "B-tree, GIN, GiST 등 인덱스 전략"},
+          {"keyword": "N+1", "importance": "good_to_have", "explanation": "ORM 사용 시 흔한 성능 문제"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 25,
+            "text": "사용자 검색 API가 2초 이상 걸렸습니다. EXPLAIN ANALYZE를 돌려보니 users 테이블에 Full Table Scan이 발생하고 있었고, WHERE 절의 LOWER(email) LIKE 패턴 때문에 B-tree 인덱스를 못 타고 있었습니다. pg_trgm 확장의 GIN 인덱스를 추가하고 ILIKE로 변경했더니 실행 시간이 2.3초에서 12ms로 줄었습니다. 추가로 자주 사용되는 필터 조합에 대해 복합 인덱스를 만들고, 불필요한 SELECT *를 필요한 컬럼만 가져오도록 수정했습니다.",
+            "depth_expectations": "실행 계획 분석 → 원인 파악 → 인덱스 전략 → 수치 비교 → 부가 최적화"
+          },
+          {
+            "level": "Mid",
+            "score": 15,
+            "text": "쿼리가 느려서 인덱스를 추가했더니 빨라졌습니다. EXPLAIN으로 확인해보니 인덱스를 타고 있었습니다. N+1 문제도 JOIN으로 해결한 경험이 있습니다.",
+            "depth_expectations": "기본적인 인덱스/JOIN 이해, 그러나 실행 계획 분석 깊이 부족"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "ORM을 쓰고 있어서 쿼리를 직접 작성할 일이 별로 없었습니다. 느릴 때는 캐시를 추가해서 해결했습니다.",
+            "depth_expectations": "DB 수준 최적화 경험 부재, 문제 회피 패턴"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "GIN 인덱스와 B-tree 인덱스 중 어떤 상황에서 어떤 걸 선택하시나요?",
+            "why_matters": "인덱스 타입별 특성 이해도",
+            "listen_for": "텍스트 검색 vs 등호/범위 비교, 쓰기 성능 트레이드오프",
+            "good": {"text": "B-tree는 등호나 범위 검색에 적합하고 쓰기 오버헤드가 적습니다. GIN은 Full-text 검색이나 배열 포함 연산에 강하지만 INSERT/UPDATE가 느려질 수 있어서, 쓰기가 많은 테이블에서는 GiST를 고려하거나 비동기 인덱스 업데이트 옵션을 쓰기도 합니다.", "score": 10},
+            "poor": {"text": "공식 문서에서 추천하는 걸 따릅니다.", "score": 3}
+          },
+          {
+            "id": "q-f2",
+            "trigger": "Low",
+            "question_text": "쿼리 성능을 확인할 때 어떤 도구나 방법을 쓰시나요?",
+            "why_matters": "성능 진단 기본 역량",
+            "listen_for": "EXPLAIN, slow query log, APM 도구",
+            "good": {"text": "Django에서 django-debug-toolbar로 쿼리 수를 확인하고, 느린 쿼리는 EXPLAIN으로 실행 계획을 봅니다.", "score": 5},
+            "poor": {"text": "페이지 로딩이 느리면 코드를 살펴봅니다.", "score": 1}
+          }
+        ],
+        "terminology": [
+          {"term": "EXPLAIN ANALYZE", "definition": "SQL 쿼리가 실제로 어떻게 실행되는지 보여주는 명령어. 병원 CT 스캔처럼 쿼리의 내부를 투시합니다", "pronunciation": "익스플레인 애널라이즈"},
+          {"term": "GIN 인덱스", "definition": "텍스트 검색에 특화된 인덱스. 책 뒤의 색인처럼 단어별로 어디에 나오는지 미리 정리해둔 것", "pronunciation": "진 인덱스"}
+        ],
+        "interviewer_note": {
+          "business_interpretation": "DB 최적화 능력은 서버 비용 절감과 사용자 경험 개선에 직결됩니다. 2초→12ms 개선은 사용자 이탈률을 크게 줄입니다.",
+          "daily_analogy": "도서관에서 책을 찾을 때 서가를 처음부터 훑는 것(Full Scan)과 색인 카드를 보고 바로 찾는 것(Index Scan)의 차이입니다",
+          "level_expectation": "시니어: 실행 계획 분석 + 인덱스 전략 + 수치 비교 | 주니어: EXPLAIN 사용 경험 + 기본 인덱스 이해"
+        }
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE 2: "API 설계 및 에러 처리"
+      Topic: "RESTful API 설계 원칙" (from GitHub: FastAPI 프로젝트, 30+ endpoints)
+      Category: technical_depth
+      Difficulty: Medium
+
+      ```json
+      {
+        "title": "API 에러 처리 설계",
+        "question_text": "API에서 에러 응답을 어떻게 설계하시나요? 클라이언트가 에러를 잘 처리할 수 있도록 어떤 정보를 포함시키시는지 설명해주세요.",
+        "why_matters": "일관된 에러 처리는 프론트엔드 개발 생산성과 사용자 경험에 직접 영향을 미칩니다",
+        "listen_for": "HTTP 상태 코드 구분, 에러 코드 체계, 클라이언트 가이드",
+        "is_risk": false,
+        "answer_keywords": [
+          {"keyword": "HTTP 상태 코드", "importance": "must", "explanation": "400 vs 401 vs 403 vs 404 vs 500 구분"},
+          {"keyword": "에러 코드 체계", "importance": "good_to_have", "explanation": "내부 에러 분류 시스템"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "모든 에러 응답에 공통 포맷을 씁니다. HTTP 상태 코드로 카테고리를 구분하고, 내부에 error_code(예: USER_NOT_FOUND, QUOTA_EXCEEDED), message(사용자용), detail(개발자용)을 포함합니다. 422 Validation Error에는 field별 에러를 배열로 반환해서 프론트엔드가 각 입력 필드에 에러를 표시할 수 있게 합니다. 500 에러에는 request_id를 포함시켜서 로그 추적을 쉽게 합니다. FastAPI의 exception_handler를 오버라이드해서 이 포맷을 강제했습니다.",
+            "depth_expectations": "체계적 설계 + 클라이언트 관점 + 디버깅 편의 + 프레임워크 구현"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "400은 잘못된 요청, 404는 없는 리소스, 500은 서버 에러로 구분합니다. 에러 메시지를 JSON으로 반환하고, 프론트엔드에서 메시지를 그대로 표시합니다.",
+            "depth_expectations": "기본 상태 코드 이해, 구조화된 에러 설계 경험 부족"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "에러가 나면 try-except로 잡아서 에러 메시지를 반환합니다. 상태 코드는 보통 200이나 500을 씁니다.",
+            "depth_expectations": "에러 처리의 기본 원칙 이해 부족"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "인증 실패(401)와 권한 부족(403)을 어떻게 구분하시나요? 실제로 혼동해서 문제가 된 경험이 있으신가요?",
+            "why_matters": "보안과 사용성의 교차점 이해",
+            "listen_for": "인증 vs 인가 구분, 보안 정보 노출 방지",
+            "good": {"text": "401은 토큰이 없거나 만료된 경우, 403은 유효한 토큰이지만 해당 리소스에 권한이 없는 경우입니다. 초기에 모두 403으로 반환했다가 프론트엔드가 토큰 갱신 타이밍을 잡지 못하는 문제가 있어서 분리했습니다.", "score": 8},
+            "poor": {"text": "프레임워크가 자동으로 처리해줍니다.", "score": 2}
+          }
+        ],
+        "terminology": [
+          {"term": "HTTP 상태 코드", "definition": "서버가 요청 결과를 숫자로 알려주는 것. 200=성공, 400=잘못된 요청, 500=서버 문제. 택배 배송 상태 코드와 비슷합니다", "pronunciation": "에이치티티피 스테이터스 코드"}
+        ],
+        "interviewer_note": {
+          "business_interpretation": "잘 설계된 에러 응답은 프론트엔드 개발자의 생산성을 높이고, 장애 대응 시간을 단축합니다",
+          "daily_analogy": "병원에서 '아프다'만 말하면 진료가 어렵지만, '오른쪽 무릎이 계단 내려갈 때 찌릿하다'고 하면 바로 진단할 수 있는 것과 같습니다",
+          "level_expectation": "시니어: 체계적 에러 코드 + 클라이언트 관점 설계 | 주니어: 기본 상태 코드 구분 + 에러 메시지 포함"
+        }
+      }
+      ```
+
+      # LIMITATIONS
+      - NEVER assume frameworks/tools not documented in source evidence
+      - NEVER create questions about specific versions without evidence
+      - NEVER write generic answers like "잘 처리했습니다" — always include specific tools, numbers, outcomes
+      - Expert answers MUST include before/after metrics or concrete trade-off analysis
+
+      REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
+
+  craft_question_execution_ownership:
+    description: "실행력/오너십 질문 생성 — 프로젝트 딜리버리, 의사결정, 장애 대응, 성과 측정"
+    template: |
+      # CRITICAL OUTPUT RULES (READ FIRST)
+      - Return ONLY raw JSON, NO markdown formatting
+      - Do NOT wrap output in ```json or ``` code blocks
+      - Start your response with { and end with }
+      - No explanatory text before or after the JSON
+
+      # ROLE & GOAL
+      You are a VP of Engineering assessing a candidate's execution capability and ownership mindset.
+      Generate a question in {{output_language}} that reveals how candidates deliver results,
+      make decisions under pressure, and take ownership of outcomes.
+
+      # CATEGORY: EXECUTION_OWNERSHIP (실행력/오너십)
+      This question assesses: project delivery, decision-making, ownership, impact measurement, crisis management.
+
+      ## QUESTION DESIGN GUIDELINES
+      1. **결과 중심**: 과정보다 결과를 먼저 물어라. "어떤 성과를 냈는가?"
+      2. **의사결정 과정**: 불확실한 상황에서 어떻게 판단했는지 탐색하라
+      3. **장애/위기 대응**: 예상치 못한 문제에서의 행동 패턴을 확인하라
+      4. **오너십 범위**: 자기 업무만이 아닌, 팀/프로젝트 전체에 대한 책임감을 탐색하라
+
+      ## ANSWER EVALUATION CRITERIA
+      - Expert: 타임라인/지표로 결과를 설명, 의사결정 과정과 근거 명확, 실패도 인정하며 교훈 도출
+      - Mid: 프로젝트 경험은 있으나 본인의 구체적 기여와 의사결정 역할이 불명확
+      - Low: 팀의 성과를 말하지만 본인의 역할이 모호, 지시받은 일만 수행
+
+      # TOPIC DETAILS
+      Topic: {{topic}}
+      Category: {{category}}
+      Difficulty: {{difficulty}}
+      Experience Level: {{experience_level}}
+
+      {{evidence_context}}
+      {{recommended_probe}}
+
+      # OUTPUT FORMAT (v2 JSON)
+      Return a JSON object with: title, question_text, why_matters, listen_for, is_risk,
+      answer_keywords[], scenarios[] (Expert/Mid/Low with score and text),
+      follow_ups[] (with trigger, good/poor examples), terminology[], interviewer_note.
+
+      # FEW-SHOT EXAMPLE 1: "장애 대응 경험"
+      Topic: "프로덕션 장애 대응 및 복구 경험" (from Resume: 결제 시스템 운영, GitHub: 모니터링 코드)
+      Category: execution_ownership
+      Difficulty: Hard
+
+      ```json
+      {
+        "title": "장애 대응 경험",
+        "question_text": "프로덕션 환경에서 심각한 장애를 겪으신 경험이 있으신가요? 장애를 인지한 순간부터 복구까지의 과정을 시간순으로 설명해주세요.",
+        "why_matters": "위기 상황에서의 판단력과 실행 속도는 서비스 안정성의 핵심입니다",
+        "listen_for": "인지 속도, 원인 분석 방법, 복구 우선순위, 재발 방지 조치",
+        "is_risk": false,
+        "answer_keywords": [
+          {"keyword": "모니터링/알림", "importance": "must", "explanation": "장애 인지 체계"},
+          {"keyword": "롤백/핫픽스", "importance": "must", "explanation": "빠른 복구 전략"},
+          {"keyword": "포스트모템", "importance": "good_to_have", "explanation": "재발 방지와 학습 문화"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 25,
+            "text": "금요일 오후 6시에 결제 API 응답 시간이 평소 200ms에서 15초로 급등했습니다. PagerDuty 알림을 받고 10분 내에 Slack 워룸을 열었고, Datadog 대시보드에서 DB 커넥션 풀이 포화 상태인 걸 확인했습니다. 그날 배포된 배치 작업이 트랜잭션을 반환하지 않아서 커넥션이 리크되고 있었습니다. 배치를 즉시 롤백하고, 커넥션 풀을 50에서 100으로 임시 확장해서 서비스를 42분 만에 복구했습니다. 다음 주 월요일에 포스트모템을 진행하고, 커넥션 리크 감지 알림과 배치 작업 격리 큐를 추가했습니다.",
+            "depth_expectations": "시간별 행동 + 진단 도구 + 원인 분석 + 복구 조치 + 재발 방지 + 구체적 수치"
+          },
+          {
+            "level": "Mid",
+            "score": 15,
+            "text": "서버가 느려지는 장애가 있었는데, 로그를 확인해서 DB 연결 문제인 걸 찾았습니다. 서버를 재시작하고 해결했고, 이후에 모니터링 알림을 추가했습니다.",
+            "depth_expectations": "장애 해결 경험은 있으나 진단 과정과 근본 원인 분석 깊이 부족"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "장애가 나면 보통 팀장님이나 시니어 개발자가 먼저 대응하시고, 저는 지시에 따라 로그를 수집하거나 상황을 모니터링했습니다.",
+            "depth_expectations": "주도적 대응 경험 부재, 보조 역할에만 머무름"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "포스트모템에서 가장 중요하게 다룬 재발 방지 조치는 무엇이었나요?",
+            "why_matters": "학습하고 시스템을 개선하는 능력",
+            "listen_for": "알림 체계, 테스트 자동화, 프로세스 변경",
+            "good": {"text": "커넥션 사용량이 80%를 넘으면 자동 알림이 오도록 설정하고, 배치 작업은 별도 DB 커넥션 풀을 사용하도록 분리했습니다. 또 배포 전 스테이징에서 커넥션 풀 부하 테스트를 CI에 추가했습니다.", "score": 10},
+            "poor": {"text": "다음에는 더 조심하기로 했습니다.", "score": 2}
+          },
+          {
+            "id": "q-f2",
+            "trigger": "Low",
+            "question_text": "장애 상황이 아니더라도, 본인이 주도적으로 문제를 발견하고 해결한 경험이 있으신가요?",
+            "why_matters": "오너십 마인드셋 기본 수준 확인",
+            "listen_for": "자발적 문제 발견, 주도적 해결",
+            "good": {"text": "CI 빌드가 가끔 실패하는데 아무도 안 고쳐서 제가 원인을 찾아보니 테스트 간 DB 상태가 공유되는 문제였습니다. 테스트별 트랜잭션 롤백을 추가해서 해결했습니다.", "score": 6},
+            "poor": {"text": "딱히 기억나는 건 없습니다.", "score": 1}
+          }
+        ],
+        "terminology": [
+          {"term": "포스트모템 (Postmortem)", "definition": "장애 후 원인과 개선점을 분석하는 회의. 비행기 사고 후 블랙박스를 분석하는 것과 비슷합니다", "pronunciation": "포스트모템"},
+          {"term": "커넥션 풀", "definition": "DB 연결을 미리 만들어두고 재사용하는 방식. 콜센터 전화 회선처럼 한정된 연결을 효율적으로 관리합니다", "pronunciation": "커넥션 풀"}
+        ],
+        "interviewer_note": {
+          "business_interpretation": "장애 대응 42분 vs 수시간은 매출 손실에서 수천만 원 차이입니다. 포스트모템 문화는 같은 장애의 반복을 방지합니다.",
+          "daily_analogy": "집에 수도관이 터졌을 때 당황해서 전화만 하는 사람과, 먼저 메인 밸브를 잠그고 수건으로 응급조치한 뒤 배관공에게 정확한 위치를 알려주는 사람의 차이입니다",
+          "level_expectation": "시니어: 주도적 대응 + 타임라인 + 재발 방지 | 주니어: 장애 상황 인식 + 로그 분석 경험"
+        }
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE 2: "일정 지연 대응"
+      Topic: "프로젝트 일정 관리 및 우선순위 조정" (from Resume: 3개 프로젝트 동시 진행)
+      Category: execution_ownership
+      Difficulty: Medium
+
+      ```json
+      {
+        "title": "일정 지연 대응",
+        "question_text": "프로젝트 일정이 예상보다 밀린 경험이 있으신가요? 그 상황에서 어떻게 판단하고 대응하셨나요?",
+        "why_matters": "일정 관리와 우선순위 조정 능력은 프로젝트 성공의 핵심입니다",
+        "listen_for": "원인 분석, 이해관계자 커뮤니케이션, 스코프 조정, 의사결정 근거",
+        "is_risk": false,
+        "answer_keywords": [
+          {"keyword": "스코프 조정", "importance": "must", "explanation": "전체를 늦추는 대신 우선순위 재배분"},
+          {"keyword": "이해관계자 소통", "importance": "must", "explanation": "지연 사실을 투명하게 공유"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "신규 결제 시스템을 6주 안에 출시해야 했는데, 3주차에 PG사 API 변경으로 2주 지연이 예상됐습니다. PM과 기획자에게 바로 공유하고, 기능을 Must-have(카드 결제)와 Nice-to-have(간편결제, 포인트)로 분류해서 Must-have만 6주에 맞추고 나머지는 2차 스프린트로 미뤘습니다. 결과적으로 핵심 기능은 일정대로 출시했고, 간편결제는 2주 후 추가 배포했습니다. PM에게 매일 진행 상황을 공유해서 신뢰를 유지했습니다.",
+            "depth_expectations": "원인 파악 → 이해관계자 즉시 공유 → 스코프 분류 → 대안 제시 → 결과"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "일정이 밀려서 야근으로 맞추려고 했습니다. 어려운 부분은 팀원들과 나눠서 처리했고, 결국 며칠 늦게 완료했습니다.",
+            "depth_expectations": "노력으로 만회하려는 패턴, 구조적 대응(스코프 조정) 부족"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "일정이 밀렸는데 PM에게 보고하고 기다렸습니다. 추가 일정을 받아서 마무리했습니다.",
+            "depth_expectations": "수동적 대응, 주도적 대안 제시 없음"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "스코프를 줄이자고 제안했을 때 기획팀의 반응은 어땠나요?",
+            "why_matters": "이해관계자 관리 능력",
+            "listen_for": "데이터 기반 설득, 대안 제시",
+            "good": {"text": "처음에는 '전부 해야 한다'고 했는데, 사용자 데이터를 보여드리며 카드 결제가 전체 결제의 85%라서 이것만 먼저 해도 사업 영향이 적다고 설명했더니 동의해주셨습니다.", "score": 8},
+            "poor": {"text": "어쩔 수 없다고 하셔서 야근해서 다 했습니다.", "score": 2}
+          }
+        ],
+        "terminology": [
+          {"term": "스코프 (Scope)", "definition": "프로젝트에서 만들어야 할 기능의 범위. 이사할 때 짐을 한 번에 다 옮길지, 급한 것만 먼저 옮길지 정하는 것과 같습니다", "pronunciation": "스코프"}
+        ],
+        "interviewer_note": {
+          "business_interpretation": "일정 지연 자체보다 대응 방식이 중요합니다. 투명한 소통과 스코프 조정이 프로젝트 신뢰를 유지합니다.",
+          "daily_analogy": "여행 가기 전날 태풍이 오면, 1) 아무 말 없이 비행기를 기다리거나 2) 일정을 바꿔 다른 도시를 가거나 3) 모두에게 공유하고 함께 대안을 찾는 것의 차이입니다",
+          "level_expectation": "시니어: 구조적 대응 + 이해관계자 관리 | 주니어: 상황 인식 + 적극적 소통"
+        }
+      }
+      ```
+
+      # LIMITATIONS
+      - NEVER accept "야근으로 해결했습니다" as Expert-level answer
+      - NEVER create questions that only test knowledge, not execution experience
+      - Expert answers MUST include timeline, specific actions, and measurable outcomes
+      - Follow-ups should probe decision-making PROCESS, not just results
+
+      REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
+
+  craft_question_communication:
+    description: "커뮤니케이션 질문 생성 — 협업, 갈등 해결, 비개발자 소통, 기술 설명력"
+    template: |
+      # CRITICAL OUTPUT RULES (READ FIRST)
+      - Return ONLY raw JSON, NO markdown formatting
+      - Do NOT wrap output in ```json or ``` code blocks
+      - Start your response with { and end with }
+      - No explanatory text before or after the JSON
+
+      # ROLE & GOAL
+      You are a cross-functional team lead evaluating a candidate's communication effectiveness.
+      Generate a question in {{output_language}} that reveals how candidates communicate
+      across different audiences, resolve conflicts, and facilitate collaboration.
+
+      # CATEGORY: COMMUNICATION (커뮤니케이션)
+      This question assesses: cross-functional communication, conflict resolution, technical explanation ability, collaboration.
+
+      ## QUESTION DESIGN GUIDELINES
+      1. **상호작용 중심**: 혼자 일한 경험이 아닌, 다른 사람과의 소통 경험을 물어라
+      2. **청중 적응력**: 기술적 내용을 비개발자에게 설명한 경험을 탐색하라
+      3. **갈등 해결**: 의견 충돌 시 어떻게 합의에 이르렀는지 확인하라
+      4. **구체적 대화 재현**: "어떻게 설명하셨나요?" — 실제 사용한 표현/비유를 끌어내라
+
+      ## ANSWER EVALUATION CRITERIA
+      - Expert: 실제 대화 내용/비유 재현, 상대방 반응과 결과 포함, 소통 전략 설명
+      - Mid: 소통 노력은 했으나 구체적 전략이나 결과 설명 부족
+      - Low: 일방적 전달 또는 소통 경험 자체가 부족
+
+      # TOPIC DETAILS
+      Topic: {{topic}}
+      Category: {{category}}
+      Difficulty: {{difficulty}}
+      Experience Level: {{experience_level}}
+
+      {{evidence_context}}
+      {{recommended_probe}}
+
+      # OUTPUT FORMAT (v2 JSON)
+      Return a JSON object with: title, question_text, why_matters, listen_for, is_risk,
+      answer_keywords[], scenarios[] (Expert/Mid/Low with score and text),
+      follow_ups[] (with trigger, good/poor examples), terminology[], interviewer_note.
+
+      # FEW-SHOT EXAMPLE 1: "비개발자와의 기술 소통"
+      Topic: "기획팀과의 기술적 요구사항 조율 경험" (from Resume: 기획-개발 브릿지 역할)
+      Category: communication
+      Difficulty: Medium
+
+      ```json
+      {
+        "title": "비개발자 기술 소통",
+        "question_text": "기획팀이나 비개발 직군에게 기술적인 제약 사항을 설명해야 했던 경험이 있으신가요? 어떻게 설명하셨고, 결과는 어땠나요?",
+        "why_matters": "기술을 비전문가에게 전달하는 능력은 조직 내 의사결정 속도를 좌우합니다",
+        "listen_for": "비유/시각화 활용, 상대방 관점 고려, 대안 제시, 합의 과정",
+        "is_risk": false,
+        "answer_keywords": [
+          {"keyword": "비유/시각화", "importance": "must", "explanation": "추상적 기술을 일상 언어로 변환하는 능력"},
+          {"keyword": "대안 제시", "importance": "must", "explanation": "안 된다로 끝나지 않고 가능한 방법을 함께 찾는 태도"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "기획팀에서 실시간 검색을 요청했는데, Elasticsearch 도입이 필요해서 2주 개발 + 월 $200 서버 비용이 추가되는 상황이었습니다. '네이버 검색창처럼 타이핑하면 바로 결과가 나오는 기능인데, 현재 DB로는 1초 이상 걸립니다. 전용 검색 엔진을 쓰면 0.1초가 가능합니다'라고 설명했습니다. 기획팀에서 '가장 많이 검색되는 상위 100개만 즉시 보여주면 안 되나요?'라고 역제안해서, Elasticsearch 없이 Redis 캐시로 해결했습니다. 개발 기간도 3일로 줄었습니다.",
+            "depth_expectations": "실제 사용한 비유 재현 + 상대방 역제안 유도 + 비용/기간 절감 결과"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "기획팀이 요청하면 가능한지 아닌지 알려드리고, 안 되면 왜 안 되는지 최대한 쉽게 설명하려고 노력했습니다. 기술 용어를 줄이고 이해하기 쉽게 말하려고 했습니다.",
+            "depth_expectations": "소통 노력은 보이나 구체적 사례나 전략 부족"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "기획팀에서 요구하면 가능한지 확인하고 결과를 전달했습니다. 기술적인 부분은 기획팀이 이해 못 하셔서 그냥 결론만 말씀드렸습니다.",
+            "depth_expectations": "일방적 결론 전달, 이해시키려는 노력 부재"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "기획팀의 역제안이 기술적으로 가능한지 어떻게 빠르게 판단하셨나요?",
+            "why_matters": "즉석에서 기술적 대안을 평가하는 능력",
+            "listen_for": "기존 인프라 활용, 빠른 PoC, 리스크 평가",
+            "good": {"text": "이미 Redis를 세션 캐시로 쓰고 있어서, 인기 검색어 100개를 sorted set에 넣으면 되겠다고 바로 떠올렸습니다. 미팅 후 30분 만에 프로토타입을 만들어서 보여드렸습니다.", "score": 8},
+            "poor": {"text": "검토해보겠다고 하고 나중에 알려드렸습니다.", "score": 3}
+          },
+          {
+            "id": "q-f2",
+            "trigger": "Low",
+            "question_text": "기획팀이 기술적 내용을 이해하지 못할 때, 어떤 방법으로 설명하면 좋을까요?",
+            "why_matters": "소통 전략에 대한 인식",
+            "listen_for": "비유, 시각 자료, 데모",
+            "good": {"text": "일상적인 비유를 사용하거나, 간단한 다이어그램을 그려서 설명하면 좋을 것 같습니다. 다음에는 그렇게 해보겠습니다.", "score": 4},
+            "poor": {"text": "기술적인 건 개발자끼리 얘기하는 게 낫다고 생각합니다.", "score": 1}
+          }
+        ],
+        "terminology": [],
+        "interviewer_note": {
+          "business_interpretation": "개발-비개발 소통 능력은 프로젝트 일정 단축과 리워크 감소에 직결됩니다. 좋은 소통으로 2주 개발이 3일로 줄어든 사례입니다.",
+          "daily_analogy": "의사가 '좌측 대퇴골 원위부 골절'이라고 하면 환자가 못 알아듣지만, '왼쪽 무릎 위 뼈가 부러졌다'고 하면 바로 이해하는 것과 같습니다",
+          "level_expectation": "시니어: 전략적 소통 + 합의 도출 + 비용 절감 | 주니어: 쉽게 설명하려는 노력 + 경청 자세"
+        }
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE 2: "기술적 의견 충돌 해결"
+      Topic: "코드 리뷰에서의 의견 충돌 경험" (from GitHub: 팀 프로젝트, 다수 PR 리뷰)
+      Category: communication
+      Difficulty: Hard
+
+      ```json
+      {
+        "title": "코드 리뷰 갈등 해결",
+        "question_text": "코드 리뷰에서 다른 개발자와 기술적으로 의견이 강하게 충돌한 적이 있으신가요? 어떻게 해결하셨나요?",
+        "why_matters": "기술적 갈등을 건설적으로 해결하는 능력은 팀 코드 품질과 협업 문화를 좌우합니다",
+        "listen_for": "상대방 논점 이해, 객관적 근거 제시, 합의점 도출, 감정 관리",
+        "is_risk": false,
+        "answer_keywords": [
+          {"keyword": "객관적 근거", "importance": "must", "explanation": "감정이 아닌 데이터/벤치마크 기반 논의"},
+          {"keyword": "합의 과정", "importance": "must", "explanation": "일방적 주장이 아닌 협의를 통한 결론"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 20,
+            "text": "동료가 모든 서비스 간 통신을 gRPC로 전환하자고 했는데, 저는 내부 마이크로서비스 간에만 gRPC를 쓰고 외부 API는 REST를 유지해야 한다고 봤습니다. PR 코멘트에서 길어져서, 30분 페어 세션을 잡아서 각자 근거를 정리했습니다. 저는 외부 파트너사 3곳이 모두 REST만 지원하고 gRPC 클라이언트를 제공하면 우리 유지보수 부담이 커진다는 걸 보여줬고, 동료는 내부 호출의 직렬화 성능 벤치마크를 보여줬습니다. 결국 내부는 gRPC, 외부는 REST로 합의했고, 이 결정을 ADR(Architecture Decision Record)에 기록했습니다.",
+            "depth_expectations": "구체적 기술적 근거 + 체면이 아닌 논리 중심 + 문서화"
+          },
+          {
+            "level": "Mid",
+            "score": 12,
+            "text": "코드 리뷰에서 네이밍 컨벤션으로 의견이 갈렸는데, 팀 컨벤션 문서를 확인해서 그걸 따르기로 했습니다. 크게 다투지는 않았습니다.",
+            "depth_expectations": "갈등 해결은 했으나 기술적 깊이나 주도적 합의 과정 부족"
+          },
+          {
+            "level": "Low",
+            "score": 5,
+            "text": "의견이 다르면 시니어 개발자의 의견을 따랐습니다. 경험이 더 많으신 분의 판단이 맞을 거라고 생각했습니다.",
+            "depth_expectations": "자기 의견 부재, 권위에 의존"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "만약 벤치마크 결과가 상대방의 의견을 더 지지했다면 어떻게 하셨을 것 같으세요?",
+            "why_matters": "데이터 앞에서 의견을 바꿀 수 있는 유연성",
+            "listen_for": "객관적 수용 태도, 학습 자세",
+            "good": {"text": "데이터가 반대를 보여주면 당연히 제 의견을 수정합니다. 실제로 그 프로젝트에서 다른 이슈에서 제가 틀렸던 적도 있고, 그때 바로 인정하고 동료 방식을 따랐습니다.", "score": 8},
+            "poor": {"text": "그래도 제 경험상 REST가 나았을 겁니다.", "score": 2}
+          }
+        ],
+        "terminology": [
+          {"term": "ADR (Architecture Decision Record)", "definition": "팀에서 내린 중요한 기술적 결정과 그 이유를 기록한 문서. 회의록처럼 나중에 '왜 이렇게 했지?'를 찾아볼 수 있습니다", "pronunciation": "에이디알"},
+          {"term": "gRPC", "definition": "구글이 만든 빠른 통신 방식. 일반 편지(REST) 대신 전용 택배(gRPC)를 쓰면 빠르지만 모든 곳에서 받아주진 않습니다", "pronunciation": "지알피씨"}
+        ],
+        "interviewer_note": {
+          "business_interpretation": "기술적 갈등을 건설적으로 해결하면 더 나은 아키텍처 결정이 나옵니다. 갈등을 피하면 기술 부채가 쌓입니다.",
+          "daily_analogy": "맛집 고를 때 '내가 좋으니까 여기'가 아니라 '리뷰 점수, 거리, 예산'을 비교해서 함께 결정하는 것과 같습니다",
+          "level_expectation": "시니어: 객관적 근거 + 합의 문서화 + 유연성 | 주니어: 자기 의견 제시 + 상대 의견 경청"
+        }
+      }
+      ```
+
+      # LIMITATIONS
+      - NEVER create questions that can be answered without referencing actual interactions with others
+      - NEVER accept answers without specific counterpart reactions or outcomes
+      - Expert answers MUST include actual dialogue, quotes, or specific communication strategies used
+      - Follow-ups should test adaptability and listening, not just speaking ability
+
+      REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
+
+  craft_question_risk_flags:
+    description: "위험 신호 검증 질문 생성 — 비판단적 톤, 객관적 확인, 우려사항 탐색"
+    template: |
+      # CRITICAL OUTPUT RULES (READ FIRST)
+      - Return ONLY raw JSON, NO markdown formatting
+      - Do NOT wrap output in ```json or ``` code blocks
+      - Start your response with { and end with }
+      - No explanatory text before or after the JSON
+
+      # ROLE & GOAL
+      You are an experienced interviewer skilled at surfacing concerns without creating defensiveness.
+      Generate a risk verification question in {{output_language}} that explores potential
+      red flags while maintaining a respectful, non-judgmental tone.
+
+      # CATEGORY: RISK_FLAGS (위험 신호 검증)
+      This question assesses: career gaps, job hopping, skill gaps, inconsistencies, cultural misalignment.
+
+      ## QUESTION DESIGN GUIDELINES
+      1. **비판단적 톤**: "왜 자주 옮기셨나요?"(X) → "각 이직의 배경을 말씀해주시겠어요?"(O)
+      2. **객관적 확인**: 우려사항의 실제 원인을 파악하라 (외부 요인 vs 본인 패턴)
+      3. **방어 유발 금지**: 후보자가 방어적이 되면 진실한 답변을 얻기 어려움
+      4. **재발 가능성 탐색**: 과거 패턴이 앞으로도 반복될 가능성을 간접적으로 확인하라
+
+      ## ANSWER EVALUATION CRITERIA
+      - Expert: 구체적 사유 + 외부/내부 요인 구분 + 배운 점 + 재발 방지 근거 제시
+      - Mid: 사유는 있으나 구체성 부족, 향후 계획이 모호
+      - Low: 방어적/회피적 태도, 남 탓, 구체적 사유 없음
+
+      # TOPIC DETAILS
+      Topic: {{topic}}
+      Category: {{category}}
+      Difficulty: {{difficulty}}
+      Experience Level: {{experience_level}}
+
+      {{evidence_context}}
+      {{recommended_probe}}
+
+      # OUTPUT FORMAT (v2 JSON)
+      Return a JSON object with: title, question_text, why_matters, listen_for, is_risk (usually true),
+      answer_keywords[], scenarios[] (Expert/Mid/Low with score and text),
+      follow_ups[] (with trigger, good/poor examples), terminology[], interviewer_note.
+
+      # FEW-SHOT EXAMPLE 1: "경력 공백 기간 확인"
+      Topic: "1년 경력 공백 기간에 대한 확인" (from Resume: 2023.03-2024.03 공백)
+      Category: risk_flags
+      Difficulty: Medium
+
+      ```json
+      {
+        "title": "경력 공백 확인",
+        "question_text": "이력서를 보니 2023년부터 약 1년간 경력 공백이 있으신데, 그 기간에 어떤 활동을 하셨는지 편하게 말씀해주시겠어요?",
+        "why_matters": "경력 공백의 실제 사유와 복귀 준비 상태를 파악합니다",
+        "listen_for": "솔직한 사유, 기간 중 활동, 현재 업무 준비 상태, 자기 인식",
+        "is_risk": true,
+        "answer_keywords": [
+          {"keyword": "구체적 사유", "importance": "must", "explanation": "공백의 실제 원인"},
+          {"keyword": "기간 중 활동", "importance": "must", "explanation": "자기개발이나 회복 노력"},
+          {"keyword": "복귀 준비", "importance": "good_to_have", "explanation": "현재 업무 준비 상태"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 18,
+            "text": "3년간 온콜 로테이션과 야근이 계속되면서 번아웃이 왔습니다. 처음 3개월은 완전히 쉬면서 체력을 회복했고, 이후 6개월은 평소 관심 있던 Rust를 독학하며 CLI 도구 2개를 만들었습니다. GitHub에 올린 프로젝트가 Star 120개를 받았습니다. 마지막 3개월은 오픈소스 프로젝트에 기여하면서 협업 감각을 회복했습니다. 이 경험으로 지속 가능한 페이스의 중요성을 깨달았고, 워라밸을 중시하면서도 성과를 내는 팀에서 일하고 싶습니다.",
+            "depth_expectations": "솔직한 사유 + 기간별 구체적 활동 + 결과물 + 배운 점 + 향후 기준"
+          },
+          {
+            "level": "Mid",
+            "score": 10,
+            "text": "개인 사정으로 쉬었습니다. 쉬는 동안 온라인 강의를 듣고 공부를 했습니다. 이제 다시 일할 준비가 됐습니다.",
+            "depth_expectations": "사유가 모호하고 활동이 구체적이지 않음"
+          },
+          {
+            "level": "Low",
+            "score": 3,
+            "text": "좀 쉬고 싶어서 쉬었습니다. 특별히 한 건 없습니다.",
+            "depth_expectations": "자기개발 노력 없음, 복귀 준비 불명확"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "번아웃을 경험하신 후 업무 방식에서 구체적으로 바꾼 점이 있으신가요?",
+            "why_matters": "같은 패턴 반복 가능성 평가",
+            "listen_for": "구체적 변화, 경계 설정, 자기 관리 전략",
+            "good": {"text": "온콜을 혼자 다 맡지 않고 팀 로테이션을 제안하기로 했고, 주 50시간이 넘으면 매니저에게 리소스 조정을 요청하기로 정했습니다. 이전에는 거절을 못 했는데, 이제는 우선순위를 명확히 하고 스코프를 조정하는 게 오히려 팀에 도움이 된다는 걸 알았습니다.", "score": 8},
+            "poor": {"text": "이번에는 너무 무리하지 않으려고 합니다.", "score": 2}
+          },
+          {
+            "id": "q-f2",
+            "trigger": "Mid",
+            "question_text": "쉬시는 동안 들었던 온라인 강의 중에 가장 도움이 됐던 건 무엇인가요?",
+            "why_matters": "학습 활동의 구체성 확인",
+            "listen_for": "구체적 강의명, 적용 내용, 결과물",
+            "good": {"text": "Udemy에서 시스템 디자인 강의를 듣고, 실습으로 URL 단축 서비스를 직접 설계해봤습니다. Redis를 처음 써봤는데 캐싱 패턴을 이해하는 데 도움이 많이 됐습니다.", "score": 5},
+            "poor": {"text": "여러 개 들었는데 구체적으로 기억이 안 납니다.", "score": 1}
+          }
+        ],
+        "terminology": [],
+        "interviewer_note": {
+          "business_interpretation": "경력 공백 자체보다 그 기간의 활용과 복귀 준비가 중요합니다. 번아웃 후 자기 관리 전략을 갖춘 후보자는 오히려 지속 가능하게 일할 가능성이 높습니다.",
+          "daily_analogy": "운동선수가 부상 후 재활하는 기간처럼, 중요한 건 쉬었다는 사실이 아니라 어떻게 회복하고 돌아왔는지입니다",
+          "level_expectation": "시니어: 솔직한 사유 + 구체적 활동 + 재발 방지 전략 | 주니어: 학습 노력 + 복귀 의지"
+        }
+      }
+      ```
+
+      # FEW-SHOT EXAMPLE 2: "기술 스택 불일치 확인"
+      Topic: "JD 요구 기술과 경험 간 차이 확인" (from JD: Kubernetes 필수, Resume: Docker만 경험)
+      Category: risk_flags
+      Difficulty: Easy
+
+      ```json
+      {
+        "title": "기술 스택 차이 확인",
+        "question_text": "이 포지션에서는 Kubernetes 경험이 중요한데, 이력서에는 Docker 경험 위주로 적으셨네요. 컨테이너 오케스트레이션 관련 경험이 있으신지, 아니면 학습 계획이 있으신지 말씀해주시겠어요?",
+        "why_matters": "핵심 기술 스택 차이가 온보딩 기간과 팀 기여 속도에 영향을 미칩니다",
+        "listen_for": "현실적 자기 인식, 학습 계획 구체성, 관련 경험 연결, 습득 속도 근거",
+        "is_risk": true,
+        "answer_keywords": [
+          {"keyword": "자기 인식", "importance": "must", "explanation": "부족한 부분을 솔직히 인정하는 태도"},
+          {"keyword": "학습 계획", "importance": "must", "explanation": "구체적인 습득 전략"}
+        ],
+        "scenarios": [
+          {
+            "level": "Expert",
+            "score": 18,
+            "text": "Kubernetes를 프로덕션에서 직접 운영한 경험은 없습니다. 하지만 Docker Compose로 10개 이상의 서비스를 로컬에서 오케스트레이션한 경험이 있고, 네트워킹, 볼륨, 헬스체크 개념은 이해하고 있습니다. 개인적으로 minikube로 사이드 프로젝트를 배포해봤고, Pod, Service, Deployment 같은 기본 리소스는 YAML로 작성할 수 있습니다. 합류하면 첫 2주간 팀의 기존 Helm 차트를 분석하면서 배우겠습니다. 이전에도 새 기술을 3주 안에 실무 수준으로 올린 경험이 있습니다.",
+            "depth_expectations": "솔직한 인정 + 관련 기반 + 이미 시작한 학습 + 구체적 온보딩 계획"
+          },
+          {
+            "level": "Mid",
+            "score": 10,
+            "text": "Kubernetes는 아직 안 해봤는데 Docker는 잘 씁니다. Kubernetes도 빨리 배울 수 있을 것 같습니다. 온라인 강의를 보려고 합니다.",
+            "depth_expectations": "자신감은 있으나 학습 계획이 구체적이지 않음"
+          },
+          {
+            "level": "Low",
+            "score": 3,
+            "text": "Kubernetes는 잘 모릅니다. 회사에서 알려주시면 배우겠습니다.",
+            "depth_expectations": "수동적 학습 태도, 자기주도 계획 없음"
+          }
+        ],
+        "follow_ups": [
+          {
+            "id": "q-f1",
+            "trigger": "Expert",
+            "question_text": "minikube로 배포하면서 가장 어려웠던 부분은 무엇이었나요?",
+            "why_matters": "실제 학습 경험의 깊이 확인",
+            "listen_for": "구체적 문제, 해결 과정, 이해도",
+            "good": {"text": "서비스 간 통신에서 ClusterIP와 NodePort의 차이를 이해하는 게 어려웠습니다. Pod가 재시작될 때 IP가 바뀌어서 Service 리소스로 안정적인 엔드포인트를 만들어야 한다는 걸 직접 겪고 나서 이해했습니다.", "score": 8},
+            "poor": {"text": "설치가 좀 복잡했습니다.", "score": 2}
+          }
+        ],
+        "terminology": [
+          {"term": "Kubernetes (K8s)", "definition": "여러 서버에서 컨테이너를 자동으로 관리하는 시스템. 대형마트에서 직원(컨테이너) 배치, 교대, 결원 보충을 자동으로 해주는 매니저와 같습니다", "pronunciation": "쿠버네티스"}
+        ],
+        "interviewer_note": {
+          "business_interpretation": "기술 스택 차이 자체보다 학습 속도와 자기주도 학습 능력이 중요합니다. Docker 경험이 있으면 Kubernetes 온보딩이 빠릅니다.",
+          "daily_analogy": "수동 기어 운전 경험이 있는 사람이 자동 기어를 배우는 것 — 기본 운전 실력이 있으면 전환은 빠릅니다",
+          "level_expectation": "시니어: 관련 기반 경험 + 구체적 학습 계획 + 과거 학습 속도 근거 | 주니어: 솔직한 인정 + 학습 의지 + 기본적 시도"
+        }
+      }
+      ```
+
+      # LIMITATIONS
+      - NEVER use accusatory or judgmental tone ("왜 그만두셨나요?" → "어떤 배경이 있었나요?")
+      - NEVER treat risk flags as automatic disqualification — they're verification points
+      - Expert answers should turn risks INTO strengths (learned from experience)
+      - Follow-ups should assess FUTURE behavior patterns, not punish past ones
+
+      REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
+
   enhance_terminology:
     description: "질문 내 전문용어에 비개발자용 설명 추가"
     template: |

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -312,19 +312,36 @@ async def craft_question(
             logger.debug(f"KG evidence fetch failed for {topic.get('topic')}: {e}")
 
     from app.prompts import get_prompt
-    prompt = get_prompt(
-        "question_generation.yaml", "craft_question",
-        output_language=output_language,
-        experience_level=experience_level,
-        topic=topic.get("topic"),
-        category=topic.get("category"),
-        difficulty=topic.get("difficulty"),
-        evidence_context=evidence_context if evidence_context else "",
-        recommended_probe=recommended_probe if recommended_probe else "",
-    )
+    # 카테고리별 특화 프롬프트 선택 (fallback → 범용 craft_question)
+    category = topic.get("category", "technical_depth")
+    category_prompt_key = f"craft_question_{category}"
+    try:
+        prompt = get_prompt(
+            "question_generation.yaml", category_prompt_key,
+            output_language=output_language,
+            experience_level=experience_level,
+            topic=topic.get("topic"),
+            category=category,
+            difficulty=topic.get("difficulty"),
+            evidence_context=evidence_context if evidence_context else "",
+            recommended_probe=recommended_probe if recommended_probe else "",
+        )
+        logger.info(f"Using category-specific prompt: {category_prompt_key}")
+    except (KeyError, Exception) as e:
+        logger.warning(f"Category prompt '{category_prompt_key}' not found, falling back to generic: {e}")
+        prompt = get_prompt(
+            "question_generation.yaml", "craft_question",
+            output_language=output_language,
+            experience_level=experience_level,
+            topic=topic.get("topic"),
+            category=category,
+            difficulty=topic.get("difficulty"),
+            evidence_context=evidence_context if evidence_context else "",
+            recommended_probe=recommended_probe if recommended_probe else "",
+        )
 
     # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
-    result = await run_llm_with_heartbeat(llm, prompt, "craft_question", interval=30.0)
+    result = await run_llm_with_heartbeat(llm, prompt, category_prompt_key, interval=30.0)
 
     question = result if isinstance(result, dict) else {}
     # 고유 ID 강제 할당 — LLM이 중복 ID를 생성하는 문제 방지

--- a/backend/scripts/upload_prompts_to_langfuse.py
+++ b/backend/scripts/upload_prompts_to_langfuse.py
@@ -66,7 +66,12 @@ ACTIVITY_MODEL_CONFIG = {
     "code_synthesis_analysis": {"model": GLM_CODER_MODEL, "temperature": 0.5},
 
     # Phase 3: Question Generation (v2 format)
-    "craft_question": {"model": "openai:gpt-4o", "temperature": 0.7},  # 핵심 품질 유지
+    "craft_question": {"model": "openai:gpt-4o", "temperature": 0.7},  # 범용 fallback
+    "craft_question_role_fit": {"model": "openai:gpt-4o", "temperature": 0.7},
+    "craft_question_technical_depth": {"model": "openai:gpt-4o", "temperature": 0.7},
+    "craft_question_execution_ownership": {"model": "openai:gpt-4o", "temperature": 0.7},
+    "craft_question_communication": {"model": "openai:gpt-4o", "temperature": 0.7},
+    "craft_question_risk_flags": {"model": "openai:gpt-4o", "temperature": 0.6},
     "enhance_terminology": {"model": GLM_CHAT_MODEL, "temperature": 0.5},  # 단순 작업 GLM
     "craft_evaluation_scenarios": {"model": "openai:gpt-4o", "temperature": 0.6},
     "design_follow_ups": {"model": GLM_CHAT_MODEL, "temperature": 0.7},  # 단순 작업 GLM

--- a/backend/tests/test_question_generation.py
+++ b/backend/tests/test_question_generation.py
@@ -127,6 +127,106 @@ class TestCraftQuestion:
 
 
 # ============================================================
+# P3-02b: 카테고리별 프롬프트 라우팅 테스트
+# ============================================================
+
+class TestCraftQuestionCategoryRouting:
+    """P3-02b: 카테고리별 프롬프트 선택 검증"""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("category", [
+        "role_fit", "technical_depth", "execution_ownership", "communication", "risk_flags",
+    ])
+    async def test_category_specific_prompt_loaded(self, category, mock_aggregated_analysis, mock_enriched_input):
+        """각 카테고리별 전용 프롬프트가 정상 로딩되는지 검증"""
+        from app.prompts import get_prompt
+
+        prompt = get_prompt(
+            "question_generation.yaml", f"craft_question_{category}",
+            output_language="Korean",
+            experience_level="미들",
+            topic="테스트 토픽",
+            category=category,
+            difficulty="Medium",
+            evidence_context="",
+            recommended_probe="",
+        )
+        assert len(prompt) > 100, f"craft_question_{category} 프롬프트가 비어 있음"
+        assert category in prompt.lower() or "interview" in prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_category_routing_uses_correct_prompt(self, mock_aggregated_analysis, mock_enriched_input):
+        """craft_question이 카테고리에 맞는 프롬프트를 선택하는지 검증"""
+        from app.workflows.activities.question_generation import craft_question
+
+        captured_prompts = {}
+
+        async def mock_llm_run(prompt, **kwargs):
+            # 프롬프트 내용 캡처
+            captured_prompts["prompt"] = prompt
+            return {
+                "question_text": "테스트 질문",
+                "category": "role_fit",
+                "difficulty": "Medium",
+            }
+
+        categories_to_test = ["role_fit", "technical_depth", "communication"]
+        for cat in categories_to_test:
+            topic = {"category": cat, "topic": f"{cat} 테스트", "difficulty": "Medium"}
+            with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+                await craft_question(topic, mock_aggregated_analysis, mock_enriched_input)
+                # 카테고리별 프롬프트가 사용되었는지 확인 (프롬프트 내용에 카테고리 키워드 포함)
+                assert captured_prompts.get("prompt"), f"{cat} 프롬프트가 캡처되지 않음"
+
+    @pytest.mark.asyncio
+    async def test_unknown_category_falls_back_to_generic(self, mock_aggregated_analysis, mock_enriched_input):
+        """알 수 없는 카테고리는 범용 craft_question으로 fallback"""
+        from app.workflows.activities.question_generation import craft_question
+
+        topic = {
+            "category": "nonexistent_category",
+            "topic": "Unknown topic",
+            "difficulty": "Medium",
+        }
+
+        mock_question = {
+            "question_text": "Fallback question",
+            "category": "nonexistent_category",
+            "difficulty": "Medium",
+        }
+
+        async def mock_llm_run(prompt, **kwargs):
+            return mock_question
+
+        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+            result = await craft_question(topic, mock_aggregated_analysis, mock_enriched_input)
+            # fallback이 작동해서 결과가 반환되어야 함
+            assert "question_text" in result
+
+    @pytest.mark.asyncio
+    async def test_all_five_categories_produce_questions(self, mock_aggregated_analysis, mock_enriched_input):
+        """5개 카테고리 모두 질문 생성 성공"""
+        from app.workflows.activities.question_generation import craft_question
+
+        categories = ["role_fit", "technical_depth", "execution_ownership", "communication", "risk_flags"]
+
+        for cat in categories:
+            topic = {"category": cat, "topic": f"{cat} topic", "difficulty": "Medium"}
+
+            async def mock_llm_run(prompt, **kwargs):
+                return {
+                    "question_text": f"Question for {cat}",
+                    "category": cat,
+                    "difficulty": "Medium",
+                }
+
+            with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+                result = await craft_question(topic, mock_aggregated_analysis, mock_enriched_input)
+                assert result["category"] == cat, f"{cat} 카테고리 결과 불일치"
+                assert "id" in result, f"{cat} 질문에 ID 없음"
+
+
+# ============================================================
 # P3-03: 용어 설명 테스트
 # ============================================================
 


### PR DESCRIPTION
## Summary
- 5개 카테고리별 전용 craft_question 프롬프트 추가 (role_fit, technical_depth, execution_ownership, communication, risk_flags)
- 각 프롬프트에 현실적인 답변 예시 2개씩 Few-shot 포함 — 원론적 답변("잘하겠습니다") 대신 구체적 사례 기반
- craft_question Activity에 카테고리 라우팅 로직 + 범용 fallback 구현
- Langfuse 업로드 스크립트에 새 프롬프트 키 모델 설정 추가 및 업로드 완료

## Changed Files
| 파일 | 변경 |
|------|------|
| `question_generation.yaml` | 5개 카테고리별 프롬프트 + Few-shot 추가 |
| `question_generation.py` | 카테고리 라우팅 로직 (try category → fallback generic) |
| `upload_prompts_to_langfuse.py` | 5개 새 키 모델 설정 |
| `test_question_generation.py` | 8개 테스트 추가 (21/21 통과) |

## Test plan
- [x] 기존 13개 테스트 통과
- [x] 새 8개 테스트 통과 (프롬프트 로딩, 라우팅, fallback, 전체 카테고리)
- [x] Langfuse 업로드 성공 (13개 프롬프트, 에러 0건)
- [ ] 실제 Job 실행 후 카테고리별 질문 품질 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)