### PR TITLE
qual: LLM 출력 품질 강화 3가지 수정

### DIFF
--- a/backend/app/services/cached_llm.py
+++ b/backend/app/services/cached_llm.py
@@ -210,15 +210,17 @@ def _parse_llm_json_response(data: Any) -> Any:
         except json.JSONDecodeError:
             pass
 
-        # Strategy 2: Extract first JSON object from mixed text
+        # Strategy 2: Extract first JSON object or array from mixed text
         # Handles cases like "Here is the analysis:\n{...}\nLet me know..."
-        brace_start = cleaned.find('{')
-        if brace_start >= 0:
-            # Find matching closing brace by counting nesting
+        # or "Here are the topics:\n[...]\nI hope this helps"
+        for open_ch, close_ch, type_name in [('{', '}', 'object'), ('[', ']', 'array')]:
+            start_pos = cleaned.find(open_ch)
+            if start_pos < 0:
+                continue
             depth = 0
             in_string = False
             escape_next = False
-            for i in range(brace_start, len(cleaned)):
+            for i in range(start_pos, len(cleaned)):
                 ch = cleaned[i]
                 if escape_next:
                     escape_next = False
@@ -231,16 +233,16 @@ def _parse_llm_json_response(data: Any) -> Any:
                     continue
                 if in_string:
                     continue
-                if ch == '{':
+                if ch == open_ch:
                     depth += 1
-                elif ch == '}':
+                elif ch == close_ch:
                     depth -= 1
                     if depth == 0:
-                        json_candidate = cleaned[brace_start:i + 1]
+                        json_candidate = cleaned[start_pos:i + 1]
                         try:
                             parsed = json.loads(json_candidate)
-                            if isinstance(parsed, dict):
-                                logger.debug("Extracted JSON object from mixed LLM response text")
+                            if isinstance(parsed, (dict, list)):
+                                logger.debug(f"Extracted JSON {type_name} from mixed LLM response text")
                                 return parsed
                         except json.JSONDecodeError:
                             pass

--- a/backend/app/workflows/activities/quality_review.py
+++ b/backend/app/workflows/activities/quality_review.py
@@ -73,8 +73,22 @@ async def review_questions(questions: list[dict], output_language: str = "ko") -
         if isinstance(review_result, dict):
             if review_result.get("duplicates"):
                 issues.append({"type": "duplicates", "details": review_result["duplicates"]})
+            # LLM이 식별한 개별 질문 문제
+            for qr in review_result.get("question_reviews", []):
+                if isinstance(qr, dict) and qr.get("issue"):
+                    questions_to_revise.append(qr)
+            # 환각 위험 질문 검출
+            for hr in review_result.get("hallucination_risks", []):
+                if isinstance(hr, dict):
+                    issues.append({"type": "hallucination_risk", "details": hr})
 
-    verdict = "APPROVED" if len(questions_to_revise) == 0 and len(issues) < 3 else "NEEDS_REVISION"
+    # 심각도 기반 판정: 중복/환각은 HIGH, 분포 불균형은 LOW
+    high_severity_count = sum(
+        1 for i in issues if i.get("type") in ("duplicates", "hallucination_risk")
+    )
+    verdict = "NEEDS_REVISION" if high_severity_count > 0 or len(questions_to_revise) > 0 else (
+        "APPROVED" if len(issues) < 3 else "NEEDS_REVISION"
+    )
 
     return {
         "verdict": verdict,

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -379,6 +379,12 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
 
     # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
     result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
+
+    # LLM이 {"topics": [...]} 형태로 반환할 경우 배열 추출
+    if isinstance(result, dict) and "topics" in result and isinstance(result["topics"], list):
+        logger.info("select_topics: extracted list from wrapped dict")
+        result = result["topics"]
+
     if isinstance(result, list):
         if alog:
             await alog.result("Topics selected", {
@@ -531,6 +537,9 @@ async def craft_question(
     result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
 
     question = result if isinstance(result, dict) else {}
+    if not isinstance(result, dict):
+        logger.warning(f"craft_question LLM returned non-dict: {type(result)}, using empty dict fallback")
+
     # 고유 ID 강제 할당 — LLM이 중복 ID를 생성하는 문제 방지
     question["id"] = f"q-{topic.get('category', 'x')[:4]}-{uuid.uuid4().hex[:8]}"
     question.setdefault("question_text", f"[{topic.get('topic')}] 관련 질문")
@@ -538,6 +547,18 @@ async def craft_question(
     question.setdefault("difficulty", topic.get("difficulty", "Medium"))
     question.setdefault("language", output_language)
     question.setdefault("topic", topic.get("topic"))
+
+    # 필수 필드 검증 — LLM이 빈 질문 텍스트를 반환하는 경우 방지
+    if not question.get("question_text") or question["question_text"].startswith("["):
+        question["_quality_flag"] = "low_quality_text"
+        logger.warning(f"craft_question produced low quality text: {question.get('question_text', '')[:50]}")
+
+    # 평가 시나리오 기본값 보장
+    question.setdefault("evaluation_scenarios", {
+        "excellent": "",
+        "acceptable": "",
+        "poor": "",
+    })
 
     # Add KG provenance metadata
     if topic.get("source", "").startswith("kg_"):


### PR DESCRIPTION
## Summary
- quality_review 심각도 기반 판정: 중복/환각 이슈 HIGH → NEEDS_REVISION 자동 분류, LLM review에서 question_reviews/hallucination_risks 데이터 추출
- cached_llm JSON 배열 추출 지원: `[...]` 형태 LLM 응답도 정상 파싱 (기존 `{...}`만 지원)
- question_generation 출력 검증 강화: select_topics dict-wrapped 배열 자동 언래핑, 저품질 질문 감지 + evaluation_scenarios 기본값 보장

## Test plan
- [ ] select_topics에서 `{"topics": [...]}` 형태 응답 시 정상 배열 추출 확인
- [ ] quality_review에서 중복 질문 감지 시 NEEDS_REVISION 판정 확인
- [ ] craft_question에서 빈 텍스트 반환 시 _quality_flag 설정 확인
- [ ] 기존 정상 워크플로우 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)