### PR TITLE
perf: 워크플로우 병렬화 + 프론트엔드 렌더링 최적화

### DIFF
--- a/backend/app/api/routes/jobs.py
+++ b/backend/app/api/routes/jobs.py
@@ -2,6 +2,7 @@
 backend/app/api/routes/jobs.py
 Job CRUD API 엔드포인트
 """
+import asyncio
 import logging
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -88,7 +89,9 @@ async def get_job(
             from app.core.temporal import get_temporal_client
             client = await get_temporal_client()
             handle = client.get_workflow_handle(job.temporal_workflow_id)
-            progress = await handle.query("get_progress")
+            progress = await asyncio.wait_for(
+                handle.query("get_progress"), timeout=5.0
+            )
             result["progress"] = progress
 
             # Temporal 상태가 DB와 다르면 DB 동기화

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -152,16 +152,24 @@ class InterviewGenerationWorkflow:
                 )
 
             # Code Analysis (조건부) - HYBRID 병렬 처리
-            code_analysis_result = None
+            # JD/Doc 분석과 코드 분석을 동시에 실행하여 총 소요시간 단축
+            code_analysis_coro = None
             if phases.get("code_analysis"):
-                code_analysis_result = await self._run_parallel_code_analysis(
+                code_analysis_coro = self._run_parallel_code_analysis(
                     enriched=enriched,
                     raw_input=raw_input,
                     execution_plan=execution_plan,
                     job_id=job_id,
                 )
 
-            analysis_results = await asyncio.gather(*analysis_tasks)
+            # 모든 분석을 병렬 실행 (JD + Doc + Code)
+            if code_analysis_coro:
+                all_results = await asyncio.gather(*analysis_tasks, code_analysis_coro)
+                analysis_results = list(all_results[:-1])
+                code_analysis_result = all_results[-1]
+            else:
+                analysis_results = await asyncio.gather(*analysis_tasks)
+                code_analysis_result = None
 
             # Aggregate results
             analysis = {"jd_analysis": analysis_results[0]}

--- a/frontend/src/components/charts/RadarChart.tsx
+++ b/frontend/src/components/charts/RadarChart.tsx
@@ -3,6 +3,7 @@
  *
  * Uses pure SVG for rendering without external dependencies.
  */
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface RadarChartProps {
@@ -36,71 +37,101 @@ export function RadarChart({
   const angleStep = (2 * Math.PI) / numAxes
   const startAngle = -Math.PI / 2 // Start from top
 
-  // Calculate point position on radar
-  const getPoint = (value: number, axisIndex: number): { x: number; y: number } => {
-    const angle = startAngle + axisIndex * angleStep
-    const radius = (value / 100) * maxRadius
-    return {
-      x: center + radius * Math.cos(angle),
-      y: center + radius * Math.sin(angle)
+  // Memoize expensive geometry calculations
+  const geometry = useMemo(() => {
+    const getPoint = (value: number, axisIndex: number) => {
+      const angle = startAngle + axisIndex * angleStep
+      const radius = (value / 100) * maxRadius
+      return {
+        x: center + radius * Math.cos(angle),
+        y: center + radius * Math.sin(angle)
+      }
     }
-  }
 
-  // Generate polygon points string
-  const getPolygonPoints = (data: number[]): string => {
-    return data
-      .map((value, i) => {
+    const getPolygonPoints = (data: number[]): string =>
+      data.map((value, i) => {
         const point = getPoint(value, i)
         return `${point.x},${point.y}`
-      })
-      .join(' ')
-  }
+      }).join(' ')
 
-  // Generate grid lines
-  const gridLevels = [20, 40, 60, 80, 100]
+    const gridLevels = [20, 40, 60, 80, 100]
+    const gridPolygons = gridLevels.map((level) => {
+      const radius = (level / 100) * maxRadius
+      const points = Array.from({ length: numAxes }, (_, i) => {
+        const angle = startAngle + i * angleStep
+        return `${center + radius * Math.cos(angle)},${center + radius * Math.sin(angle)}`
+      }).join(' ')
+      return { level, points }
+    })
+
+    const axisLines = Array.from({ length: numAxes }, (_, i) => {
+      const angle = startAngle + i * angleStep
+      return {
+        index: i,
+        endX: center + maxRadius * Math.cos(angle),
+        endY: center + maxRadius * Math.sin(angle),
+      }
+    })
+
+    const candidatePoints = candidateData.map((value, i) => ({
+      ...getPoint(value, i),
+      value,
+      index: i,
+    }))
+
+    const labelPositions = Array.from({ length: numAxes }, (_, i) => {
+      const angle = startAngle + i * angleStep
+      const labelRadius = maxRadius + 25
+      let textAnchor: 'start' | 'middle' | 'end' = 'middle'
+      if (Math.cos(angle) > 0.3) textAnchor = 'start'
+      else if (Math.cos(angle) < -0.3) textAnchor = 'end'
+      return {
+        x: center + labelRadius * Math.cos(angle),
+        y: center + labelRadius * Math.sin(angle),
+        textAnchor,
+      }
+    })
+
+    return {
+      gridPolygons,
+      axisLines,
+      requiredPolygon: getPolygonPoints(requiredData),
+      candidatePolygon: getPolygonPoints(candidateData),
+      candidatePoints,
+      labelPositions,
+    }
+  }, [candidateData, requiredData, size, center, maxRadius, angleStep, startAngle])
 
   return (
     <div className="relative w-full max-w-[320px] mx-auto">
       <svg viewBox={`0 0 ${size} ${size}`} className="w-full h-auto">
         {/* Background grid circles */}
-        {gridLevels.map((level) => {
-          const radius = (level / 100) * maxRadius
-          const points = Array.from({ length: numAxes }, (_, i) => {
-            const angle = startAngle + i * angleStep
-            return `${center + radius * Math.cos(angle)},${center + radius * Math.sin(angle)}`
-          }).join(' ')
-          return (
-            <polygon
-              key={level}
-              points={points}
-              fill="none"
-              stroke="#e5e7eb"
-              strokeWidth={1}
-            />
-          )
-        })}
+        {geometry.gridPolygons.map(({ level, points }) => (
+          <polygon
+            key={level}
+            points={points}
+            fill="none"
+            stroke="#e5e7eb"
+            strokeWidth={1}
+          />
+        ))}
 
         {/* Axis lines */}
-        {Array.from({ length: numAxes }, (_, i) => {
-          const angle = startAngle + i * angleStep
-          const endX = center + maxRadius * Math.cos(angle)
-          const endY = center + maxRadius * Math.sin(angle)
-          return (
-            <line
-              key={i}
-              x1={center}
-              y1={center}
-              x2={endX}
-              y2={endY}
-              stroke="#d1d5db"
-              strokeWidth={1}
-            />
-          )
-        })}
+        {geometry.axisLines.map(({ index, endX, endY }) => (
+          <line
+            key={index}
+            x1={center}
+            y1={center}
+            x2={endX}
+            y2={endY}
+            stroke="#d1d5db"
+            strokeWidth={1}
+          />
+        ))}
 
         {/* Required polygon (background) */}
         <polygon
-          points={getPolygonPoints(requiredData)}
+          points={geometry.requiredPolygon}
           fill="rgba(99, 102, 241, 0.2)"
           stroke="#6366f1"
           strokeWidth={2}
@@ -110,7 +141,7 @@ export function RadarChart({
 
         {/* Candidate polygon (foreground) */}
         <polygon
-          points={getPolygonPoints(candidateData)}
+          points={geometry.candidatePolygon}
           fill="rgba(16, 185, 129, 0.3)"
           stroke="#10b981"
           strokeWidth={2}
@@ -118,61 +149,45 @@ export function RadarChart({
         />
 
         {/* Data points with hover tooltip */}
-        {candidateData.map((value, i) => {
-          const point = getPoint(value, i)
-          return (
-            <g key={i}>
-              {/* Larger invisible hit area for hover */}
-              <circle
-                cx={point.x}
-                cy={point.y}
-                r={10}
-                fill="transparent"
-                style={{ cursor: 'pointer' }}
-              >
-                <title>{resolvedLabels[i]}: {value} ({t('radar_required')}: {requiredData[i]})</title>
-              </circle>
-              <circle
-                cx={point.x}
-                cy={point.y}
-                r={4}
-                fill="#10b981"
-                stroke="white"
-                strokeWidth={2}
-                style={{ transition: 'r 0.2s ease' }}
-                className="hover:r-6"
-              >
-                <title>{resolvedLabels[i]}: {value} ({t('radar_required')}: {requiredData[i]})</title>
-              </circle>
-            </g>
-          )
-        })}
+        {geometry.candidatePoints.map(({ x, y, value, index: i }) => (
+          <g key={i}>
+            <circle
+              cx={x}
+              cy={y}
+              r={10}
+              fill="transparent"
+              style={{ cursor: 'pointer' }}
+            >
+              <title>{resolvedLabels[i]}: {value} ({t('radar_required')}: {requiredData[i]})</title>
+            </circle>
+            <circle
+              cx={x}
+              cy={y}
+              r={4}
+              fill="#10b981"
+              stroke="white"
+              strokeWidth={2}
+              style={{ transition: 'r 0.2s ease' }}
+              className="hover:r-6"
+            >
+              <title>{resolvedLabels[i]}: {value} ({t('radar_required')}: {requiredData[i]})</title>
+            </circle>
+          </g>
+        ))}
 
         {/* Labels */}
-        {resolvedLabels.map((label, i) => {
-          const angle = startAngle + i * angleStep
-          const labelRadius = maxRadius + 25
-          const x = center + labelRadius * Math.cos(angle)
-          const y = center + labelRadius * Math.sin(angle)
-
-          // Adjust text anchor based on position
-          let textAnchor: 'start' | 'middle' | 'end' = 'middle'
-          if (Math.cos(angle) > 0.3) textAnchor = 'start'
-          else if (Math.cos(angle) < -0.3) textAnchor = 'end'
-
-          return (
-            <text
-              key={i}
-              x={x}
-              y={y}
-              textAnchor={textAnchor}
-              dominantBaseline="middle"
-              className="fill-gray-600 text-xs font-medium"
-            >
-              {label}
-            </text>
-          )
-        })}
+        {resolvedLabels.map((label, i) => (
+          <text
+            key={i}
+            x={geometry.labelPositions[i].x}
+            y={geometry.labelPositions[i].y}
+            textAnchor={geometry.labelPositions[i].textAnchor}
+            dominantBaseline="middle"
+            className="fill-gray-600 text-xs font-medium"
+          >
+            {label}
+          </text>
+        ))}
       </svg>
 
       {/* Legend */}

--- a/frontend/src/components/tabs/DecisionTab.tsx
+++ b/frontend/src/components/tabs/DecisionTab.tsx
@@ -1,7 +1,7 @@
 /**
  * DecisionTab - JD Competency Achievement + Hiring Recommendation
  */
-import { useState } from 'react'
+import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DecisionSupport, Candidate, CategoryWeights, RiskFlag } from '../../types/interview'
 
@@ -14,7 +14,7 @@ interface DecisionTabProps {
   riskFlags?: RiskFlag[]
 }
 
-export function DecisionTab({
+export const DecisionTab = memo(function DecisionTab({
   decision,
   candidate,
   categoryWeights,
@@ -337,4 +337,4 @@ export function DecisionTab({
       </div>
     </div>
   )
-}
+})

--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -1,6 +1,7 @@
 /**
  * DeepAnalysisTab - Radar Chart + Engineering DNA + Skill Matching Table
  */
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DeepAnalysis } from '../../types/interview'
 import { RadarChart, ProgressBarGroup } from '../charts'
@@ -9,7 +10,7 @@ interface DeepAnalysisTabProps {
   analysis: DeepAnalysis
 }
 
-export function DeepAnalysisTab({ analysis }: DeepAnalysisTabProps) {
+export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepAnalysisTabProps) {
   const { t } = useTranslation()
   const { radar_candidate, radar_required, engineering_dna, risk_flags, skill_table, overall_match } = analysis
 
@@ -180,4 +181,4 @@ export function DeepAnalysisTab({ analysis }: DeepAnalysisTabProps) {
       )}
     </div>
   )
-}
+})

--- a/frontend/src/components/tabs/IntelBriefTab.tsx
+++ b/frontend/src/components/tabs/IntelBriefTab.tsx
@@ -1,6 +1,7 @@
 /**
  * IntelBriefTab - JD Analysis + GitHub Chart + LinkedIn Timeline + Competency Matching
  */
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { IntelBrief, Candidate } from '../../types/interview'
 import { ContributionChart } from '../charts'
@@ -11,7 +12,7 @@ interface IntelBriefTabProps {
   techStack?: string[]
 }
 
-export function IntelBriefTab({ intel, candidate, techStack }: IntelBriefTabProps) {
+export const IntelBriefTab = memo(function IntelBriefTab({ intel, candidate, techStack }: IntelBriefTabProps) {
   const { t } = useTranslation()
   const { jd_summary, competencies, github, linkedin, linkedin_warning } = intel
 
@@ -319,4 +320,4 @@ export function IntelBriefTab({ intel, candidate, techStack }: IntelBriefTabProp
       )}
     </div>
   )
-}
+})

--- a/frontend/src/components/tabs/LiveInterviewTab.tsx
+++ b/frontend/src/components/tabs/LiveInterviewTab.tsx
@@ -1,7 +1,7 @@
 /**
  * LiveInterviewTab - Question Selection → Interactive Scoring → Follow-up Branching
  */
-import { useState, useMemo } from 'react'
+import { memo, useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type {
   InterviewQuestion,
@@ -15,7 +15,7 @@ interface LiveInterviewTabProps {
   categoryWeights?: CategoryWeights
 }
 
-export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTabProps) {
+export const LiveInterviewTab = memo(function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTabProps) {
   const { t } = useTranslation()
 
   // Deduplicate questions by ID — backend generates UUID-based IDs,
@@ -446,4 +446,4 @@ export function LiveInterviewTab({ questions, categoryWeights }: LiveInterviewTa
       </div>
     </div>
   )
-}
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,4 +17,16 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    reportCompressedSize: true,
+    chunkSizeWarningLimit: 500,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-i18n': ['i18next', 'react-i18next'],
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Phase 2 코드 분석을 JD/Doc 분석과 asyncio.gather로 병렬 실행하여 워크플로우 총 소요시간 단축
- Temporal 쿼리에 5초 타임아웃 추가하여 무한 대기 방지
- RadarChart useMemo + 4개 탭 React.memo로 불필요한 리렌더링 제거
- Vite vendor 청크 분리로 초기 로드 최적화

## Test plan
- [ ] Job 생성 후 워크플로우 완료 확인 (Phase 2 병렬 실행)
- [ ] Job 상태 조회 API 타임아웃 동작 확인
- [ ] 프론트엔드 빌드 성공 확인 (`npm run build`)
- [ ] ResultPage 4개 탭 렌더링 정상 확인
- [ ] RadarChart 데이터 변경 시 정상 업데이트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)