### PR TITLE
fix: OAuth 로그인 localhost 리다이렉트 수정 (#114)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       dockerfile: Dockerfile
     container_name: iaas-frontend
     restart: unless-stopped
-    environment:
-      - VITE_BACKEND_URL=${FRONTEND_BACKEND_URL:-http://localhost:8000}
     depends_on:
       - backend
     healthcheck:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,10 +13,6 @@ RUN npm ci || npm install
 # Copy source and build
 COPY . .
 
-# Build-time environment variables
-ARG VITE_BACKEND_URL=https://test.mystery-place.com
-ENV VITE_BACKEND_URL=${VITE_BACKEND_URL}
-
 RUN npm run build
 
 # Stage 2: Production

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,8 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { setToken, getToken, clearToken } from '../lib/api'
 
-const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000'
-
 interface User {
   id: string
   email: string
@@ -21,7 +19,7 @@ export function useAuth() {
       return
     }
     try {
-      const res = await fetch(`${BACKEND}/auth/me`, {
+      const res = await fetch(`/auth/me`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (!res.ok) throw new Error('Unauthorized')

--- a/frontend/src/pages/CreateJobPage.tsx
+++ b/frontend/src/pages/CreateJobPage.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { useJob } from '../hooks/useJob'
 import { getToken } from '../lib/api'
 
-const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000'
 
 // 지원 언어 목록
 const SUPPORTED_LANGUAGES = [
@@ -156,7 +155,7 @@ export function CreateJobPage() {
       formData.append('file', file)
 
       const token = getToken()
-      const response = await fetch(`${BACKEND}/api/v1/upload/${fileType}`, {
+      const response = await fetch(`/api/v1/upload/${fileType}`, {
         method: 'POST',
         headers: {
           ...(token ? { Authorization: `Bearer ${token}` } : {}),

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,8 +2,6 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { setToken } from '../lib/api'
 
-const BACKEND = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000'
-
 // Google Icon SVG
 function GoogleIcon({ className }: { className?: string }) {
   return (
@@ -44,7 +42,7 @@ export function LoginPage() {
   const handleDevLogin = async () => {
     setDevLoading(true)
     try {
-      const res = await fetch(`${BACKEND}/auth/dev-login`, { method: 'POST' })
+      const res = await fetch(`/auth/dev-login`, { method: 'POST' })
       if (!res.ok) throw new Error('Dev login failed')
       const data = await res.json()
       setToken(data.token)
@@ -84,7 +82,7 @@ export function LoginPage() {
           {/* OAuth Buttons */}
           <div className="space-y-3">
             <a
-              href={`${BACKEND}/auth/google/login`}
+              href={`/auth/google/login`}
               className="group flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition-all hover:border-gray-400 hover:bg-gray-50 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             >
               <GoogleIcon className="h-5 w-5" />
@@ -92,7 +90,7 @@ export function LoginPage() {
             </a>
 
             <a
-              href={`${BACKEND}/auth/github/login`}
+              href={`/auth/github/login`}
               className="group flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white transition-all hover:bg-gray-800 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2"
             >
               <GitHubIcon className="h-5 w-5" />


### PR DESCRIPTION
## 요약

test.mystery-place.com에서 Google OAuth 로그인 시 localhost로 리다이렉트되는 문제 수정.

## 근본 원인

프론트엔드가 `VITE_BACKEND_URL` 빌드타임 환경변수로 절대 URL을 생성하는데,
Docker 이미지 캐시나 빌드 설정 불일치로 `http://localhost:8000`이 번들에 포함됨.

## 수정 내역

| 파일 | 변경 |
|------|------|
| `LoginPage.tsx` | `${BACKEND}/auth/*` → `/auth/*` (상대 URL) |
| `CreateJobPage.tsx` | `${BACKEND}/api/v1/upload/*` → `/api/v1/upload/*` (상대 URL) |
| `useAuth.ts` | `${BACKEND}/auth/me` → `/auth/me` (상대 URL) |
| `Dockerfile` | `ARG VITE_BACKEND_URL` 제거 |
| `docker-compose.yml` | `FRONTEND_BACKEND_URL` 환경변수 제거 |

## 동작 원리

- **개발**: Vite proxy가 `/auth`, `/api` → `http://localhost:8000` 프록시
- **프로덕션**: nginx가 `/auth`, `/api` → `http://iaas-backend:8000` 프록시
- 양쪽 모두 상대 URL로 동작 → `VITE_BACKEND_URL` 불필요

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)