### PR TITLE
fix: CRITICAL/HIGH 보안 및 인프라 6건 수정 (#121)

### DIFF
--- a/backend/app/api/routes/evals.py
+++ b/backend/app/api/routes/evals.py
@@ -4,9 +4,11 @@ Phoenix 평가 API 엔드포인트
 """
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
+from app.api.deps import get_current_user_or_api_key
+from app.core.rate_limit import limiter
 from app.services.phoenix_eval import phoenix_eval_service
 
 router = APIRouter(prefix="/evals", tags=["evals"])
@@ -34,7 +36,8 @@ class BatchEvalRequest(BaseModel):
 
 
 @router.get("/status")
-async def get_eval_status():
+@limiter.limit("30/minute")
+async def get_eval_status(request: Request, _user=Depends(get_current_user_or_api_key)):
     """Phoenix 평가 서비스 상태 확인"""
     return {
         "enabled": phoenix_eval_service.is_enabled(),
@@ -43,7 +46,8 @@ async def get_eval_status():
 
 
 @router.post("/hallucination", response_model=EvalResponse)
-async def evaluate_hallucination(request: EvalRequest):
+@limiter.limit("10/minute")
+async def evaluate_hallucination(request: Request, body: EvalRequest, _user=Depends(get_current_user_or_api_key)):
     """환각(Hallucination) 평가
 
     답변이 컨텍스트에 기반하는지 확인
@@ -52,15 +56,16 @@ async def evaluate_hallucination(request: EvalRequest):
         raise HTTPException(status_code=503, detail="Phoenix not enabled")
 
     result = await phoenix_eval_service.evaluate_hallucination(
-        question=request.question,
-        context=request.context,
-        answer=request.answer,
+        question=body.question,
+        context=body.context,
+        answer=body.answer,
     )
     return result
 
 
 @router.post("/relevance", response_model=EvalResponse)
-async def evaluate_relevance(request: EvalRequest):
+@limiter.limit("10/minute")
+async def evaluate_relevance(request: Request, body: EvalRequest, _user=Depends(get_current_user_or_api_key)):
     """관련성(Relevance) 평가
 
     답변이 질문에 관련 있는지 확인
@@ -69,14 +74,15 @@ async def evaluate_relevance(request: EvalRequest):
         raise HTTPException(status_code=503, detail="Phoenix not enabled")
 
     result = await phoenix_eval_service.evaluate_relevance(
-        question=request.question,
-        answer=request.answer,
+        question=body.question,
+        answer=body.answer,
     )
     return result
 
 
 @router.post("/batch/interview-questions")
-async def evaluate_interview_questions(request: BatchEvalRequest):
+@limiter.limit("5/minute")
+async def evaluate_interview_questions(request: Request, body: BatchEvalRequest, _user=Depends(get_current_user_or_api_key)):
     """면접 질문 배치 평가
 
     생성된 면접 질문들의 품질을 평가
@@ -85,8 +91,8 @@ async def evaluate_interview_questions(request: BatchEvalRequest):
         raise HTTPException(status_code=503, detail="Phoenix not enabled")
 
     results = await phoenix_eval_service.evaluate_interview_questions(
-        questions=request.questions,
-        jd_context=request.jd_context,
-        candidate_context=request.candidate_context,
+        questions=body.questions,
+        jd_context=body.jd_context,
+        candidate_context=body.candidate_context,
     )
     return {"evaluations": results}

--- a/backend/app/api/routes/ws.py
+++ b/backend/app/api/routes/ws.py
@@ -62,6 +62,11 @@ async def job_progress_ws(
             await websocket.close(code=4004)
             return
 
+        if job.user_id != user.id:
+            await websocket.send_json({"error": "Not authorized"})
+            await websocket.close(code=4003)
+            return
+
         # Poll Temporal for progress
         from app.core.temporal import get_temporal_client
         client = await get_temporal_client()
@@ -83,7 +88,7 @@ async def job_progress_ws(
 
             except Exception as e:
                 logger.debug(f"Workflow query failed: {e}")
-                await websocket.send_json({"event": "query_error", "message": str(e)})
+                await websocket.send_json({"event": "query_error", "message": "Workflow query failed"})
                 break
 
             await asyncio.sleep(2)
@@ -206,7 +211,7 @@ async def job_logs_ws(
 
             except Exception as e:
                 logger.debug(f"Log polling error: {e}")
-                await websocket.send_json({"event": "error", "message": str(e)})
+                await websocket.send_json({"event": "error", "message": "Log polling failed"})
                 break
 
             await asyncio.sleep(2)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -3,6 +3,8 @@ backend/app/services/auth_service.py
 JWT 생성/검증, API Key 생성/검증, Fernet 암호화
 """
 import hashlib
+import hmac
+import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 
@@ -10,6 +12,8 @@ from cryptography.fernet import Fernet
 from jose import JWTError, jwt
 
 from app.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 # --- JWT ---
 
@@ -46,8 +50,9 @@ def create_api_key() -> tuple[str, str]:
 
 
 def verify_api_key(raw_key: str, stored_hash: str) -> bool:
-    """API Key 검증"""
-    return hashlib.sha256(raw_key.encode()).hexdigest() == stored_hash
+    """API Key 검증 (constant-time comparison)"""
+    computed = hashlib.sha256(raw_key.encode()).hexdigest()
+    return hmac.compare_digest(computed, stored_hash)
 
 
 def hash_api_key(raw_key: str) -> str:
@@ -57,14 +62,22 @@ def hash_api_key(raw_key: str) -> str:
 
 # --- Fernet 암호화 (OAuth access_token 저장용) ---
 
+_DEV_FERNET_KEY = Fernet.generate_key()
+
+
 def get_fernet() -> Fernet:
     """Fernet 인스턴스 (OAUTH_TOKEN_ENCRYPTION_KEY)"""
     key = settings.OAUTH_TOKEN_ENCRYPTION_KEY
-    # 키가 유효한 Fernet 키가 아니면 dev fallback 사용
     try:
         return Fernet(key.encode() if isinstance(key, str) else key)
     except Exception:
-        return Fernet(Fernet.generate_key())
+        if not getattr(settings, "is_local", True):
+            raise ValueError(
+                "OAUTH_TOKEN_ENCRYPTION_KEY가 유효한 Fernet 키가 아닙니다. "
+                "python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\" 으로 생성하세요."
+            )
+        logger.warning("OAUTH_TOKEN_ENCRYPTION_KEY 무효 → 개발용 임시 키 사용 (프로세스 재시작 시 토큰 무효화)")
+        return Fernet(_DEV_FERNET_KEY)
 
 
 def encrypt_token(token: str) -> str:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - backend
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      test: ["CMD-SHELL", "wget -qO /dev/null http://localhost:80/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -85,7 +85,7 @@ services:
       phoenix:
         condition: service_started
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/')"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## 요약

개선 사이클 #4에서 발견된 CRITICAL/HIGH 이슈 6건 수정.

### 수정 내역

| # | 심각도 | 파일 | 수정 내용 |
|---|--------|------|----------|
| 1 | CRITICAL | `docker-compose.yml:15,88` | healthcheck `curl` → `wget`/`python urllib` (컨테이너에 curl 미설치) |
| 2 | CRITICAL | `auth_service.py:50` | API key `==` → `hmac.compare_digest` (타이밍 공격 방지) |
| 3 | CRITICAL | `auth_service.py:60-67` | Fernet 매 호출 랜덤 키 → 프로세스 내 안정 키 + 프로덕션 예외 발생 |
| 4 | HIGH | `ws.py:60-64` | WebSocket progress에 `job.user_id != user.id` 소유권 검증 추가 |
| 5 | HIGH | `ws.py:86,209` | 내부 에러 메시지(`str(e)`) 대신 제네릭 메시지 전송 |
| 6 | HIGH | `evals.py` | 전체 엔드포인트에 `get_current_user_or_api_key` 인증 + Rate Limiting 추가 |

### 검증 결과

- ✅ `hmac.compare_digest` 사용 확인
- ✅ API key 생성/검증 round-trip 정상
- ✅ Fernet dev 모드 안정적 키 사용 확인
- ✅ WebSocket ownership 검증 2개 (progress + logs)
- ✅ 내부 에러 노출 0건
- ✅ Backend healthcheck HTTP 200 정상

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)