### PR TITLE
fix: LLM 시맨틱 스킬 매칭 + Kimi 모델 강제 + Nginx storage 수정

### DIFF
--- a/backend/app/prompts/v2_generation.yaml
+++ b/backend/app/prompts/v2_generation.yaml
@@ -98,6 +98,53 @@ prompts:
         }}
       }}
 
+  skill_matching:
+    description: "JD 요구사항 vs 후보자 스킬 시맨틱 매칭"
+    template: |
+      # CRITICAL OUTPUT RULES
+      - Return ONLY raw JSON array, NO markdown formatting
+      - Start your response with [ and end with ]
+
+      # ROLE
+      You are an expert technical recruiter performing semantic skill matching.
+
+      # TASK
+      Match each JD requirement against the candidate's actual skills from resume and code analysis.
+      Use semantic understanding: "Boto3" relates to "cloud infrastructure", "OpenAI SDK" relates to "LLM API development", etc.
+      Be honest: if a skill genuinely doesn't match, mark it as "none".
+
+      # OUTPUT LANGUAGE (CRITICAL)
+      Write ALL output text in {{output_language}}.
+      The fields "skill", "candidate", and "evidence" MUST be written in {{output_language}}.
+      JSON keys must remain in English.
+
+      # MATCH TYPES
+      - "exact": Direct match (e.g., "Python" ↔ "Python")
+      - "similar": Closely related skill (e.g., "API development" ↔ "FastAPI experience")
+      - "partial": Tangentially related (e.g., "Cloud services" ↔ "AWS S3 usage")
+      - "none": No meaningful connection
+
+      # INPUT
+      JD Requirements (top 6):
+      {{jd_requirements}}
+
+      Candidate Skills (Resume):
+      {{candidate_skills}}
+
+      Candidate Skills (GitHub code analysis):
+      {{code_skills}}
+
+      # OUTPUT FORMAT (JSON array, one per JD requirement)
+      [
+        {{
+          "skill": "JD requirement text in {{output_language}}",
+          "candidate": "matched candidate skill name, or '—' if none",
+          "type": "exact|similar|partial|none",
+          "evidence": "source: Resume|GitHub|No evidence",
+          "confidence": 0-100
+        }}
+      ]
+
   engineering_dna:
     description: "Engineering DNA 심층 분석"
     template: |

--- a/backend/app/services/llm_config.py
+++ b/backend/app/services/llm_config.py
@@ -98,6 +98,7 @@ ACTIVITY_MODEL_CONFIG: dict[str, str] = {
     "intel_competency_matching": KIMI_CHAT_MODEL,
     "radar_analysis": KIMI_CHAT_MODEL,
     "engineering_dna": KIMI_CHAT_MODEL,
+    "skill_matching": KIMI_CHAT_MODEL,
     "decision_summary": KIMI_CHAT_MODEL,
     "interviewer_tips": KIMI_CHAT_MODEL,
 }
@@ -122,6 +123,7 @@ MODEL_MAX_OUTPUT_TOKENS: dict[str, int] = {
     "openai:": 16384,
     "openai/": 16384,
     # Anthropic
+    "claude-3-haiku": 4096,       # Haiku 실제 제한
     "anthropic:": 8192,
     "anthropic/": 8192,
     # Gemini

--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -323,13 +323,88 @@ def _extract_risk_flags(
     return flags[:5]  # 최대 5개
 
 
+async def _llm_build_skill_table(
+    jd_analysis: dict,
+    code_analysis: dict | None,
+    document_analysis: dict,
+    output_language: str = "ko",
+    job_id: str | None = None,
+) -> list[SkillMatchRow] | None:
+    """LLM 기반 시맨틱 스킬 매칭 (실패 시 None 반환)"""
+    try:
+        from app.services.cached_llm import CachedLLMService
+        from app.prompts import get_prompt_with_config
+        from app.workflows.utils import run_llm_with_prompt_config_heartbeat
+
+        jd_requirements = jd_analysis.get("requirements", [])
+        if not jd_requirements:
+            return None
+
+        raw_candidate_skills = document_analysis.get("profile", {}).get("skills", [])
+        candidate_skills = (
+            list(raw_candidate_skills.keys()) if isinstance(raw_candidate_skills, dict)
+            else list(raw_candidate_skills) if raw_candidate_skills else []
+        )
+        code_skills = code_analysis.get("tech_stack", []) if code_analysis else []
+
+        jd_text = json.dumps(
+            [r.get("skill", r.get("text", "")) for r in jd_requirements[:6]],
+            ensure_ascii=False,
+        )
+        candidate_text = json.dumps(candidate_skills[:15], ensure_ascii=False) if candidate_skills else "[]"
+        code_text = json.dumps(list(code_skills)[:15], ensure_ascii=False) if code_skills else "[]"
+
+        prompt_config = get_prompt_with_config(
+            "v2_generation.yaml", "skill_matching",
+            jd_requirements=jd_text,
+            candidate_skills=candidate_text,
+            code_skills=code_text,
+            output_language=output_language,
+        )
+
+        # Langfuse 모델 오버라이드 방지 — Kimi 모델 강제 사용
+        from app.services.llm_config import KIMI_CHAT_MODEL
+        prompt_config.model = KIMI_CHAT_MODEL
+
+        llm = CachedLLMService()
+        result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
+
+        if not isinstance(result, list):
+            return None
+
+        valid_types = {"exact", "similar", "partial", "none"}
+        rows = []
+        for item in result[:6]:
+            if not isinstance(item, dict):
+                continue
+            match_type = item.get("type", "none")
+            if match_type not in valid_types:
+                match_type = "none"
+            rows.append(SkillMatchRow(
+                skill=item.get("skill", ""),
+                candidate=item.get("candidate", "—"),
+                type=match_type,
+                evidence=item.get("evidence", "No evidence"),
+                confidence=max(0, min(100, int(item.get("confidence", 0)))),
+            ))
+
+        if rows:
+            logger.info(f"LLM skill matching: {len(rows)} rows, avg confidence={sum(r.confidence for r in rows)//len(rows)}%")
+            return rows
+        return None
+
+    except Exception as e:
+        logger.warning(f"LLM skill matching failed, using fallback: {e}")
+        return None
+
+
 def _build_skill_table(
     jd_analysis: dict,
     code_analysis: dict | None,
     document_analysis: dict,
     lang: str = "ko",
 ) -> list[SkillMatchRow]:
-    """스킬 매칭 테이블 생성"""
+    """스킬 매칭 테이블 생성 (규칙 기반 fallback)"""
     rows = []
 
     jd_requirements = jd_analysis.get("requirements", [])
@@ -449,8 +524,14 @@ async def generate_deep_analysis(
     risk_flags = _extract_risk_flags(code_analysis, document_analysis, lang=output_language)
     activity.heartbeat()
 
-    # 4. 스킬 매칭 테이블 생성
-    skill_table = _build_skill_table(jd_analysis, code_analysis, document_analysis, lang=output_language)
+    # 4. 스킬 매칭 테이블 생성 (LLM 우선, 규칙 기반 fallback)
+    skill_table = await _llm_build_skill_table(
+        jd_analysis, code_analysis, document_analysis,
+        output_language=output_language, job_id=job_id,
+    )
+    if skill_table is None:
+        skill_table = _build_skill_table(jd_analysis, code_analysis, document_analysis, lang=output_language)
+    activity.heartbeat()
 
     # 전체 매칭 점수 계산
     if skill_table:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -40,8 +40,8 @@ server {
         proxy_read_timeout 86400;
     }
 
-    # Storage files (avatars, etc.) → backend
-    location /storage/ {
+    # Storage files (avatars, etc.) → backend (^~ prevents regex override)
+    location ^~ /storage/ {
         proxy_pass http://iaas-backend:8000/storage/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## 요약
- LLM 기반 시맨틱 스킬 매칭 구현 (기존 규칙 기반 substring 매칭은 JD 긴 문장 vs 단일 기술명 갭 브릿지 불가)
- Langfuse Haiku 모델 오버라이드 방지를 위해 Kimi 모델 명시적 강제 설정
- Nginx `^~` prefix로 정적 파일 캐싱 regex가 storage 라우트를 가로채는 문제 해결

## 테스트 결과
- **이전**: skill_table 6개 항목 모두 0%, overall_match: 0%
- **이후**: skill_table avg confidence 61%, overall_match: 61%
- Avatar 서빙: 404 → 200 OK (9270 bytes)

## 수정 파일
| 파일 | 변경 |
|------|------|
| `analysis_generation.py` | `_llm_build_skill_table()` 신규 + LLM-first 패턴 |
| `llm_config.py` | `skill_matching` Activity 모델 설정 + Haiku max_tokens 안전장치 |
| `v2_generation.yaml` | `skill_matching` 프롬프트 추가 |
| `nginx.conf` | `location ^~ /storage/` regex 오버라이드 방지 |

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)