### PR TITLE
fix: ResultPage React Error #310 — Hook 호출 순서 수정

### DIFF
--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -49,6 +49,26 @@ export function ResultPage() {
       .finally(() => setLoading(false))
   }, [jobId])
 
+  // Tab keyboard navigation (WCAG 2.1)
+  // IMPORTANT: useCallback must be called before any early returns
+  // to maintain consistent hook call order (React Rules of Hooks).
+  const v2TabIds = ['intel', 'analysis', 'interview', 'decision'] as const
+  const v1TabIds = ['questions', 'summary', 'guide'] as const
+
+  const handleTabKeyDown = useCallback((e: React.KeyboardEvent, tabs: readonly string[]) => {
+    const currentIndex = tabs.indexOf(activeTab)
+    if (currentIndex === -1) return
+    let newIndex = currentIndex
+    if (e.key === 'ArrowRight') newIndex = (currentIndex + 1) % tabs.length
+    else if (e.key === 'ArrowLeft') newIndex = (currentIndex - 1 + tabs.length) % tabs.length
+    else if (e.key === 'Home') newIndex = 0
+    else if (e.key === 'End') newIndex = tabs.length - 1
+    else return
+    e.preventDefault()
+    setActiveTab(tabs[newIndex] as typeof activeTab)
+    document.getElementById(`tab-${tabs[newIndex]}`)?.focus()
+  }, [activeTab])
+
   if (loading) {
     return (
       <div className="space-y-6 py-6">
@@ -100,24 +120,6 @@ export function ResultPage() {
   const handleScoreChange = (index: number, score: number) => {
     setScores((prev) => ({ ...prev, [index]: score }))
   }
-
-  // Tab keyboard navigation (WCAG 2.1)
-  const v2TabIds = ['intel', 'analysis', 'interview', 'decision'] as const
-  const v1TabIds = ['questions', 'summary', 'guide'] as const
-
-  const handleTabKeyDown = useCallback((e: React.KeyboardEvent, tabs: readonly string[]) => {
-    const currentIndex = tabs.indexOf(activeTab)
-    if (currentIndex === -1) return
-    let newIndex = currentIndex
-    if (e.key === 'ArrowRight') newIndex = (currentIndex + 1) % tabs.length
-    else if (e.key === 'ArrowLeft') newIndex = (currentIndex - 1 + tabs.length) % tabs.length
-    else if (e.key === 'Home') newIndex = 0
-    else if (e.key === 'End') newIndex = tabs.length - 1
-    else return
-    e.preventDefault()
-    setActiveTab(tabs[newIndex] as typeof activeTab)
-    document.getElementById(`tab-${tabs[newIndex]}`)?.focus()
-  }, [activeTab])
 
   const totalScore = Object.values(scores).reduce((sum, s) => sum + s, 0)
   const maxScore = Object.keys(scores).length * 5


### PR DESCRIPTION
## 요약

- `ResultPage.tsx`에서 `useCallback` Hook이 early return문 **이후**에 배치 → 렌더 간 Hook 호출 횟수 불일치 → **React Error #310** 발생
- `useCallback`을 early return문 **이전**으로 이동하여 모든 렌더에서 동일한 Hook 호출 순서 보장

## 수정 파일

- `frontend/src/pages/ResultPage.tsx`: `useCallback` + `v2TabIds`/`v1TabIds` 상수 위치 이동

## 이전/이후

| | 1차 렌더 (loading) | 2차 렌더 (data loaded) |
|--|---|---|
| **이전** | 9 Hooks → early return | 10 Hooks (useCallback 추가) → **Error #310** |
| **이후** | 10 Hooks → early return | 10 Hooks → 정상 렌더 |

## 검증

- `npx tsc --noEmit` ✅
- Playwright 4탭 순회 통과 ✅
- 콘솔 에러 0건 ✅

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)