### PR TITLE
refactor: CachedLLMService DRY + 상수화 + 선택적 캐시 무효화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,3 +372,189 @@ docker compose exec backend python scripts/create_test_job.py --dry-run
 3. LLM 호출 Activity는 `CachedLLMService` 사용 (Redis 캐시)
 4. 각 Phase 완료 시 checkpoint 저장
 5. `worker.py`에 새 Activity 등록 필수
+
+---
+
+## 🔄 Continuous Improvement Engine (지속적 개선 엔진)
+
+> **핵심 원칙**: 한 번의 개선으로 끝나지 않는다. 매 사이클마다 측정 → 분석 → 개선 → 검증을 반복하여 프로젝트 품질을 지속적으로 향상시킨다.
+
+### 개선 사이클 구조
+
+```
+┌─────────────────────────────────────────────┐
+│         CONTINUOUS IMPROVEMENT LOOP          │
+│                                             │
+│  ┌─────────┐    ┌─────────┐    ┌─────────┐ │
+│  │ MEASURE │ →  │ ANALYZE │ →  │ IMPROVE │ │
+│  │ (측정)  │    │ (분석)  │    │ (개선)  │ │
+│  └────↑────┘    └─────────┘    └────│────┘ │
+│       │                              │      │
+│  ┌────│────┐                   ┌────↓────┐ │
+│  │ REPORT │ ←──────────────── │ VERIFY  │ │
+│  │ (보고) │                   │ (검증)  │ │
+│  └─────────┘                   └─────────┘ │
+└─────────────────────────────────────────────┘
+```
+
+### 6대 개선 영역 (매 사이클 반복)
+
+#### 1. 성능 최적화 (`/improve --perf`)
+
+**백엔드:**
+- DB 쿼리: N+1 쿼리 탐지, 인덱스 활용도, 커넥션 풀 사용량
+- Redis 캐시: 히트율 측정, TTL 최적화, 메모리 사용량
+- API 응답: 엔드포인트별 p50/p95 응답시간 기록
+- LLM 호출: 토큰 사용량, 캐시 히트율, 모델별 비용 추적
+- Temporal: Activity 실행 시간, heartbeat 간격, 재시도 빈도
+
+**프론트엔드:**
+- 번들 사이즈: chunk별 크기 추적 (목표: 초기 <300KB)
+- 렌더링 성능: 불필요한 re-render 탐지, React.memo/useMemo 적용
+- 네트워크: API 호출 워터폴 분석, 캐싱 전략
+- Core Web Vitals: LCP <2.5s, FID <100ms, CLS <0.1
+
+**측정 명령:**
+```bash
+# 백엔드 API 응답시간
+docker compose exec backend python -c "from app.core.config import settings; print(settings)"
+# 프론트엔드 번들 분석
+cd frontend && npx vite-bundle-visualizer
+```
+
+#### 2. 보안 향상 (`/analyze --focus security`)
+
+**체크리스트 (OWASP Top 10 기반):**
+- [ ] A01 접근 제어: 모든 API 엔드포인트에 인증/인가 확인
+- [ ] A02 암호화: JWT 시크릿 강도, 비밀번호 해싱, HTTPS 강제
+- [ ] A03 주입: SQL injection, Command injection, YAML injection 방지
+- [ ] A04 설계: Rate limiting, 입력 크기 제한, 파일 업로드 유효성
+- [ ] A05 설정: 디버그 모드 비활성화, 기본 계정 제거, 헤더 보안
+- [ ] A06 취약 컴포넌트: 의존성 CVE 스캔 (`pip audit`, `npm audit`)
+- [ ] A07 인증: 세션 관리, 토큰 만료, OAuth PKCE
+- [ ] A08 무결성: Docker 이미지 검증, 의존성 잠금
+- [ ] A09 로깅: 보안 이벤트 로깅, 민감 데이터 마스킹
+- [ ] A10 SSRF: 외부 URL 검증 (GitHub/LinkedIn API 호출)
+
+**자동 스캔:**
+```bash
+docker compose exec backend pip audit --format json
+cd frontend && npm audit --json
+```
+
+#### 3. 에이전트 아웃풋 품질 향상
+
+**코드 분석 파이프라인 (`code_analyzer.py` + `code_analysis.py`):**
+- AST 분석: Python `ast`, JS/TS `tree-sitter` — 의미있는 메트릭 추출 확인
+- 기여도 분석: `PyDriller` — 커밋 빈도, 코드 변경량, 핫스팟 파일
+- 기술 스택: `requirements.txt`, `package.json`, `Dockerfile` 등에서 정확한 추출
+- 코드 품질: 복잡도 (cyclomatic), 테스트 커버리지 유무, 문서화 수준
+
+**레포 분석 데이터 품질 검증:**
+- [ ] tech_stack이 실제 사용 기술을 반영하는지
+- [ ] contributions가 의미있는 기여 패턴을 보여주는지
+- [ ] complexity_metrics가 코드 복잡도를 정확히 측정하는지
+- [ ] 분석 실패 시 fallback이 유의미한 데이터를 제공하는지
+
+**스킬 매칭 검증:**
+- [ ] JD 요구사항 ↔ 후보자 스킬 매칭 정확도
+- [ ] 매칭 confidence 값의 현실성
+- [ ] evidence 출처의 추적 가능성
+
+#### 4. UI/UX 프론트엔드 향상 + Playwright 테스트
+
+**UI/UX 점검:**
+- 디자인 일관성: 색상, 타이포그래피, 간격, 버튼 스타일 통일
+- 반응형: 모바일(375px), 태블릿(768px), 데스크탑(1280px) 검증
+- 접근성: WCAG 2.1 AA — 키보드 네비게이션, 스크린 리더, 색상 대비
+- 로딩 상태: 스켈레톤 UI, 에러 바운더리, 빈 상태 처리
+- i18n: 모든 사용자 대면 텍스트 번역 키 사용
+
+**Playwright 자동 테스트 플로우:**
+```
+1. OAuth 우회 로그인 → 토큰 직접 주입
+2. Job 목록 페이지 → Job 존재 확인
+3. Result 페이지 → 4탭 순회:
+   - Intel Brief: 후보자 정보 렌더링
+   - Deep Analysis: 레이더 차트 + 스킬 매칭
+   - Live Interview: 질문 카드 + 카테고리 배분
+   - Decision: 점수 + 추천 + 위험 평가
+4. 콘솔 에러 수집 → 0개 확인
+5. 스크린샷 캡처 → 이전 버전과 비교
+```
+
+#### 5. 아키텍처 최적화
+
+**디자인 패턴 적용:**
+- Strategy Pattern: LLM 모델 선택 (현재 if/else → 전략 패턴)
+- Factory Pattern: Activity 생성 (보일러플레이트 표준화)
+- Observer Pattern: 워크플로우 상태 변경 알림
+- Repository Pattern: 데이터 접근 계층 분리
+
+**하드코딩 제거:**
+- 매직 넘버 → 상수 파일 (`constants.py`) 또는 환경변수
+- 한국어 문자열 → `i18n_labels.py` `_t()` 함수
+- URL/경로 → 설정 파일 (`config.py`)
+- 모델명/온도 → `llm_config.py` 단일 소스
+
+**코드 구조:**
+- 300줄 초과 파일 분리 (SRP 적용)
+- 공통 로직 추출 → 유틸리티 모듈
+- 타입 힌트 100% 적용 (Python 함수 시그니처)
+- docstring 표준화 (Google style)
+
+#### 6. 선택적 캐시 무효화 전략
+
+**목표**: 문제되는 에이전트 로직만 캐시 초기화, 나머지는 기존 캐시 유지 → 토큰 절약
+
+**메커니즘:**
+```python
+# 캐시 키 구조: {activity_name}:{input_hash}
+# 예: "generate_intel_brief:a1b2c3d4"
+
+# 특정 Activity만 캐시 무효화
+async def invalidate_activity_cache(activity_name: str, job_id: str):
+    pattern = f"llm_cache:{activity_name}:*"
+    keys = await redis.keys(pattern)
+    await redis.delete(*keys)
+
+# 전체 Job의 특정 Phase만 재실행
+async def rerun_from_phase(job_id: str, phase: int):
+    # phase 이전 결과는 캐시 유지
+    # phase 이후만 캐시 삭제 + 재실행
+```
+
+**테스트 시 캐시 전략:**
+- 동일 입력값 → 기존 캐시 재사용 (토큰 0)
+- 로직 변경된 Activity → 해당 Activity + 하위 의존 Activity만 캐시 삭제
+- 프롬프트 변경 → Langfuse 프롬프트 버전 올리면 자동으로 새 캐시 생성
+
+### Git 워크플로우 (매 개선건마다)
+
+```
+1. gh issue create --title "개선: [영역] [구체적 설명]"
+2. git checkout -b improve/[영역]-[설명]
+3. 코드 수정 + 테스트
+4. git commit -m "improve: [설명] Closes #N"
+5. gh pr create + gh pr merge --merge
+6. git checkout main && git pull
+```
+
+### 개선 사이클 보고서 형식
+
+매 사이클 완료 시 다음 형식으로 보고:
+
+```markdown
+## 개선 사이클 #N 보고서
+
+### 측정 결과
+| 영역 | 이전 | 이후 | 변화 |
+|------|------|------|------|
+
+### 수정 내역
+| Issue | PR | 영역 | 설명 |
+|-------|-----|------|------|
+
+### 다음 사이클 목표
+- [ ] ...
+```

--- a/backend/app/services/cached_llm.py
+++ b/backend/app/services/cached_llm.py
@@ -14,6 +14,12 @@ from app.core.observability import get_current_trace_metadata, is_langfuse_enabl
 
 logger = logging.getLogger(__name__)
 
+# ─── 상수 ───────────────────────────────────────────────
+CACHE_TTL_SECONDS = 86400  # 24시간
+REDIS_MAX_CONNECTIONS = 20
+PROMPT_TRUNCATE_LIMIT = 5000  # Langfuse 로깅 시 프롬프트/출력 최대 길이
+OUTPUT_TRUNCATE_LIMIT = 5000
+
 # 모듈 레벨 Redis 연결 풀 싱글톤
 _redis_pool = None
 
@@ -25,7 +31,7 @@ async def _get_shared_redis():
         import redis.asyncio as aioredis
         _redis_pool = aioredis.from_url(
             settings.REDIS_URL,
-            max_connections=20,
+            max_connections=REDIS_MAX_CONNECTIONS,
             decode_responses=False,
         )
     return _redis_pool
@@ -100,11 +106,11 @@ def _log_llm_generation(
         except Exception:
             pass
 
-        output_str = str(output)[:5000] if output else None
+        output_str = str(output)[:OUTPUT_TRUNCATE_LIMIT] if output else None
         gen_kwargs = dict(
             name=activity_name or "llm_call",
             model=model_name,
-            input=prompt[:5000] if isinstance(prompt, str) else str(prompt)[:5000],
+            input=prompt[:PROMPT_TRUNCATE_LIMIT] if isinstance(prompt, str) else str(prompt)[:PROMPT_TRUNCATE_LIMIT],
             usage_details=usage_details,
             metadata={
                 **trace_meta,
@@ -249,9 +255,13 @@ def _parse_llm_json_response(data: Any) -> Any:
 
 
 class CachedLLMService:
-    """LLM 호출 결과를 Redis에 캐싱하는 래퍼"""
+    """LLM 호출 결과를 Redis에 캐싱하는 래퍼
 
-    def __init__(self, ttl: int = 86400):
+    DRY 패턴: 모든 run 메서드는 _execute_with_cache()를 통해 동작.
+    캐시 조회 → LLM 호출(폴백) → JSON 파싱 → Langfuse 로깅 → 캐시 저장
+    """
+
+    def __init__(self, ttl: int = CACHE_TTL_SECONDS):
         self.ttl = ttl
 
     async def _get_redis(self):
@@ -259,12 +269,7 @@ class CachedLLMService:
 
     @staticmethod
     def _model_settings(model: str | None = None, override_max_tokens: int | None = None):
-        """모델별 최적 ModelSettings 반환 (max_tokens 등)
-
-        Args:
-            model: LLM 모델명
-            override_max_tokens: Langfuse config 등에서 지정한 max_tokens (모델 기본값보다 우선)
-        """
+        """모델별 최적 ModelSettings 반환"""
         from pydantic_ai import ModelSettings
         from app.services.llm_config import get_max_output_tokens
         if override_max_tokens:
@@ -275,58 +280,66 @@ class CachedLLMService:
             max_tokens = settings.LLM_MAX_OUTPUT_TOKENS
         return ModelSettings(max_tokens=max_tokens)
 
-    def _cache_key(self, prompt: str, model: str, activity_name: str | None = None) -> str:
-        """Activity 컨텍스트를 포함한 캐시 키 생성
+    @staticmethod
+    def _make_cache_key(prompt: str, model: str, activity_name: str | None = None, job_id: str | None = None) -> str:
+        """캐시 키 생성 (Activity + Job 스코프 통합)
 
-        기존: llm_cache:SHA256(model:prompt)
-        개선: llm_cache:activity_name:SHA256(model:prompt)
+        키 형식:
+          글로벌:   llm_cache:{activity}:{hash}
+          잡스코프: llm_cache:job:{job_id}:{activity}:{hash}
         """
         content = f"{model}:{prompt}"
         hash_part = hashlib.sha256(content.encode()).hexdigest()
+        parts = ["llm_cache"]
+        if job_id:
+            parts.extend(["job", job_id])
         if activity_name:
-            return f"llm_cache:{activity_name}:{hash_part}"
-        return f"llm_cache:{hash_part}"
+            parts.append(activity_name)
+        parts.append(hash_part)
+        return ":".join(parts)
 
-    async def run(
+    # ─── 캐시 I/O (공통) ─────────────────────────────────
+
+    async def _cache_get(self, key: str, trace_meta: dict) -> Any | None:
+        """캐시에서 읽기. 히트 시 파싱된 데이터 반환, 미스 시 None."""
+        if not settings.LLM_CACHE_ENABLED:
+            return None
+        try:
+            redis = await self._get_redis()
+            cached = await redis.get(key)
+            if cached:
+                logger.debug(f"LLM cache hit: {key[:30]}...")
+                self._log_cache_event("hit", trace_meta)
+                return json.loads(cached)
+        except Exception as e:
+            logger.warning(f"Redis cache read failed: {e}")
+        self._log_cache_event("miss", trace_meta)
+        return None
+
+    async def _cache_set(self, key: str, data: Any) -> None:
+        """캐시에 저장."""
+        if not settings.LLM_CACHE_ENABLED:
+            return
+        try:
+            redis = await self._get_redis()
+            await redis.setex(key, self.ttl, json.dumps(data, default=str))
+        except Exception as e:
+            logger.warning(f"Redis cache write failed: {e}")
+
+    # ─── LLM 호출 (공통 — DRY 핵심) ─────────────────────
+
+    async def _call_llm_with_fallback(
         self,
         prompt: str,
-        model: str | None = None,
-        result_type: Any = None,
-        activity_name: str | None = None,
-    ) -> Any:
-        """LLM 호출 (캐시 우선) + Langfuse 추적
-
-        Args:
-            prompt: LLM 프롬프트
-            model: 명시적 모델명 (지정하면 activity_name보다 우선)
-            result_type: Pydantic 모델 (구조화 출력용)
-            activity_name: Activity 이름 (자동 모델 선택용)
-        """
-        if model is None and activity_name:
-            from app.services.llm_config import get_model_for_activity
-            model = get_model_for_activity(activity_name)
-        model = model or settings.LLM_MODEL
-        key = self._cache_key(prompt, model, activity_name)
-        trace_meta = get_current_trace_metadata()
-
-        # 캐시 조회 (LLM_CACHE_ENABLED일 때만)
-        if settings.LLM_CACHE_ENABLED:
-            try:
-                redis = await self._get_redis()
-                cached = await redis.get(key)
-                if cached:
-                    logger.debug(f"LLM cache hit: {key[:20]}...")
-                    self._log_cache_event("hit", trace_meta)
-                    return json.loads(cached)
-            except Exception as e:
-                logger.warning(f"Redis cache read failed: {e}")
-
-        self._log_cache_event("miss", trace_meta)
-
-        # LLM 호출 (폴백 체인: primary → fallback)
-        # asyncio.shield로 감싸서 Temporal Activity 취소로 인한 CancelledError 방지
+        model: str,
+        result_type: Any,
+        override_max_tokens: int | None = None,
+        trace_meta: dict | None = None,
+    ) -> tuple[Any, Any]:
+        """LLM 호출 + 폴백 + 결과 정규화. (data, run_result) 반환."""
         from app.services.llm_config import get_llm_agent
-        ms = self._model_settings(model)
+
+        ms = self._model_settings(model, override_max_tokens)
         try:
             agent = get_llm_agent(result_type=result_type, model=model)
             run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
@@ -337,7 +350,8 @@ class CachedLLMService:
             fallback_model = settings.LLM_FALLBACK_MODEL
             if fallback_model and fallback_model != model:
                 logger.warning(f"Primary LLM ({model}) failed: {primary_err}. Trying fallback: {fallback_model}")
-                self._log_fallback_event(model, fallback_model, trace_meta)
+                if trace_meta:
+                    self._log_fallback_event(model, fallback_model, trace_meta)
                 agent = get_llm_agent(result_type=result_type, model=fallback_model)
                 run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
             else:
@@ -350,28 +364,119 @@ class CachedLLMService:
         if hasattr(data, "model_dump"):
             data = data.model_dump()
 
-        # Parse JSON from string responses (handles markdown-wrapped JSON)
         data = _parse_llm_json_response(data)
+        return data, run_result
 
-        # Langfuse에 generation 기록 (비용 추적)
+    async def _execute_with_cache(
+        self,
+        prompt: str,
+        model: str,
+        cache_key: str,
+        trace_meta: dict,
+        result_type: Any = None,
+        activity_name: str | None = None,
+        override_max_tokens: int | None = None,
+    ) -> Any:
+        """캐시 조회 → LLM 호출 → Langfuse 로깅 → 캐시 저장 (공통 파이프라인)"""
+        # 1. 캐시 조회
+        cached = await self._cache_get(cache_key, trace_meta)
+        if cached is not None:
+            return cached
+
+        # 2. LLM 호출 + 폴백
+        data, run_result = await self._call_llm_with_fallback(
+            prompt, model, result_type, override_max_tokens, trace_meta,
+        )
+
+        # 3. Langfuse 로깅
         _log_llm_generation(
-            model=model,
-            prompt=prompt,
-            output=data,
-            run_result=run_result,
-            trace_meta=trace_meta,
+            model=model, prompt=prompt, output=data,
+            run_result=run_result, trace_meta=trace_meta,
             activity_name=activity_name,
         )
 
-        # 캐시 저장 (LLM_CACHE_ENABLED일 때만)
-        if settings.LLM_CACHE_ENABLED:
-            try:
-                redis = await self._get_redis()
-                await redis.setex(key, self.ttl, json.dumps(data, default=str))
-            except Exception as e:
-                logger.warning(f"Redis cache write failed: {e}")
-
+        # 4. 캐시 저장
+        await self._cache_set(cache_key, data)
         return data
+
+    # ─── 공개 API ────────────────────────────────────────
+
+    async def run(
+        self,
+        prompt: str,
+        model: str | None = None,
+        result_type: Any = None,
+        activity_name: str | None = None,
+    ) -> Any:
+        """LLM 호출 (캐시 우선) + Langfuse 추적"""
+        if model is None and activity_name:
+            from app.services.llm_config import get_model_for_activity
+            model = get_model_for_activity(activity_name)
+        model = model or settings.LLM_MODEL
+
+        return await self._execute_with_cache(
+            prompt=prompt,
+            model=model,
+            cache_key=self._make_cache_key(prompt, model, activity_name),
+            trace_meta=get_current_trace_metadata(),
+            result_type=result_type,
+            activity_name=activity_name,
+        )
+
+    async def run_for_job(
+        self,
+        job_id: str,
+        prompt: str,
+        model: str | None = None,
+        result_type: Any = None,
+        activity_name: str | None = None,
+    ) -> Any:
+        """Job 단위 캐시를 사용하는 LLM 호출 + Langfuse 추적"""
+        if model is None and activity_name:
+            from app.services.llm_config import get_model_for_activity
+            model = get_model_for_activity(activity_name)
+        model = model or settings.LLM_MODEL
+
+        return await self._execute_with_cache(
+            prompt=prompt,
+            model=model,
+            cache_key=self._make_cache_key(prompt, model, activity_name, job_id=job_id),
+            trace_meta={**get_current_trace_metadata(), "job_id": job_id},
+            result_type=result_type,
+            activity_name=activity_name,
+        )
+
+    async def run_with_prompt_config(
+        self,
+        prompt_config: Any,  # PromptWithConfig from app.prompts
+        result_type: Any = None,
+    ) -> Any:
+        """Langfuse PromptWithConfig를 사용하는 LLM 호출"""
+        prompt = prompt_config.prompt
+        model = prompt_config.model or settings.LLM_MODEL
+        prompt_name = prompt_config.name if prompt_config else None
+
+        trace_meta = get_current_trace_metadata()
+        trace_meta["prompt_source"] = prompt_config.source
+        trace_meta["prompt_name"] = prompt_config.name
+        if prompt_config.version:
+            trace_meta["prompt_version"] = prompt_config.version
+
+        config_max_tokens = None
+        if prompt_config.config:
+            config_max_tokens = prompt_config.config.get("max_output_tokens")
+
+        return await self._execute_with_cache(
+            prompt=prompt,
+            model=model,
+            cache_key=self._make_cache_key(prompt, model, prompt_name),
+            trace_meta=trace_meta,
+            result_type=result_type,
+            activity_name=prompt_name,
+            override_max_tokens=config_max_tokens,
+        )
+
+    # ─── Langfuse 이벤트 로깅 ────────────────────────────
 
     def _log_cache_event(self, event_type: str, metadata: dict):
         """Langfuse에 캐시 이벤트 기록"""
@@ -381,13 +486,10 @@ class CachedLLMService:
             client = get_langfuse_client()
             if client:
                 client.update_current_span(
-                    metadata={
-                        **metadata,
-                        "cache_event": event_type,
-                    }
+                    metadata={**metadata, "cache_event": event_type}
                 )
         except Exception:
-            pass  # 캐시 이벤트 로깅 실패는 무시
+            pass
 
     def _log_fallback_event(self, primary_model: str, fallback_model: str, metadata: dict):
         """Langfuse에 폴백 이벤트 기록"""
@@ -405,221 +507,35 @@ class CachedLLMService:
                     }
                 )
         except Exception:
-            pass  # 폴백 이벤트 로깅 실패는 무시
+            pass
+
+    # ─── 캐시 무효화 ────────────────────────────────────
 
     async def invalidate_for_job(self, job_id: str) -> int:
-        """특정 Job 관련 캐시 무효화 (Job 재시도 시 사용)
+        """특정 Job 관련 캐시 전체 무효화"""
+        return await self._invalidate_by_pattern(f"llm_cache:job:{job_id}:*")
 
-        Returns:
-            삭제된 키 수
+    async def invalidate_activity_cache(self, activity_name: str) -> int:
+        """특정 Activity의 글로벌 캐시 무효화 (선택적 재실행용)
+
+        예: 분석 로직을 수정한 후 해당 Activity만 캐시 삭제
         """
+        return await self._invalidate_by_pattern(f"llm_cache:{activity_name}:*")
+
+    async def invalidate_activity_for_job(self, job_id: str, activity_name: str) -> int:
+        """특정 Job의 특정 Activity 캐시만 무효화 (최소 범위 재실행)"""
+        return await self._invalidate_by_pattern(f"llm_cache:job:{job_id}:{activity_name}:*")
+
+    async def _invalidate_by_pattern(self, pattern: str) -> int:
+        """패턴 기반 캐시 삭제 (공통)"""
         try:
             redis = await self._get_redis()
-            # Job별 캐시 키 패턴 삭제
-            pattern = f"llm_cache:job:{job_id}:*"
             deleted = 0
             async for key in redis.scan_iter(match=pattern):
                 await redis.delete(key)
                 deleted += 1
-            logger.info(f"Invalidated {deleted} cache entries for job {job_id}")
+            logger.info(f"Invalidated {deleted} cache entries matching '{pattern}'")
             return deleted
         except Exception as e:
-            logger.warning(f"Cache invalidation failed for job {job_id}: {e}")
+            logger.warning(f"Cache invalidation failed for pattern '{pattern}': {e}")
             return 0
-
-    def _job_cache_key(self, job_id: str, prompt: str, model: str, activity_name: str | None = None) -> str:
-        """Job 단위 캐시 키 생성 (무효화 가능)"""
-        content = f"{model}:{prompt}"
-        hash_part = hashlib.sha256(content.encode()).hexdigest()
-        if activity_name:
-            return f"llm_cache:job:{job_id}:{activity_name}:{hash_part}"
-        return f"llm_cache:job:{job_id}:{hash_part}"
-
-    async def run_with_prompt_config(
-        self,
-        prompt_config: Any,  # PromptWithConfig from app.prompts
-        result_type: Any = None,
-    ) -> Any:
-        """Langfuse PromptWithConfig를 사용하는 LLM 호출
-
-        Langfuse에서 가져온 프롬프트의 config에 있는 model, temperature를 사용합니다.
-
-        Args:
-            prompt_config: PromptWithConfig 객체 (get_prompt_with_config 결과)
-            result_type: Pydantic 모델 (구조화 출력용)
-        """
-        prompt = prompt_config.prompt
-        # Langfuse config의 model 사용, 없으면 fallback
-        model = prompt_config.model or settings.LLM_MODEL
-        temperature = prompt_config.temperature
-        prompt_name = prompt_config.name if prompt_config else None
-
-        key = self._cache_key(prompt, model, prompt_name)
-        trace_meta = get_current_trace_metadata()
-
-        # Langfuse 프롬프트 소스 정보 추가
-        trace_meta["prompt_source"] = prompt_config.source
-        trace_meta["prompt_name"] = prompt_config.name
-        if prompt_config.version:
-            trace_meta["prompt_version"] = prompt_config.version
-
-        # 캐시 조회 (LLM_CACHE_ENABLED일 때만)
-        if settings.LLM_CACHE_ENABLED:
-            try:
-                redis = await self._get_redis()
-                cached = await redis.get(key)
-                if cached:
-                    logger.debug(f"LLM cache hit: {key[:20]}... (prompt: {prompt_config.name})")
-                    self._log_cache_event("hit", trace_meta)
-                    return json.loads(cached)
-            except Exception as e:
-                logger.warning(f"Redis cache read failed: {e}")
-
-        self._log_cache_event("miss", trace_meta)
-
-        # LLM 호출
-        from app.services.llm_config import get_llm_agent
-        # Langfuse config에서 max_output_tokens 추출 (있으면 모델 기본값보다 우선)
-        config_max_tokens = None
-        if prompt_config.config:
-            config_max_tokens = prompt_config.config.get("max_output_tokens")
-        ms = self._model_settings(model, override_max_tokens=config_max_tokens)
-        try:
-            # temperature가 있으면 agent에 전달
-            agent = get_llm_agent(result_type=result_type, model=model)
-            run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
-
-            logger.info(
-                f"LLM call: {prompt_config.name} (source={prompt_config.source}, "
-                f"model={model})"
-            )
-        except asyncio.CancelledError:
-            logger.warning(f"LLM call cancelled for model {model}")
-            raise
-        except Exception as primary_err:
-            fallback_model = settings.LLM_FALLBACK_MODEL
-            if fallback_model and fallback_model != model:
-                logger.warning(f"Primary LLM ({model}) failed: {primary_err}. Trying fallback: {fallback_model}")
-                self._log_fallback_event(model, fallback_model, trace_meta)
-                agent = get_llm_agent(result_type=result_type, model=fallback_model)
-                run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
-            else:
-                raise
-
-        # Pydantic AI v1.x uses .output, older versions use .data
-        data = getattr(run_result, 'output', None) or getattr(run_result, 'data', None)
-        if data is None:
-            raise ValueError(f"AgentRunResult has neither 'output' nor 'data' attribute: {type(run_result)}")
-        if hasattr(data, "model_dump"):
-            data = data.model_dump()
-
-        # Parse JSON from string responses (handles markdown-wrapped JSON)
-        data = _parse_llm_json_response(data)
-
-        # Langfuse에 generation 기록 (비용 추적)
-        _log_llm_generation(
-            model=model,
-            prompt=prompt,
-            output=data,
-            run_result=run_result,
-            trace_meta=trace_meta,
-            activity_name=prompt_name,
-        )
-
-        # 캐시 저장 (LLM_CACHE_ENABLED일 때만)
-        if settings.LLM_CACHE_ENABLED:
-            try:
-                redis = await self._get_redis()
-                await redis.setex(key, self.ttl, json.dumps(data, default=str))
-            except Exception as e:
-                logger.warning(f"Redis cache write failed: {e}")
-
-        return data
-
-    async def run_for_job(
-        self,
-        job_id: str,
-        prompt: str,
-        model: str | None = None,
-        result_type: Any = None,
-        activity_name: str | None = None,
-    ) -> Any:
-        """Job 단위 캐시를 사용하는 LLM 호출 + Langfuse 추적
-
-        Args:
-            job_id: Job ID
-            prompt: LLM 프롬프트
-            model: 명시적 모델명 (지정하면 activity_name보다 우선)
-            result_type: Pydantic 모델 (구조화 출력용)
-            activity_name: Activity 이름 (자동 모델 선택용)
-        """
-        if model is None and activity_name:
-            from app.services.llm_config import get_model_for_activity
-            model = get_model_for_activity(activity_name)
-        model = model or settings.LLM_MODEL
-        key = self._job_cache_key(job_id, prompt, model, activity_name)
-        trace_meta = {**get_current_trace_metadata(), "job_id": job_id}
-
-        # 캐시 조회 (LLM_CACHE_ENABLED일 때만)
-        if settings.LLM_CACHE_ENABLED:
-            try:
-                redis = await self._get_redis()
-                cached = await redis.get(key)
-                if cached:
-                    logger.debug(f"LLM job cache hit: {key[:30]}...")
-                    self._log_cache_event("hit", trace_meta)
-                    return json.loads(cached)
-            except Exception as e:
-                logger.warning(f"Redis cache read failed: {e}")
-
-        self._log_cache_event("miss", trace_meta)
-
-        # LLM 호출 (폴백 체인: primary → fallback)
-        # asyncio.shield로 감싸서 Temporal Activity 취소로 인한 CancelledError 방지
-        from app.services.llm_config import get_llm_agent
-        ms = self._model_settings(model)
-        try:
-            agent = get_llm_agent(result_type=result_type, model=model)
-            run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
-        except asyncio.CancelledError:
-            logger.warning(f"LLM call cancelled for model {model}")
-            raise
-        except Exception as primary_err:
-            fallback_model = settings.LLM_FALLBACK_MODEL
-            if fallback_model and fallback_model != model:
-                logger.warning(f"Primary LLM ({model}) failed: {primary_err}. Trying fallback: {fallback_model}")
-                self._log_fallback_event(model, fallback_model, trace_meta)
-                agent = get_llm_agent(result_type=result_type, model=fallback_model)
-                run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
-            else:
-                raise
-
-        # Pydantic AI v1.x uses .output, older versions use .data
-        data = getattr(run_result, 'output', None) or getattr(run_result, 'data', None)
-        if data is None:
-            raise ValueError(f"AgentRunResult has neither 'output' nor 'data' attribute: {type(run_result)}")
-        if hasattr(data, "model_dump"):
-            data = data.model_dump()
-
-        # Parse JSON from string responses (handles markdown-wrapped JSON)
-        data = _parse_llm_json_response(data)
-
-        # Langfuse에 generation 기록 (비용 추적)
-        _log_llm_generation(
-            model=model,
-            prompt=prompt,
-            output=data,
-            run_result=run_result,
-            trace_meta=trace_meta,
-            activity_name=activity_name,
-        )
-
-        # 캐시 저장 (LLM_CACHE_ENABLED일 때만)
-        if settings.LLM_CACHE_ENABLED:
-            try:
-                redis = await self._get_redis()
-                await redis.setex(key, self.ttl, json.dumps(data, default=str))
-            except Exception as e:
-                logger.warning(f"Redis cache write failed: {e}")
-
-        return data

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -103,7 +103,7 @@ async def analyze_code(
             repo_url=repo_url,
             job_id="",
             author=candidate_username,
-            since_years=3,
+            since_years=settings.GITHUB_ANALYSIS_YEARS,
             file_types=file_types,
         )
 


### PR DESCRIPTION
## Summary
- CachedLLMService의 `run()`, `run_for_job()`, `run_with_prompt_config()` 3개 메서드의 공통 로직(~240줄)을 `_execute_with_cache()` 단일 파이프라인으로 통합
- 매직넘버 상수화: `CACHE_TTL_SECONDS`, `REDIS_MAX_CONNECTIONS`, `PROMPT_TRUNCATE_LIMIT`, `OUTPUT_TRUNCATE_LIMIT`
- 선택적 캐시 무효화 API 추가: `invalidate_activity_cache()`, `invalidate_activity_for_job()`
- `code_analysis.py:106`의 `since_years=3` 하드코딩 버그 → `settings.GITHUB_ANALYSIS_YEARS` 수정

## Changes
| 파일 | 변경 |
|------|------|
| `cached_llm.py` | DRY 리팩터링 + 상수 추출 + 선택적 캐시 무효화 API |
| `code_analysis.py` | `since_years` 하드코딩 버그 수정 |
| `CLAUDE.md` | Continuous Improvement Engine 섹션 추가 |

## Test plan
- [ ] Docker 환경에서 워커 정상 기동 확인
- [ ] LLM 캐시 동작 (cache hit/miss) 로그 확인
- [ ] 기존 Job 재실행 시 캐시 히트 정상 동작

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)