### PR TITLE
fix: 테스트 7개 파일 mock 대상 Langfuse-first 패턴 동기화 (#112)

### DIFF
--- a/backend/tests/test_cache_and_quotas.py
+++ b/backend/tests/test_cache_and_quotas.py
@@ -9,29 +9,26 @@ class TestCachedLLMInvalidation:
         assert hasattr(svc, "invalidate_for_job")
         assert callable(svc.invalidate_for_job)
 
-    def test_job_cache_key_method_exists(self):
+    def test_make_cache_key_method_exists(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        assert hasattr(svc, "_job_cache_key")
+        assert hasattr(CachedLLMService, "_make_cache_key")
+        assert callable(CachedLLMService._make_cache_key)
 
     def test_job_cache_key_format(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        key = svc._job_cache_key("job-123", "test prompt", "gpt-4o")
+        key = CachedLLMService._make_cache_key("test prompt", "gpt-4o", job_id="job-123")
         assert key.startswith("llm_cache:job:job-123:")
 
     def test_job_cache_key_deterministic(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        k1 = svc._job_cache_key("j1", "prompt", "model")
-        k2 = svc._job_cache_key("j1", "prompt", "model")
+        k1 = CachedLLMService._make_cache_key("prompt", "model", job_id="j1")
+        k2 = CachedLLMService._make_cache_key("prompt", "model", job_id="j1")
         assert k1 == k2
 
     def test_job_cache_key_differs_by_job(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        k1 = svc._job_cache_key("j1", "prompt", "model")
-        k2 = svc._job_cache_key("j2", "prompt", "model")
+        k1 = CachedLLMService._make_cache_key("prompt", "model", job_id="j1")
+        k2 = CachedLLMService._make_cache_key("prompt", "model", job_id="j2")
         assert k1 != k2
 
     def test_run_for_job_method_exists(self):
@@ -42,40 +39,35 @@ class TestCachedLLMInvalidation:
 
 
 class TestCacheKeyWithActivityName:
-    """캐시 키에 activity_name 포함 테스트"""
+    """캐시 키에 activity_name 포함 테스트 (_make_cache_key 통합 API)"""
 
     def test_cache_key_includes_activity_name(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        key = svc._cache_key("prompt", "model", "analyze_jd")
+        key = CachedLLMService._make_cache_key("prompt", "model", "analyze_jd")
         assert "analyze_jd" in key
         assert key.startswith("llm_cache:analyze_jd:")
 
     def test_cache_key_without_activity_name(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        key = svc._cache_key("prompt", "model")
+        key = CachedLLMService._make_cache_key("prompt", "model")
         assert key.startswith("llm_cache:")
         assert key.count(":") == 1  # llm_cache:hash
 
     def test_different_activities_different_keys(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        k1 = svc._cache_key("same prompt", "model", "analyze_jd")
-        k2 = svc._cache_key("same prompt", "model", "craft_question")
+        k1 = CachedLLMService._make_cache_key("same prompt", "model", "analyze_jd")
+        k2 = CachedLLMService._make_cache_key("same prompt", "model", "craft_question")
         assert k1 != k2
 
     def test_job_cache_key_includes_activity(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        key = svc._job_cache_key("job-1", "prompt", "model", "analyze_jd")
+        key = CachedLLMService._make_cache_key("prompt", "model", "analyze_jd", job_id="job-1")
         assert "analyze_jd" in key
         assert key.startswith("llm_cache:job:job-1:analyze_jd:")
 
     def test_job_cache_key_without_activity(self):
         from app.services.cached_llm import CachedLLMService
-        svc = CachedLLMService()
-        key = svc._job_cache_key("job-1", "prompt", "model")
+        key = CachedLLMService._make_cache_key("prompt", "model", job_id="job-1")
         assert key.startswith("llm_cache:job:job-1:")
         assert "None" not in key
 

--- a/backend/tests/test_document_analysis.py
+++ b/backend/tests/test_document_analysis.py
@@ -11,6 +11,12 @@ Phase 2: Document Analysis Activity 단위 테스트
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 
+# ============================================================
+# 테스트 상수
+# ============================================================
+HEARTBEAT_PATCH = "temporalio.activity.heartbeat"
+LLM_RUN_PATCH = "app.services.cached_llm.CachedLLMService.run_with_prompt_config"
+
 
 # ============================================================
 # P2D-01: 문서 파싱 테스트
@@ -70,12 +76,13 @@ class TestLlmProfileExtraction:
         async def mock_parse_document(path):
             return MockParseResult()
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_profile
 
         with patch("app.workflows.activities.document_analysis.activity") as mock_activity, \
              patch("app.services.document_parser.parse_document", side_effect=mock_parse_document), \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -93,7 +100,9 @@ class TestLlmProfileExtraction:
 
         input_data = {}  # 문서 경로 없음
 
-        with patch("app.workflows.activities.document_analysis.activity") as mock_activity:
+        with patch("app.workflows.activities.document_analysis.activity") as mock_activity, \
+             patch(HEARTBEAT_PATCH):
+
             mock_activity.heartbeat = MagicMock()
 
             result = await analyze_documents(input_data)
@@ -134,12 +143,13 @@ class TestDocumentAnalysisErrorHandling:
                 raise ValueError("Parse failed")
             return MockParseResult()
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {"name": "Test"}
 
         with patch("app.workflows.activities.document_analysis.activity") as mock_activity, \
              patch("app.services.document_parser.parse_document", side_effect=mock_parse_document), \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -171,7 +181,9 @@ class TestDocumentAnalysisIntegration:
 
         input_data = {}
 
-        with patch("app.workflows.activities.document_analysis.activity") as mock_activity:
+        with patch("app.workflows.activities.document_analysis.activity") as mock_activity, \
+             patch(HEARTBEAT_PATCH):
+
             mock_activity.heartbeat = MagicMock()
 
             result = await analyze_documents(input_data)

--- a/backend/tests/test_jd_analysis.py
+++ b/backend/tests/test_jd_analysis.py
@@ -6,9 +6,16 @@ Phase 2: JD Analysis Activity 단위 테스트
 - P2J-01: JD 요구사항 추출
 - P2J-02: 스킬 추출
 - P2J-03: LLM 실패 시 기본값 반환
+
+Note: analyze_jd는 Langfuse-first 패턴(run_with_prompt_config)을 사용하므로
+run_with_prompt_config을 모킹합니다.
 """
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
+
+
+HEARTBEAT_PATCH = "temporalio.activity.heartbeat"
+LLM_RUN_PATCH = "app.services.cached_llm.CachedLLMService.run_with_prompt_config"
 
 
 # ============================================================
@@ -22,7 +29,6 @@ class TestJdRequirementsExtraction:
     async def test_analyze_jd_returns_requirements(self, sample_jd_text):
         """JD 분석 결과에 요구사항 포함"""
         from app.workflows.activities.jd_analysis import analyze_jd
-        from unittest.mock import patch
 
         mock_result = {
             "job_title": "AI Engineer",
@@ -36,10 +42,11 @@ class TestJdRequirementsExtraction:
             "tech_stack": ["Python", "TypeScript", "FastAPI"],
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_result
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await analyze_jd(sample_jd_text)
 
             assert result["job_title"] == "AI Engineer"
@@ -58,7 +65,6 @@ class TestJdSkillExtraction:
     async def test_analyze_jd_extracts_tech_stack(self, sample_jd_text):
         """JD에서 기술스택 추출"""
         from app.workflows.activities.jd_analysis import analyze_jd
-        from unittest.mock import patch
 
         mock_result = {
             "job_title": "Backend Developer",
@@ -67,10 +73,11 @@ class TestJdSkillExtraction:
             "responsibilities": [],
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_result
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await analyze_jd(sample_jd_text)
 
             assert "tech_stack" in result
@@ -88,12 +95,12 @@ class TestJdAnalysisErrorHandling:
     async def test_analyze_jd_llm_returns_non_dict(self):
         """LLM이 dict가 아닌 값 반환 시"""
         from app.workflows.activities.jd_analysis import analyze_jd
-        from unittest.mock import patch
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return "Not a dict response"
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await analyze_jd("Test JD")
 
             # 기본값 반환
@@ -118,7 +125,6 @@ class TestJdAnalysisIntegration:
     async def test_output_structure(self, sample_jd_text):
         """출력 구조 검증"""
         from app.workflows.activities.jd_analysis import analyze_jd
-        from unittest.mock import patch
 
         mock_result = {
             "job_title": "Test",
@@ -129,10 +135,11 @@ class TestJdAnalysisIntegration:
             "tech_stack": [],
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_result
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await analyze_jd(sample_jd_text)
 
             # 필수 필드 확인

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -45,13 +45,12 @@ class TestObservabilityModule:
         assert observability._initialized is True
 
         import litellm
-        assert "langfuse" in litellm.success_callback
-        assert "langfuse" in litellm.failure_callback
+        # Langfuse 3.x uses litellm.callbacks (not success_callback/failure_callback)
+        assert any("langfuse" in str(cb) for cb in litellm.callbacks)
 
         # Cleanup
         observability._initialized = False
-        litellm.success_callback = []
-        litellm.failure_callback = []
+        litellm.callbacks = []
 
     def test_idempotent(self, monkeypatch):
         """Calling setup twice doesn't fail."""
@@ -67,8 +66,7 @@ class TestObservabilityModule:
         # Cleanup
         observability._initialized = False
         import litellm
-        litellm.success_callback = []
-        litellm.failure_callback = []
+        litellm.callbacks = []
 
     def test_main_calls_setup(self):
         """main.py imports and calls setup_langfuse."""

--- a/backend/tests/test_quality_review.py
+++ b/backend/tests/test_quality_review.py
@@ -11,6 +11,10 @@ Phase 3: Quality Review Activity 단위 테스트
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 
+# Constants for patch targets
+HEARTBEAT_PATCH = "temporalio.activity.heartbeat"
+LLM_RUN_PATCH = "app.services.cached_llm.CachedLLMService.run_with_prompt_config"
+
 
 # ============================================================
 # P3-QR-01: 카테고리 분포 검사 테스트
@@ -32,11 +36,12 @@ class TestCategoryDistribution:
             {"question_text": "Q3", "category": "role_fit", "difficulty": "Hard"},
         ]
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {"duplicates": []}
 
         with patch("app.workflows.activities.quality_review.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -62,11 +67,12 @@ class TestCategoryDistribution:
                     "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"][i],
                 })
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {"duplicates": []}
 
         with patch("app.workflows.activities.quality_review.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -99,11 +105,12 @@ class TestDifficultyDistribution:
             for i in range(2)
         ]
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {"duplicates": []}
 
         with patch("app.workflows.activities.quality_review.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -128,11 +135,12 @@ class TestDifficultyDistribution:
             for i in range(2)
         ]
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {"duplicates": []}
 
         with patch("app.workflows.activities.quality_review.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -161,11 +169,12 @@ class TestDuplicateDetection:
             {"question_text": "Python 사용 경험에 대해 말씀해주세요.", "category": "technical_depth", "difficulty": "Medium"},
         ]
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {"duplicates": [(0, 1, "Similar questions about Python experience")]}
 
         with patch("app.workflows.activities.quality_review.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -199,11 +208,12 @@ class TestVerdict:
                     "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"][i],
                 })
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {"duplicates": []}
 
         with patch("app.workflows.activities.quality_review.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -222,11 +232,12 @@ class TestVerdict:
             {"question_text": "Q1", "category": "role_fit", "difficulty": "Easy"},
         ]
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {"duplicates": [(0, 0, "Self duplicate")]}
 
         with patch("app.workflows.activities.quality_review.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -256,11 +267,12 @@ class TestQualityReviewIntegration:
 
         questions = []
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return {}
 
         with patch("app.workflows.activities.quality_review.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
 
             mock_activity.heartbeat = MagicMock()
 

--- a/backend/tests/test_question_generation.py
+++ b/backend/tests/test_question_generation.py
@@ -11,9 +11,18 @@ Phase 3-4: Question Generation Activities 단위 테스트
 - P3-06: 면접관 노트 (generate_interviewer_notes)
 - P3-07: 의사결정 가이드 (generate_decision_guide)
 - P3-08: 질문 수정 (revise_questions)
+
+Note: 모든 question_generation activity는 Langfuse-first 패턴
+(run_llm_with_prompt_config_heartbeat → run_with_prompt_config)을 사용하므로
+run_with_prompt_config을 모킹합니다.
 """
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
+
+
+HEARTBEAT_PATCH = "temporalio.activity.heartbeat"
+LLM_RUN_PATCH = "app.services.cached_llm.CachedLLMService.run_with_prompt_config"
+ACTIVITY_MODULE_PATCH = "app.workflows.activities.question_generation.activity"
 
 
 # ============================================================
@@ -27,18 +36,17 @@ class TestSelectTopics:
     async def test_select_topics_basic(self, mock_aggregated_analysis, mock_enriched_input):
         """토픽 선정 기본 테스트"""
         from app.workflows.activities.question_generation import select_topics
-        from unittest.mock import patch
 
         mock_topics = [
             {"category": "role_fit", "topic": "AI Experience", "difficulty": "Medium", "source": "jd_match"},
             {"category": "technical_depth", "topic": "Python", "difficulty": "Hard", "source": "code"},
         ]
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_topics
 
-        with patch("app.workflows.activities.question_generation.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(ACTIVITY_MODULE_PATCH) as mock_activity, \
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -51,13 +59,12 @@ class TestSelectTopics:
     async def test_select_topics_fallback(self, mock_aggregated_analysis, mock_enriched_input):
         """LLM 실패 시 폴백 토픽 생성"""
         from app.workflows.activities.question_generation import select_topics
-        from unittest.mock import patch
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return "Not a list"  # LLM 실패 시뮬레이션
 
-        with patch("app.workflows.activities.question_generation.activity") as mock_activity, \
-             patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(ACTIVITY_MODULE_PATCH) as mock_activity, \
+             patch(LLM_RUN_PATCH, side_effect=mock_llm_run):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -79,7 +86,6 @@ class TestCraftQuestion:
     async def test_craft_question_basic(self, mock_aggregated_analysis, mock_enriched_input):
         """단일 질문 생성"""
         from app.workflows.activities.question_generation import craft_question
-        from unittest.mock import patch
 
         topic = {
             "category": "technical_depth",
@@ -94,10 +100,11 @@ class TestCraftQuestion:
             "expected_answer": {"level_1": "기본 개념", "level_2": "구현 경험", "level_3": "최적화"},
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_question
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await craft_question(topic, mock_aggregated_analysis, mock_enriched_input)
 
             assert "question_text" in result
@@ -107,7 +114,6 @@ class TestCraftQuestion:
     async def test_craft_question_llm_failure(self, mock_aggregated_analysis, mock_enriched_input):
         """LLM 실패 시 기본값 반환"""
         from app.workflows.activities.question_generation import craft_question
-        from unittest.mock import patch
 
         topic = {
             "category": "role_fit",
@@ -115,10 +121,11 @@ class TestCraftQuestion:
             "difficulty": "Easy",
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return "Not a dict"
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await craft_question(topic, mock_aggregated_analysis, mock_enriched_input)
 
             # 기본값 반환
@@ -161,9 +168,9 @@ class TestCraftQuestionCategoryRouting:
 
         captured_prompts = {}
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             # 프롬프트 내용 캡처
-            captured_prompts["prompt"] = prompt
+            captured_prompts["prompt"] = getattr(prompt_config, "prompt", str(prompt_config))
             return {
                 "question_text": "테스트 질문",
                 "category": "role_fit",
@@ -173,9 +180,10 @@ class TestCraftQuestionCategoryRouting:
         categories_to_test = ["role_fit", "technical_depth", "communication"]
         for cat in categories_to_test:
             topic = {"category": cat, "topic": f"{cat} 테스트", "difficulty": "Medium"}
-            with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+            with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+                 patch(HEARTBEAT_PATCH):
                 await craft_question(topic, mock_aggregated_analysis, mock_enriched_input)
-                # 카테고리별 프롬프트가 사용되었는지 확인 (프롬프트 내용에 카테고리 키워드 포함)
+                # 카테고리별 프롬프트가 사용되었는지 확인
                 assert captured_prompts.get("prompt"), f"{cat} 프롬프트가 캡처되지 않음"
 
     @pytest.mark.asyncio
@@ -195,10 +203,11 @@ class TestCraftQuestionCategoryRouting:
             "difficulty": "Medium",
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_question
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await craft_question(topic, mock_aggregated_analysis, mock_enriched_input)
             # fallback이 작동해서 결과가 반환되어야 함
             assert "question_text" in result
@@ -213,14 +222,15 @@ class TestCraftQuestionCategoryRouting:
         for cat in categories:
             topic = {"category": cat, "topic": f"{cat} topic", "difficulty": "Medium"}
 
-            async def mock_llm_run(prompt, **kwargs):
+            async def mock_llm_run(prompt_config, **kwargs):
                 return {
                     "question_text": f"Question for {cat}",
                     "category": cat,
                     "difficulty": "Medium",
                 }
 
-            with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+            with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+                 patch(HEARTBEAT_PATCH):
                 result = await craft_question(topic, mock_aggregated_analysis, mock_enriched_input)
                 assert result["category"] == cat, f"{cat} 카테고리 결과 불일치"
                 assert "id" in result, f"{cat} 질문에 ID 없음"
@@ -237,7 +247,6 @@ class TestEnhanceTerminology:
     async def test_enhance_terminology(self, mock_enriched_input):
         """용어 설명 추가"""
         from app.workflows.activities.question_generation import enhance_terminology
-        from unittest.mock import patch
 
         questions = [
             {"question_text": "FastAPI의 dependency injection을 설명해주세요."},
@@ -251,10 +260,11 @@ class TestEnhanceTerminology:
             }
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_result
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await enhance_terminology(questions, mock_enriched_input)
 
             assert isinstance(result, dict)
@@ -271,7 +281,6 @@ class TestCraftEvaluationScenarios:
     async def test_craft_evaluation_scenarios(self, mock_enriched_input):
         """평가 시나리오 생성"""
         from app.workflows.activities.question_generation import craft_evaluation_scenarios
-        from unittest.mock import patch
 
         questions = [
             {"question_text": "Python 경험을 설명해주세요.", "category": "technical_depth"},
@@ -287,10 +296,11 @@ class TestCraftEvaluationScenarios:
             }
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_result
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await craft_evaluation_scenarios(questions, mock_enriched_input)
 
             assert isinstance(result, dict)
@@ -307,7 +317,6 @@ class TestDesignFollowUps:
     async def test_design_follow_ups(self, mock_enriched_input):
         """후속질문 설계"""
         from app.workflows.activities.question_generation import design_follow_ups
-        from unittest.mock import patch
 
         questions = [
             {"question_text": "팀 협업 경험을 설명해주세요.", "category": "communication"},
@@ -322,10 +331,11 @@ class TestDesignFollowUps:
             }
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_result
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await design_follow_ups(questions, mock_enriched_input)
 
             assert isinstance(result, dict)
@@ -342,7 +352,6 @@ class TestGenerateInterviewerNotes:
     async def test_generate_interviewer_notes(self, mock_enriched_input):
         """면접관 노트 생성"""
         from app.workflows.activities.question_generation import generate_interviewer_notes
-        from unittest.mock import patch
 
         questions = [
             {"question_text": "프로젝트 경험을 설명해주세요.", "category": "execution_ownership"},
@@ -354,10 +363,11 @@ class TestGenerateInterviewerNotes:
             }
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_result
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await generate_interviewer_notes(questions, mock_enriched_input)
 
             assert isinstance(result, dict)
@@ -374,7 +384,6 @@ class TestGenerateDecisionGuide:
     async def test_generate_decision_guide(self, mock_aggregated_analysis, mock_enriched_input):
         """의사결정 가이드 생성"""
         from app.workflows.activities.question_generation import generate_decision_guide
-        from unittest.mock import patch
 
         mock_result = {
             "key_decision_factors": ["기술 깊이", "문제 해결 능력"],
@@ -382,10 +391,11 @@ class TestGenerateDecisionGuide:
             "red_flags": ["팀워크 부족", "코드 품질 낮음"],
         }
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_result
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await generate_decision_guide(mock_aggregated_analysis, mock_enriched_input)
 
             assert isinstance(result, dict)
@@ -402,7 +412,6 @@ class TestReviseQuestions:
     async def test_revise_questions(self, mock_enriched_input):
         """피드백 기반 질문 수정"""
         from app.workflows.activities.question_generation import revise_questions
-        from unittest.mock import patch
 
         questions = [
             {"question_text": "Python 경험을 설명해주세요.", "category": "technical_depth"},
@@ -416,10 +425,11 @@ class TestReviseQuestions:
             {"question_text": "Python으로 해결한 가장 복잡한 문제는 무엇인가요?", "category": "technical_depth"},
         ]
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return mock_revised
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await revise_questions(questions, review_feedback, mock_enriched_input)
 
             assert isinstance(result, list)
@@ -429,16 +439,16 @@ class TestReviseQuestions:
     async def test_revise_questions_llm_failure(self, mock_enriched_input):
         """LLM 실패 시 원본 반환"""
         from app.workflows.activities.question_generation import revise_questions
-        from unittest.mock import patch
 
         original_questions = [
             {"question_text": "Original question", "category": "technical_depth"},
         ]
 
-        async def mock_llm_run(prompt, **kwargs):
+        async def mock_llm_run(prompt_config, **kwargs):
             return "Not a list"
 
-        with patch("app.services.cached_llm.CachedLLMService.run", side_effect=mock_llm_run):
+        with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
+             patch(HEARTBEAT_PATCH):
             result = await revise_questions(original_questions, {}, mock_enriched_input)
 
             # 원본 반환

--- a/backend/tests/test_workflow_v2.py
+++ b/backend/tests/test_workflow_v2.py
@@ -159,26 +159,32 @@ class TestDecisionLevelEstimation:
     """경력 레벨 추정 로직 검증 (버그 수정 확인)"""
 
     def test_level_junior(self):
+        """경력 1년 → Junior (years-based fallback)"""
         from app.workflows.activities.decision_generation import _extract_decision_summary
         result = _extract_decision_summary(
             {}, {},
             {"profile": {"experience_years": 1, "skills": [], "experiences": []}},
+            experience_level="",
         )
         assert result.level == "Junior"
 
     def test_level_mid(self):
+        """경력 5년 → Mid (years-based fallback)"""
         from app.workflows.activities.decision_generation import _extract_decision_summary
         result = _extract_decision_summary(
             {}, {},
             {"profile": {"experience_years": 5, "skills": [], "experiences": []}},
+            experience_level="",
         )
         assert result.level == "Mid"
 
     def test_level_senior(self):
+        """경력 8년 → Senior (years-based fallback)"""
         from app.workflows.activities.decision_generation import _extract_decision_summary
         result = _extract_decision_summary(
             {}, {},
             {"profile": {"experience_years": 8, "skills": [], "experiences": []}},
+            experience_level="",
         )
         assert result.level == "Senior"
 
@@ -188,6 +194,7 @@ class TestDecisionLevelEstimation:
         result = _extract_decision_summary(
             {}, {},
             {"profile": {"experience_years": 12, "skills": [], "experiences": []}},
+            experience_level="",
         )
         assert result.level == "Lead"
 
@@ -197,8 +204,19 @@ class TestDecisionLevelEstimation:
         result = _extract_decision_summary(
             {}, {},
             {"profile": {"experience_years": 10, "skills": [], "experiences": []}},
+            experience_level="",
         )
         assert result.level == "Lead"
+
+    def test_level_from_experience_level_param(self):
+        """experience_level 파라미터가 LEVEL_MAP에 있으면 그대로 사용"""
+        from app.workflows.activities.decision_generation import _extract_decision_summary
+        result = _extract_decision_summary(
+            {}, {},
+            {"profile": {"experience_years": 1, "skills": [], "experiences": []}},
+            experience_level="시니어",
+        )
+        assert result.level == "Senior"
 
 
 # ============================================================


### PR DESCRIPTION
## 요약

PR #101~#106 리팩터링 후 테스트 mock이 구버전 API를 가리켜 실패하던 문제를 7개 파일에서 일괄 수정.

## 수정 내역

| 파일 | 수정 내용 |
|------|----------|
| `test_cache_and_quotas.py` | `_cache_key`/`_job_cache_key` → `_make_cache_key` 정적 메서드 |
| `test_jd_analysis.py` | `CachedLLMService.run` → `run_with_prompt_config` + heartbeat mock |
| `test_observability.py` | `litellm.success_callback` → `litellm.callbacks` (Langfuse 3.x) |
| `test_question_generation.py` | `CachedLLMService.run` → `run_with_prompt_config` + heartbeat mock |
| `test_document_analysis.py` | `CachedLLMService.run` → `run_with_prompt_config` + heartbeat mock |
| `test_quality_review.py` | `CachedLLMService.run` → `run_with_prompt_config` + heartbeat mock |
| `test_workflow_v2.py` | `experience_level=""` 전달로 years-based fallback 검증 + 파라미터 우선 테스트 추가 |

## 테스트 결과

```
474 passed, 4 skipped, 0 failed (19.56s)
```

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)