### PR TITLE
ux: WCAG 탭 접근성 + 하드코딩 한국어 i18n 전환

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -256,6 +256,15 @@ const resources = {
       result_scoring_scale: '점수 범위',
       result_passing_threshold: '합격 기준',
       result_v1_category_weights: '카테고리별 가중치',
+      // JobStatusPage
+      status_title: '면접 스크립트 #{{id}}',
+      progress_label: '진행률',
+      view_analysis_logs: '분석 로그 보기',
+      processing_steps: '처리 단계',
+      script_generated_desc: '면접 스크립트가 성공적으로 생성되었습니다',
+      create_new_script: '새 스크립트 생성하기',
+      // JobListPage
+      script_count: '{{count}}개의 스크립트',
     },
   },
   en: {
@@ -512,6 +521,15 @@ const resources = {
       result_scoring_scale: 'Scoring Scale',
       result_passing_threshold: 'Passing Threshold',
       result_v1_category_weights: 'Category Weights',
+      // JobStatusPage
+      status_title: 'Interview Script #{{id}}',
+      progress_label: 'Progress',
+      view_analysis_logs: 'View Analysis Logs',
+      processing_steps: 'Processing Steps',
+      script_generated_desc: 'Interview script generated successfully',
+      create_new_script: 'Create New Script',
+      // JobListPage
+      script_count: '{{count}} scripts',
     },
   },
 }

--- a/frontend/src/pages/JobListPage.tsx
+++ b/frontend/src/pages/JobListPage.tsx
@@ -138,7 +138,7 @@ export function JobListPage() {
           <h1 className="text-2xl font-bold text-gray-900">{t('script_list_title')}</h1>
           {jobs.length > 0 && (
             <p className="mt-1 text-sm text-gray-500">
-              {jobs.length}개의 스크립트
+              {t('script_count', { count: jobs.length })}
             </p>
           )}
         </div>
@@ -197,7 +197,7 @@ export function JobListPage() {
                     <Link
                       to={`/jobs/${job.job_id}/logs`}
                       className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                      title="분석 로그"
+                      title={t('result_analysis_logs')}
                     >
                       <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -213,7 +213,7 @@ export function JobListPage() {
                     )}
                     <button
                       onClick={() => handleDelete(job.job_id)}
-                      className="rounded-lg p-2 text-gray-400 opacity-0 transition-all hover:bg-red-50 hover:text-red-500 group-hover:opacity-100"
+                      className="rounded-lg p-2 text-gray-400 opacity-0 transition-all hover:bg-red-50 hover:text-red-500 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
                       aria-label={t('delete')}
                     >
                       <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/pages/JobStatusPage.tsx
+++ b/frontend/src/pages/JobStatusPage.tsx
@@ -213,7 +213,7 @@ export function JobStatusPage() {
               <PhaseIcon phase={status} className={`h-7 w-7 ${config.color}`} />
             </div>
             <div>
-              <h1 className="text-xl font-bold text-gray-900">면접 스크립트 #{jobId?.slice(0, 8)}</h1>
+              <h1 className="text-xl font-bold text-gray-900">{t('status_title', { id: jobId?.slice(0, 8) })}</h1>
               <div className="mt-1 flex items-center gap-2">
                 <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${config.bgColor} ${config.color}`}>
                   {!isTerminal && (
@@ -238,7 +238,7 @@ export function JobStatusPage() {
         {/* Progress bar */}
         <div className="mt-6">
           <div className="mb-2 flex items-center justify-between text-sm">
-            <span className="font-medium text-gray-700">진행률</span>
+            <span className="font-medium text-gray-700">{t('progress_label')}</span>
             <span className={`font-semibold ${config.color}`}>{progressPercent}%</span>
           </div>
           <div className="h-2.5 w-full overflow-hidden rounded-full bg-gray-200">
@@ -261,7 +261,7 @@ export function JobStatusPage() {
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
-          분석 로그 보기
+          {t('view_analysis_logs')}
           {!isTerminal && connected && (
             <span className="ml-1 h-2 w-2 animate-pulse rounded-full bg-green-500" />
           )}
@@ -270,7 +270,7 @@ export function JobStatusPage() {
 
       {/* Timeline */}
       <div className="mb-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-        <h2 className="mb-4 text-sm font-semibold text-gray-900">처리 단계</h2>
+        <h2 className="mb-4 text-sm font-semibold text-gray-900">{t('processing_steps')}</h2>
         <div className="space-y-4">
           {phases.map((phase, index) => {
             const isActive = phase === status
@@ -310,7 +310,7 @@ export function JobStatusPage() {
             </div>
             <div className="flex-1">
               <h3 className="text-lg font-semibold text-green-800">{t('script_complete')}</h3>
-              <p className="text-sm text-green-600">면접 스크립트가 성공적으로 생성되었습니다</p>
+              <p className="text-sm text-green-600">{t('script_generated_desc')}</p>
             </div>
             <Link
               to={`/jobs/${jobId}/result`}
@@ -346,7 +346,7 @@ export function JobStatusPage() {
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
-                새 스크립트 생성하기
+                {t('create_new_script')}
               </Link>
             </div>
           </div>

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -167,6 +167,24 @@ export function ResultPage() {
     setScores((prev) => ({ ...prev, [index]: score }))
   }
 
+  // Tab keyboard navigation (WCAG 2.1)
+  const v2TabIds = ['intel', 'analysis', 'interview', 'decision'] as const
+  const v1TabIds = ['questions', 'summary', 'guide'] as const
+
+  const handleTabKeyDown = useCallback((e: React.KeyboardEvent, tabs: readonly string[]) => {
+    const currentIndex = tabs.indexOf(activeTab)
+    if (currentIndex === -1) return
+    let newIndex = currentIndex
+    if (e.key === 'ArrowRight') newIndex = (currentIndex + 1) % tabs.length
+    else if (e.key === 'ArrowLeft') newIndex = (currentIndex - 1 + tabs.length) % tabs.length
+    else if (e.key === 'Home') newIndex = 0
+    else if (e.key === 'End') newIndex = tabs.length - 1
+    else return
+    e.preventDefault()
+    setActiveTab(tabs[newIndex] as typeof activeTab)
+    document.getElementById(`tab-${tabs[newIndex]}`)?.focus()
+  }, [activeTab])
+
   const totalScore = Object.values(scores).reduce((sum, s) => sum + s, 0)
   const maxScore = Object.keys(scores).length * 5
   const scorePercent = maxScore > 0 ? Math.round((totalScore / maxScore) * 100) : 0
@@ -250,9 +268,15 @@ export function ResultPage() {
       {/* Tab Navigation */}
       {hasV2Data ? (
         // v2 4-tab navigation (underline style)
-        <div className="flex border-b border-gray-200 no-print overflow-x-auto scrollbar-hide">
+        <div role="tablist" aria-label={t('interview_script')} className="flex border-b border-gray-200 no-print overflow-x-auto scrollbar-hide">
           <button
+            role="tab"
+            id="tab-intel"
+            aria-selected={activeTab === 'intel'}
+            aria-controls="tabpanel-intel"
+            tabIndex={activeTab === 'intel' ? 0 : -1}
             onClick={() => setActiveTab('intel')}
+            onKeyDown={(e) => handleTabKeyDown(e, v2TabIds)}
             className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors whitespace-nowrap shrink-0 ${
               activeTab === 'intel' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
@@ -263,7 +287,13 @@ export function ResultPage() {
             Intel Brief
           </button>
           <button
+            role="tab"
+            id="tab-analysis"
+            aria-selected={activeTab === 'analysis'}
+            aria-controls="tabpanel-analysis"
+            tabIndex={activeTab === 'analysis' ? 0 : -1}
             onClick={() => setActiveTab('analysis')}
+            onKeyDown={(e) => handleTabKeyDown(e, v2TabIds)}
             className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors whitespace-nowrap shrink-0 ${
               activeTab === 'analysis' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
@@ -274,7 +304,13 @@ export function ResultPage() {
             Deep Analysis
           </button>
           <button
+            role="tab"
+            id="tab-interview"
+            aria-selected={activeTab === 'interview'}
+            aria-controls="tabpanel-interview"
+            tabIndex={activeTab === 'interview' ? 0 : -1}
             onClick={() => setActiveTab('interview')}
+            onKeyDown={(e) => handleTabKeyDown(e, v2TabIds)}
             className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors whitespace-nowrap shrink-0 ${
               activeTab === 'interview' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
@@ -285,7 +321,13 @@ export function ResultPage() {
             Live Interview ({questions.length})
           </button>
           <button
+            role="tab"
+            id="tab-decision"
+            aria-selected={activeTab === 'decision'}
+            aria-controls="tabpanel-decision"
+            tabIndex={activeTab === 'decision' ? 0 : -1}
             onClick={() => setActiveTab('decision')}
+            onKeyDown={(e) => handleTabKeyDown(e, v2TabIds)}
             className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors whitespace-nowrap shrink-0 ${
               activeTab === 'decision' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
@@ -298,9 +340,15 @@ export function ResultPage() {
         </div>
       ) : (
         // v1 3-tab navigation (underline style)
-        <div className="flex border-b border-gray-200 no-print overflow-x-auto scrollbar-hide">
+        <div role="tablist" aria-label={t('interview_script')} className="flex border-b border-gray-200 no-print overflow-x-auto scrollbar-hide">
           <button
+            role="tab"
+            id="tab-questions"
+            aria-selected={activeTab === 'questions'}
+            aria-controls="tabpanel-questions"
+            tabIndex={activeTab === 'questions' ? 0 : -1}
             onClick={() => setActiveTab('questions')}
+            onKeyDown={(e) => handleTabKeyDown(e, v1TabIds)}
             className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors whitespace-nowrap shrink-0 ${
               activeTab === 'questions' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
@@ -308,7 +356,13 @@ export function ResultPage() {
             {t('result_tab_questions')} ({questions.length})
           </button>
           <button
+            role="tab"
+            id="tab-summary"
+            aria-selected={activeTab === 'summary'}
+            aria-controls="tabpanel-summary"
+            tabIndex={activeTab === 'summary' ? 0 : -1}
             onClick={() => setActiveTab('summary')}
+            onKeyDown={(e) => handleTabKeyDown(e, v1TabIds)}
             className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors whitespace-nowrap shrink-0 ${
               activeTab === 'summary' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
@@ -316,7 +370,13 @@ export function ResultPage() {
             {t('result_tab_summary')}
           </button>
           <button
+            role="tab"
+            id="tab-guide"
+            aria-selected={activeTab === 'guide'}
+            aria-controls="tabpanel-guide"
+            tabIndex={activeTab === 'guide' ? 0 : -1}
             onClick={() => setActiveTab('guide')}
+            onKeyDown={(e) => handleTabKeyDown(e, v1TabIds)}
             className={`tab-underline flex items-center gap-2 px-5 py-3 text-sm font-medium transition-colors whitespace-nowrap shrink-0 ${
               activeTab === 'guide' ? 'active text-indigo-700' : 'text-gray-500 hover:text-gray-700'
             }`}
@@ -328,7 +388,7 @@ export function ResultPage() {
 
       {/* V2 Tabs */}
       {hasV2Data && (
-        <div key={activeTab} className="animate-fadeIn">
+        <div key={activeTab} id={`tabpanel-${activeTab}`} role="tabpanel" aria-labelledby={`tab-${activeTab}`} className="animate-fadeIn">
           {activeTab === 'intel' && script.intel && (
             <IntelBriefTab
               intel={script.intel}


### PR DESCRIPTION
## Summary
- ResultPage v1/v2 탭에 WCAG 2.1 접근성 속성 추가 (role, aria-selected, aria-controls, 키보드 내비게이션)
- JobListPage 삭제 버튼 keyboard focus 접근성 개선, 하드코딩 한국어 → i18n
- JobStatusPage 6개 하드코딩 한국어 문자열 → i18n 키 전환
- i18n.ts에 7개 신규 번역 키 추가 (ko/en 양방)

## Test plan
- [ ] ResultPage 탭: Tab/ArrowLeft/ArrowRight/Home/End 키보드 내비게이션 확인
- [ ] JobListPage: 삭제 버튼 Tab 포커스 시 표시 확인
- [ ] JobStatusPage: 한국어/영어 전환 시 모든 텍스트 정상 번역 확인
- [ ] TypeScript 빌드 오류 없음 확인 (tsc --noEmit 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)