### PR TITLE
sec: OWASP 기반 보안 강화 5가지 수정

### DIFF
--- a/backend/app/api/routes/internal.py
+++ b/backend/app/api/routes/internal.py
@@ -2,6 +2,7 @@
 backend/app/api/routes/internal.py
 Internal API - Activity에서 사용하는 내부 엔드포인트
 """
+import hmac
 import logging
 from typing import Optional
 
@@ -21,7 +22,9 @@ async def verify_internal_token(
 ) -> None:
     """Worker → Backend 내부 API 인증"""
     if not settings.is_local:
-        if not x_internal_token or x_internal_token != settings.INTERNAL_API_TOKEN:
+        if not x_internal_token or not hmac.compare_digest(
+            x_internal_token, settings.INTERNAL_API_TOKEN
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid internal API token",

--- a/backend/app/api/routes/jobs.py
+++ b/backend/app/api/routes/jobs.py
@@ -60,7 +60,9 @@ async def create_job(
 
 
 @router.get("")
+@limiter.limit("60/minute")
 async def list_jobs(
+    request: Request,
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
     user: UserDB = Depends(get_current_user_or_api_key),
@@ -72,7 +74,9 @@ async def list_jobs(
 
 
 @router.get("/{job_id}")
+@limiter.limit("120/minute")
 async def get_job(
+    request: Request,
     job_id: str,
     user: UserDB = Depends(get_current_user_or_api_key),
     db: AsyncSession = Depends(get_db),
@@ -232,7 +236,9 @@ async def retry_job(
 
 
 @router.get("/{job_id}/checkpoints")
+@limiter.limit("60/minute")
 async def get_checkpoints(
+    request: Request,
     job_id: str,
     user: UserDB = Depends(get_current_user_or_api_key),
     db: AsyncSession = Depends(get_db),

--- a/backend/app/api/routes/upload.py
+++ b/backend/app/api/routes/upload.py
@@ -23,6 +23,14 @@ ALLOWED_EXTENSIONS = {
     "cover_letter": [".pdf", ".docx"],
 }
 
+# 허용된 MIME 타입 (확장자-MIME 이중 검증)
+ALLOWED_MIME_TYPES = {
+    ".pdf": ["application/pdf"],
+    ".docx": [
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ],
+}
+
 MAX_FILE_SIZE = 50 * 1024 * 1024  # 50MB
 
 
@@ -53,6 +61,14 @@ async def upload_file(
         raise HTTPException(
             status_code=400,
             detail=f"Invalid file extension for {file_type}. Allowed: {ALLOWED_EXTENSIONS[file_type]}",
+        )
+
+    # MIME 타입 검증 (확장자-MIME 이중 검증)
+    allowed_mimes = ALLOWED_MIME_TYPES.get(file_ext, [])
+    if file.content_type and file.content_type not in allowed_mimes:
+        raise HTTPException(
+            status_code=400,
+            detail=f"MIME type mismatch. Expected {allowed_mimes} for {file_ext}, got {file.content_type}",
         )
 
     # 파일 크기 검증

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -112,7 +112,8 @@ app.add_middleware(
     allow_origins=settings.CORS_ORIGINS,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["*"],
+    allow_headers=["Authorization", "Content-Type", "X-Internal-Token"],
+    max_age=600,
 )
 
 app.add_middleware(

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,6 +8,16 @@ server {
     client_max_body_size 150m;
 
     # ============================================
+    # Security Headers
+    # ============================================
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' wss: ws:; font-src 'self';" always;
+
+    # ============================================
     # Backend API Proxy
     # ============================================
 


### PR DESCRIPTION
## Summary
- Nginx 보안 헤더 6종 추가 (CSP, X-Frame-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy, X-Content-Type-Options)
- CORS `allow_headers=["*"]` → 명시적 `["Authorization", "Content-Type", "X-Internal-Token"]` 제한
- Rate Limiting 미적용 GET 엔드포인트 3개에 추가 (list_jobs 60/min, get_job 120/min, checkpoints 60/min)
- 파일 업로드 MIME 타입 이중 검증 (확장자 + Content-Type 매칭)
- Internal API 토큰 비교 `hmac.compare_digest` 적용 (timing attack 방지)

## Test plan
- [ ] CORS preflight 요청에 올바른 헤더 반환 확인
- [ ] Rate limiting 초과 시 429 응답 확인
- [ ] 잘못된 MIME 타입으로 파일 업로드 시 400 응답 확인
- [ ] Internal API 토큰 인증 정상 동작 확인
- [ ] Nginx 응답 헤더에 보안 헤더 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)