### PR TITLE
fix: OAuth redirect_uri 리버스 프록시 동적 감지

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -44,6 +44,19 @@ OAUTH_SCOPES = {
 }
 
 
+def _get_public_base_url(request: Request) -> str:
+    """nginx 리버스 프록시 뒤에서 공개 URL 감지.
+
+    X-Forwarded-Proto/Host 헤더가 있으면 사용하고,
+    없으면 settings 값으로 fallback.
+    """
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    host = request.headers.get("host")
+    if forwarded_proto and host:
+        return f"{forwarded_proto}://{host}"
+    return settings.BACKEND_URL
+
+
 # --- Login ---
 
 @router.get("/{provider}/login")
@@ -53,7 +66,7 @@ async def oauth_login(provider: str, request: Request):
         raise ValidationError(f"Unsupported provider: {provider}")
 
     client = OAUTH_CLIENTS[provider]
-    callback_url = f"{settings.BACKEND_URL}/auth/{provider}/callback"
+    callback_url = f"{_get_public_base_url(request)}/auth/{provider}/callback"
     scopes = OAUTH_SCOPES.get(provider, [])
 
     authorization_url = await client.get_authorization_url(
@@ -78,7 +91,7 @@ async def oauth_callback(
         raise ValidationError(f"Unsupported provider: {provider}")
 
     client = OAUTH_CLIENTS[provider]
-    callback_url = f"{settings.BACKEND_URL}/auth/{provider}/callback"
+    callback_url = f"{_get_public_base_url(request)}/auth/{provider}/callback"
 
     # 1. code → access_token
     try:
@@ -171,8 +184,9 @@ async def oauth_callback(
         "plan": user.plan,
     })
 
-    # 6. 프론트엔드로 리다이렉트
-    return RedirectResponse(url=f"{settings.FRONTEND_URL}/auth/callback?token={jwt_token}")
+    # 6. 프론트엔드로 리다이렉트 (같은 도메인 뒤 nginx 프록시)
+    base_url = _get_public_base_url(request)
+    return RedirectResponse(url=f"{base_url}/auth/callback?token={jwt_token}")
 
 
 # --- API Key Management ---


### PR DESCRIPTION
## 요약

- OAuth 로그인 시 `settings.BACKEND_URL` (`http://localhost:8000`) 하드코딩으로 인해 프로덕션 환경(`test.mystery-place.com`)에서 Google OAuth callback이 `localhost:8000`으로 리다이렉트되는 문제 수정
- `_get_public_base_url(request)` 헬퍼 추가: nginx가 전달하는 `X-Forwarded-Proto` + `Host` 헤더에서 공개 URL 자동 감지
- 로컬 환경에서는 `settings.BACKEND_URL` fallback 유지

## 수정 파일

- `backend/app/api/routes/auth.py` — 3곳 (login callback URL, callback callback URL, 최종 리다이렉트)

## 동작 변경

| 환경 | 이전 | 이후 |
|------|------|------|
| 로컬 (직접 접근) | `http://localhost:8000/auth/google/callback` | `http://localhost:8000/auth/google/callback` (fallback) |
| 로컬 (nginx 경유) | `http://localhost:8000/auth/google/callback` | `http://localhost/auth/google/callback` |
| 프로덕션 | `http://localhost:8000/auth/google/callback` | `https://test.mystery-place.com/auth/google/callback` |

## 필수 조치

Google Cloud Console OAuth 설정에서 redirect URI 등록 필요:
```
https://test.mystery-place.com/auth/google/callback
```

## 테스트 결과

- pytest: 474 passed, 4 skipped
- curl 테스트: redirect_uri가 `http://localhost/auth/google/callback` (nginx 경유) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)