### PR TITLE
fix: nginx X-Forwarded-Proto Cloudflare 보존 — OAuth redirect_uri_mismatch 수정

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,6 +7,12 @@ server {
     # 파일 업로드 크기 제한 (50MB × 3파일 = 150MB)
     client_max_body_size 150m;
 
+    # Cloudflare Tunnel: 원본 X-Forwarded-Proto 보존 (없으면 $scheme fallback)
+    set $forwarded_proto $scheme;
+    if ($http_x_forwarded_proto) {
+        set $forwarded_proto $http_x_forwarded_proto;
+    }
+
     # ============================================
     # Security Headers
     # ============================================
@@ -34,7 +40,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 
     # Backend API
@@ -44,7 +50,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         # WebSocket 지원
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -58,7 +64,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 
     # Swagger docs


### PR DESCRIPTION
## 요약

- **원인**: nginx가 `X-Forwarded-Proto`를 `$scheme`(`http`)로 항상 덮어씀
- Cloudflare Tunnel → nginx(HTTP) → backend 경로에서 backend가 `http://` redirect_uri 생성
- Google Console에는 `https://` URI가 등록되어 `redirect_uri_mismatch` 오류 발생

## 수정

- `nginx.conf`: Cloudflare가 보낸 `X-Forwarded-Proto` 헤더 보존
- `$http_x_forwarded_proto` 있으면 그대로 사용, 없으면 `$scheme` fallback
- 3개 location block 모두 적용 (`/auth`, `/api`, `/storage/`)

## 테스트

```bash
# Cloudflare 경유 시뮬레이션
curl -H "Host: test.mystery-place.com" -H "X-Forwarded-Proto: https" \
  http://localhost/auth/google/login
# → redirect_uri=https://test.mystery-place.com/auth/google/callback ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)