### PR TITLE
fix: 프론트엔드 i18n 하드코딩 문자열 8건 수정

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -215,6 +215,11 @@ const resources = {
       result_analysis_logs: '분석 로그',
       result_back_to_list: '목록으로 돌아가기',
       result_terms_count: '{{count}}개 용어',
+      // ResultPage - v2 tabs
+      result_tab_intel_brief: '인텔 브리프',
+      result_tab_analysis: '심층 분석',
+      result_tab_interview: '라이브 면접',
+      result_tab_decision: '의사 결정',
       // ResultPage - v1 tabs
       result_tab_questions: '질문 목록',
       result_tab_summary: '후보자 분석',
@@ -256,6 +261,9 @@ const resources = {
       result_scoring_scale: '점수 범위',
       result_passing_threshold: '합격 기준',
       result_v1_category_weights: '카테고리별 가중치',
+      result_strong_hire: 'Strong Hire',
+      result_green_flags: '긍정 신호',
+      result_red_flags: '주의 신호',
       // JobStatusPage
       status_title: '면접 스크립트 #{{id}}',
       progress_label: '진행률',
@@ -508,6 +516,11 @@ const resources = {
       result_analysis_logs: 'Analysis Logs',
       result_back_to_list: 'Back to List',
       result_terms_count: '{{count}} terms',
+      // ResultPage - v2 tabs
+      result_tab_intel_brief: 'Intel Brief',
+      result_tab_analysis: 'Deep Analysis',
+      result_tab_interview: 'Live Interview',
+      result_tab_decision: 'Decision',
       // ResultPage - v1 tabs
       result_tab_questions: 'Questions',
       result_tab_summary: 'Candidate Analysis',
@@ -549,6 +562,9 @@ const resources = {
       result_scoring_scale: 'Scoring Scale',
       result_passing_threshold: 'Passing Threshold',
       result_v1_category_weights: 'Category Weights',
+      result_strong_hire: 'Strong Hire',
+      result_green_flags: 'Green Flags',
+      result_red_flags: 'Red Flags',
       // JobStatusPage
       status_title: 'Interview Script #{{id}}',
       progress_label: 'Progress',

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -75,7 +75,7 @@ export function LoginPage() {
                 />
               </svg>
             </div>
-            <h1 className="text-2xl font-bold text-gray-900">Vantict Sniper</h1>
+            <h1 className="text-2xl font-bold text-gray-900">{t('app_title')}</h1>
             <p className="mt-2 text-sm text-gray-600">{t('login_subtitle')}</p>
           </div>
 

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -220,7 +220,7 @@ export function ResultPage() {
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
-            Intel Brief
+            {t('result_tab_intel_brief')}
           </button>
           <button
             role="tab"
@@ -237,7 +237,7 @@ export function ResultPage() {
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
             </svg>
-            Deep Analysis
+            {t('result_tab_analysis')}
           </button>
           <button
             role="tab"
@@ -254,7 +254,7 @@ export function ResultPage() {
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
             </svg>
-            Live Interview ({questions.length})
+            {t('result_tab_interview')} ({questions.length})
           </button>
           <button
             role="tab"
@@ -271,7 +271,7 @@ export function ResultPage() {
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            Decision
+            {t('result_tab_decision')}
           </button>
         </div>
       ) : (
@@ -672,7 +672,7 @@ export function ResultPage() {
                       <div className="text-lg font-bold text-indigo-600">
                         ≥ {guide.evaluation_matrix.strong_hire_threshold}
                       </div>
-                      <div className="text-sm text-gray-500">Strong Hire</div>
+                      <div className="text-sm text-gray-500">{t('result_strong_hire')}</div>
                     </div>
                   </div>
                   {guide.evaluation_matrix.category_weights && (
@@ -694,7 +694,7 @@ export function ResultPage() {
               <div className="grid gap-6 sm:grid-cols-2">
                 {guide.green_flags_summary && guide.green_flags_summary.length > 0 && (
                   <div className="rounded-xl border border-green-200 bg-green-50 p-6">
-                    <h2 className="text-lg font-semibold text-green-900 mb-3">✅ Green Flags</h2>
+                    <h2 className="text-lg font-semibold text-green-900 mb-3">✅ {t('result_green_flags')}</h2>
                     <ul className="space-y-2">
                       {guide.green_flags_summary.map((flag, i) => (
                         <li key={i} className="text-sm text-green-800 flex items-start gap-2">
@@ -707,7 +707,7 @@ export function ResultPage() {
                 )}
                 {guide.red_flags_summary && guide.red_flags_summary.length > 0 && (
                   <div className="rounded-xl border border-red-200 bg-red-50 p-6">
-                    <h2 className="text-lg font-semibold text-red-900 mb-3">🚩 Red Flags</h2>
+                    <h2 className="text-lg font-semibold text-red-900 mb-3">🚩 {t('result_red_flags')}</h2>
                     <ul className="space-y-2">
                       {guide.red_flags_summary.map((flag, i) => (
                         <li key={i} className="text-sm text-red-800 flex items-start gap-2">


### PR DESCRIPTION
## 요약

- v2 탭 라벨 4개 (Intel Brief, Deep Analysis, Live Interview, Decision) → i18n 키 전환
- v1 가이드 라벨 3개 (Strong Hire, Green Flags, Red Flags) → i18n 키 전환
- LoginPage 앱 제목 "Vantict Sniper" → `t('app_title')` 전환
- i18n.ts에 ko/en 양방향 번역 키 8개 추가

## 수정 파일

| 파일 | 변경 |
|------|------|
| `frontend/src/i18n.ts` | 8개 새 키 추가 (ko/en) |
| `frontend/src/pages/ResultPage.tsx` | 7개 하드코딩 → i18n |
| `frontend/src/pages/LoginPage.tsx` | 1개 하드코딩 → i18n |

## 테스트 결과

- [x] TypeScript 타입 체크 통과 (`npx tsc --noEmit`)
- [x] 프로덕션 빌드 성공 (`npm run build`)
- [x] 하드코딩 문자열 재검증 (`grep` 결과 0건)

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)