### PR TITLE
improve: question_generation.py 모듈 분리 (746→411줄)

### DIFF
--- a/backend/app/workflows/activities/question_enhancement.py
+++ b/backend/app/workflows/activities/question_enhancement.py
@@ -1,0 +1,163 @@
+"""
+backend/app/workflows/activities/question_enhancement.py
+질문 Enhancement Activities — 용어설명, 평가시나리오, 꼬리질문, 면접관노트, 의사결정가이드, 수정
+
+Extracted from question_generation.py for SRP compliance.
+"""
+import json
+import logging
+
+from temporalio import activity
+
+from app.core.observability import observe_activity
+from app.workflows.utils import run_llm_with_prompt_config_heartbeat
+
+logger = logging.getLogger(__name__)
+
+
+@activity.defn
+@observe_activity(name="enhance_terminology", phase="question_generation")
+async def enhance_terminology(questions: list[dict], enriched_input: dict) -> dict:
+    """3c. Terminology Agent — 전문용어에 비개발자용 설명 추가"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt_with_config
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+
+    prompt_config = get_prompt_with_config(
+        "question_generation.yaml", "enhance_terminology",
+        output_language=output_language,
+        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
+    )
+    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
+    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
+    from app.services.cached_llm import validate_llm_output
+    return validate_llm_output(result, activity_name="enhance_terminology")
+
+
+@activity.defn
+@observe_activity(name="craft_evaluation_scenarios", phase="question_generation")
+async def craft_evaluation_scenarios(questions: list[dict], enriched_input: dict) -> dict:
+    """3d. Scenario Writer Agent — 3단계 평가 시나리오 생성"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt_with_config
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+    experience_level = raw_input.get("experience_level", "미들")
+
+    prompt_config = get_prompt_with_config(
+        "question_generation.yaml", "craft_evaluation_scenarios",
+        output_language=output_language,
+        experience_level=experience_level,
+        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
+    )
+    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
+    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
+    from app.services.cached_llm import validate_llm_output
+    return validate_llm_output(result, activity_name="craft_evaluation_scenarios")
+
+
+@activity.defn
+@observe_activity(name="design_follow_ups", phase="question_generation")
+async def design_follow_ups(questions: list[dict], enriched_input: dict) -> dict:
+    """3e. Follow-up Designer Agent — 후속질문 분기 설계"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt_with_config
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+    experience_level = raw_input.get("experience_level", "미들")
+
+    prompt_config = get_prompt_with_config(
+        "question_generation.yaml", "design_follow_ups",
+        output_language=output_language,
+        experience_level=experience_level,
+        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
+    )
+    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
+    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
+    from app.services.cached_llm import validate_llm_output
+    return validate_llm_output(result, activity_name="design_follow_ups")
+
+
+@activity.defn
+@observe_activity(name="generate_interviewer_notes", phase="question_generation")
+async def generate_interviewer_notes(questions: list[dict], enriched_input: dict) -> dict:
+    """3f. Interviewer Note Agent — 면접관 참고 노트"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt_with_config
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+
+    prompt_config = get_prompt_with_config(
+        "question_generation.yaml", "generate_interviewer_notes",
+        output_language=output_language,
+        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
+    )
+    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
+    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
+    from app.services.cached_llm import validate_llm_output
+    return validate_llm_output(result, activity_name="generate_interviewer_notes")
+
+
+@activity.defn
+@observe_activity(name="generate_decision_guide", phase="question_generation")
+async def generate_decision_guide(analysis: dict, enriched_input: dict) -> dict:
+    """3g. Decision Guide Agent — 채용 의사결정 가이드"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt_with_config
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+    experience_level = raw_input.get("experience_level", "미들")
+
+    # Summarize analysis for the prompt
+    analysis_summary = json.dumps({
+        k: v.get("summary", str(v)[:500]) if isinstance(v, dict) else str(v)[:500]
+        for k, v in analysis.items()
+    }, ensure_ascii=False, default=str)
+
+    categories = ["role_fit", "technical_depth", "execution_ownership", "communication", "risk_flags"]
+    category_summary = json.dumps(categories, ensure_ascii=False)
+
+    prompt_config = get_prompt_with_config(
+        "question_generation.yaml", "generate_decision_guide",
+        output_language=output_language,
+        experience_level=experience_level,
+        analysis_summary=analysis_summary,
+        category_summary=category_summary,
+    )
+    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
+    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
+    from app.services.cached_llm import validate_llm_output
+    return validate_llm_output(result, activity_name="generate_decision_guide")
+
+
+@activity.defn
+@observe_activity(name="revise_questions", phase="question_generation")
+async def revise_questions(questions: list[dict], review_feedback: dict, enriched_input: dict) -> list[dict]:
+    """3h. Quality Review revision — 피드백 기반 질문 수정"""
+    from app.services.cached_llm import CachedLLMService
+    from app.prompts import get_prompt_with_config
+
+    llm = CachedLLMService()
+    raw_input = enriched_input.get("raw_input", {})
+    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
+
+    prompt_config = get_prompt_with_config(
+        "question_generation.yaml", "revise_questions",
+        output_language=output_language,
+        questions_json=json.dumps(questions, ensure_ascii=False, default=str),
+        review_feedback=json.dumps(review_feedback, ensure_ascii=False, default=str),
+    )
+    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
+    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
+    return result if isinstance(result, list) else questions

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -1,6 +1,9 @@
 """
 backend/app/workflows/activities/question_generation.py
 질문 생성 Activities (토픽 선정 + 개별 질문 생성)
+
+Enhancement Activities는 question_enhancement.py로 분리됨.
+유틸리티(상수, 헬퍼)는 question_generation_utils.py로 분리됨.
 """
 import logging
 import uuid
@@ -11,204 +14,27 @@ from app.core.observability import observe_activity
 from app.services.activity_logger import ActivityLogger
 from app.workflows.utils import run_llm_with_prompt_config_heartbeat
 
+# ── 분리된 모듈 import ──
+from app.workflows.activities.question_generation_utils import (
+    TOTAL_QUESTIONS,
+    get_distribution,
+    format_distribution_for_prompt,
+    build_candidate_context,
+    format_candidates,
+)
+
+# Backwards-compatible alias (테스트에서 사용)
+_format_candidates = format_candidates  # noqa: F841
+from app.workflows.activities.question_enhancement import (  # noqa: F401 — re-export
+    enhance_terminology,
+    craft_evaluation_scenarios,
+    design_follow_ups,
+    generate_interviewer_notes,
+    generate_decision_guide,
+    revise_questions,
+)
+
 logger = logging.getLogger(__name__)
-
-# ── 경험 레벨별 퍼센트 기반 카테고리 배분 ──
-# 각 레벨에서 중요한 질문 유형에 더 높은 비율 할당
-TOTAL_QUESTIONS = 20
-
-CATEGORY_DISTRIBUTION: dict[str, dict[str, dict]] = {
-    # 신입: 기초 기술력 + 성장 가능성 + 커뮤니케이션 중심
-    "신입": {
-        "role_fit":             {"count": 6, "difficulty": ["Easy", "Easy", "Easy", "Medium", "Medium", "Hard"]},
-        "technical_depth":      {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
-        "execution_ownership":  {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
-        "communication":        {"count": 4, "difficulty": ["Easy", "Easy", "Medium", "Hard"]},
-        "risk_flags":           {"count": 2, "difficulty": ["Easy", "Medium"]},
-    },
-    # 주니어: 성장 가능성 + 기초 기술력 중심
-    "주니어": {
-        "role_fit":             {"count": 6, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Medium", "Hard"]},
-        "technical_depth":      {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
-        "execution_ownership":  {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
-        "communication":        {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
-        "risk_flags":           {"count": 2, "difficulty": ["Easy", "Medium"]},
-    },
-    # 미들: 균형 잡힌 배분
-    "미들": {
-        "role_fit":             {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
-        "technical_depth":      {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
-        "execution_ownership":  {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
-        "communication":        {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
-        "risk_flags":           {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
-    },
-    # 시니어: 실행력 + 리스크 + 기술 깊이 중심
-    "시니어": {
-        "role_fit":             {"count": 3, "difficulty": ["Medium", "Medium", "Hard"]},
-        "technical_depth":      {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
-        "execution_ownership":  {"count": 5, "difficulty": ["Easy", "Medium", "Medium", "Hard", "Hard"]},
-        "communication":        {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
-        "risk_flags":           {"count": 4, "difficulty": ["Easy", "Medium", "Hard", "Hard"]},
-    },
-    # CTO/VP: 리더십 + 전략적 실행력 + 리스크 관리 중심
-    "CTO/VP": {
-        "role_fit":             {"count": 3, "difficulty": ["Medium", "Hard", "Hard"]},
-        "technical_depth":      {"count": 3, "difficulty": ["Medium", "Hard", "Hard"]},
-        "execution_ownership":  {"count": 5, "difficulty": ["Medium", "Medium", "Hard", "Hard", "Hard"]},
-        "communication":        {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
-        "risk_flags":           {"count": 5, "difficulty": ["Medium", "Medium", "Hard", "Hard", "Hard"]},
-    },
-}
-
-
-def _get_distribution(experience_level: str) -> dict[str, dict]:
-    """경험 레벨에 맞는 카테고리 배분 반환 (fallback: 미들)"""
-    return CATEGORY_DISTRIBUTION.get(experience_level, CATEGORY_DISTRIBUTION["미들"])
-
-
-def _format_distribution_for_prompt(dist: dict[str, dict]) -> tuple[str, str]:
-    """프롬프트용 카테고리 배분 + 난이도 배분 텍스트 생성"""
-    cat_lines = []
-    diff_lines = []
-    for cat, info in dist.items():
-        count = info["count"]
-        pct = round(count / TOTAL_QUESTIONS * 100)
-        cat_desc = {
-            "role_fit": "Culture fit, motivation, career goals, growth potential",
-            "technical_depth": "Technical skills, problem-solving, architecture",
-            "execution_ownership": "Project delivery, ownership, impact, leadership",
-            "communication": "Collaboration, explanation ability, conflict resolution",
-            "risk_flags": "Gaps, concerns, areas needing clarification",
-        }
-        cat_lines.append(f"- **{cat}** ({pct}%): {count} topics — {cat_desc.get(cat, '')}")
-
-        # 난이도 카운트
-        from collections import Counter
-        diff_count = Counter(info["difficulty"])
-        diff_str = ", ".join(f"{d}:{c}" for d, c in sorted(diff_count.items(), key=lambda x: ["Easy", "Medium", "Hard"].index(x[0])))
-        diff_lines.append(f"- **{cat}** ({count} topics): {diff_str}")
-
-    return "\n      ".join(cat_lines), "\n      ".join(diff_lines)
-
-
-def _build_candidate_context(analysis: dict, enriched_input: dict) -> str:
-    """
-    후보자 정보를 LLM 프롬프트용 요약 텍스트로 조합.
-    document_analysis, code_analysis, linkedin_profile, jd_analysis에서 핵심 정보 추출.
-    각 섹션은 graceful degradation (데이터 없으면 스킵).
-    """
-    sections = []
-
-    # 1. 이력서/포트폴리오 프로필
-    doc = analysis.get("document_analysis", {})
-    profile = doc.get("profile", {})
-    if profile:
-        parts = []
-        if profile.get("name"):
-            parts.append(f"Name: {profile['name']}")
-        if profile.get("summary"):
-            parts.append(f"Summary: {profile['summary'][:200]}")
-        skills = profile.get("skills", [])
-        if skills:
-            parts.append(f"Skills: {', '.join(skills[:15])}")
-        experience = profile.get("work_experience") or profile.get("experience", [])
-        if experience and isinstance(experience, list):
-            exp_lines = []
-            for exp in experience[:3]:
-                if isinstance(exp, dict):
-                    role = exp.get("title") or exp.get("role", "")
-                    company = exp.get("company", "")
-                    if role or company:
-                        exp_lines.append(f"  - {role} @ {company}")
-                elif isinstance(exp, str):
-                    exp_lines.append(f"  - {exp[:100]}")
-            if exp_lines:
-                parts.append("Work Experience:\n" + "\n".join(exp_lines))
-        projects = profile.get("projects", [])
-        if projects and isinstance(projects, list):
-            proj_lines = []
-            for proj in projects[:3]:
-                if isinstance(proj, dict):
-                    proj_lines.append(f"  - {proj.get('name', proj.get('title', ''))}: {proj.get('description', '')[:80]}")
-                elif isinstance(proj, str):
-                    proj_lines.append(f"  - {proj[:100]}")
-            if proj_lines:
-                parts.append("Projects:\n" + "\n".join(proj_lines))
-        if parts:
-            sections.append("## Resume/Portfolio\n" + "\n".join(parts))
-
-    # 2. LinkedIn 프로필
-    raw_input = enriched_input.get("raw_input", {})
-    linkedin = raw_input.get("linkedin_profile") or enriched_input.get("linkedin_profile", {})
-    if linkedin and isinstance(linkedin, dict):
-        parts = []
-        name = linkedin.get("full_name") or linkedin.get("name", "")
-        headline = linkedin.get("headline", "")
-        if name:
-            parts.append(f"Name: {name}")
-        if headline:
-            parts.append(f"Headline: {headline}")
-        experiences = linkedin.get("experiences") or linkedin.get("experience", [])
-        if experiences and isinstance(experiences, list):
-            for exp in experiences[:3]:
-                if isinstance(exp, dict):
-                    title = exp.get("title", "")
-                    company = exp.get("company_name") or exp.get("company", "")
-                    if title or company:
-                        parts.append(f"  - {title} @ {company}")
-        li_skills = linkedin.get("skills", [])
-        if li_skills and isinstance(li_skills, list):
-            skill_names = []
-            for s in li_skills[:10]:
-                skill_names.append(s.get("name", str(s)) if isinstance(s, dict) else str(s))
-            parts.append(f"Skills: {', '.join(skill_names)}")
-        if parts:
-            sections.append("## LinkedIn Profile\n" + "\n".join(parts))
-
-    # 3. 코드 분석
-    code = analysis.get("code_analysis", {})
-    if code:
-        parts = []
-        langs = code.get("languages") or code.get("tech_stack", [])
-        if langs:
-            if isinstance(langs, dict):
-                parts.append(f"Languages: {', '.join(list(langs.keys())[:10])}")
-            elif isinstance(langs, list):
-                parts.append(f"Tech Stack: {', '.join(str(l) for l in langs[:10])}")
-        repo_summary = code.get("summary") or code.get("repo_summary", "")
-        if repo_summary and isinstance(repo_summary, str):
-            parts.append(f"Summary: {repo_summary[:200]}")
-        top_candidates = code.get("top_question_candidates", [])
-        if top_candidates:
-            cand_lines = [f"  - {c.get('title', '')}" for c in top_candidates[:5] if isinstance(c, dict)]
-            if cand_lines:
-                parts.append("Notable Implementations:\n" + "\n".join(cand_lines))
-        if parts:
-            sections.append("## Code Analysis (GitHub)\n" + "\n".join(parts))
-
-    # 4. JD 매칭 요약
-    jd = analysis.get("jd_analysis", {})
-    if jd:
-        parts = []
-        title = jd.get("job_title", "")
-        if title:
-            parts.append(f"Target Role: {title}")
-        reqs = jd.get("requirements", [])
-        if reqs:
-            req_skills = []
-            for r in reqs[:8]:
-                if isinstance(r, dict):
-                    req_skills.append(r.get("skill", str(r)))
-                else:
-                    req_skills.append(str(r))
-            parts.append(f"Key Requirements: {', '.join(req_skills)}")
-        if parts:
-            sections.append("## JD Requirements\n" + "\n".join(parts))
-
-    if not sections:
-        return ""
-
-    return "\n\n".join(sections)
 
 
 @activity.defn
@@ -232,7 +58,7 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
     raw_input = enriched_input.get("raw_input", {})
     experience_level = raw_input.get("experience_level", "미들")
     max_questions = TOTAL_QUESTIONS  # 고정 20개 (퍼센트 기반)
-    dist = _get_distribution(experience_level)
+    dist = get_distribution(experience_level)
 
     if alog:
         await alog.start("Selecting question topics", {
@@ -363,15 +189,15 @@ async def select_topics(analysis: dict, enriched_input: dict, job_id: str | None
 
     activity.heartbeat(f"Selecting {max_questions} topics from {len(candidates)} candidates...")
 
-    cat_dist_text, diff_dist_text = _format_distribution_for_prompt(dist)
-    candidate_context = _build_candidate_context(analysis, enriched_input)
+    cat_dist_text, diff_dist_text = format_distribution_for_prompt(dist)
+    candidate_context = build_candidate_context(analysis, enriched_input)
 
     from app.prompts import get_prompt_with_config
     prompt_config = get_prompt_with_config(
         "question_generation.yaml", "select_topics",
         max_questions=max_questions,
         experience_level=experience_level,
-        candidates=_format_candidates(candidates),
+        candidates=format_candidates(candidates),
         category_distribution=cat_dist_text,
         difficulty_distribution=diff_dist_text,
         candidate_context=candidate_context,
@@ -505,7 +331,7 @@ async def craft_question(
     # 카테고리별 특화 프롬프트 선택 (fallback → 범용 craft_question)
     category = topic.get("category", "technical_depth")
     category_prompt_key = f"craft_question_{category}"
-    candidate_context = _build_candidate_context(analysis, enriched_input)
+    candidate_context = build_candidate_context(analysis, enriched_input)
     try:
         prompt_config = get_prompt_with_config(
             "question_generation.yaml", category_prompt_key,
@@ -585,162 +411,3 @@ async def craft_question(
     return question
 
 
-@activity.defn
-@observe_activity(name="enhance_terminology", phase="question_generation")
-async def enhance_terminology(questions: list[dict], enriched_input: dict) -> dict:
-    """3c. Terminology Agent — 전문용어에 비개발자용 설명 추가"""
-    from app.services.cached_llm import CachedLLMService
-    from app.prompts import get_prompt_with_config
-    import json
-
-    llm = CachedLLMService()
-    raw_input = enriched_input.get("raw_input", {})
-    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
-
-    prompt_config = get_prompt_with_config(
-        "question_generation.yaml", "enhance_terminology",
-        output_language=output_language,
-        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
-    )
-    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
-    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
-    from app.services.cached_llm import validate_llm_output
-    return validate_llm_output(result, activity_name="enhance_terminology")
-
-
-@activity.defn
-@observe_activity(name="craft_evaluation_scenarios", phase="question_generation")
-async def craft_evaluation_scenarios(questions: list[dict], enriched_input: dict) -> dict:
-    """3d. Scenario Writer Agent — 3단계 평가 시나리오 생성"""
-    from app.services.cached_llm import CachedLLMService
-    from app.prompts import get_prompt_with_config
-    import json
-
-    llm = CachedLLMService()
-    raw_input = enriched_input.get("raw_input", {})
-    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
-    experience_level = raw_input.get("experience_level", "미들")
-
-    prompt_config = get_prompt_with_config(
-        "question_generation.yaml", "craft_evaluation_scenarios",
-        output_language=output_language,
-        experience_level=experience_level,
-        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
-    )
-    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
-    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
-    from app.services.cached_llm import validate_llm_output
-    return validate_llm_output(result, activity_name="craft_evaluation_scenarios")
-
-
-@activity.defn
-@observe_activity(name="design_follow_ups", phase="question_generation")
-async def design_follow_ups(questions: list[dict], enriched_input: dict) -> dict:
-    """3e. Follow-up Designer Agent — 후속질문 분기 설계"""
-    from app.services.cached_llm import CachedLLMService
-    from app.prompts import get_prompt_with_config
-    import json
-
-    llm = CachedLLMService()
-    raw_input = enriched_input.get("raw_input", {})
-    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
-    experience_level = raw_input.get("experience_level", "미들")
-
-    prompt_config = get_prompt_with_config(
-        "question_generation.yaml", "design_follow_ups",
-        output_language=output_language,
-        experience_level=experience_level,
-        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
-    )
-    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
-    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
-    from app.services.cached_llm import validate_llm_output
-    return validate_llm_output(result, activity_name="design_follow_ups")
-
-
-@activity.defn
-@observe_activity(name="generate_interviewer_notes", phase="question_generation")
-async def generate_interviewer_notes(questions: list[dict], enriched_input: dict) -> dict:
-    """3f. Interviewer Note Agent — 면접관 참고 노트"""
-    from app.services.cached_llm import CachedLLMService
-    from app.prompts import get_prompt_with_config
-    import json
-
-    llm = CachedLLMService()
-    raw_input = enriched_input.get("raw_input", {})
-    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
-
-    prompt_config = get_prompt_with_config(
-        "question_generation.yaml", "generate_interviewer_notes",
-        output_language=output_language,
-        questions_json=json.dumps(questions[:25], ensure_ascii=False, default=str),
-    )
-    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
-    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
-    from app.services.cached_llm import validate_llm_output
-    return validate_llm_output(result, activity_name="generate_interviewer_notes")
-
-
-@activity.defn
-@observe_activity(name="generate_decision_guide", phase="question_generation")
-async def generate_decision_guide(analysis: dict, enriched_input: dict) -> dict:
-    """3g. Decision Guide Agent — 채용 의사결정 가이드"""
-    from app.services.cached_llm import CachedLLMService
-    from app.prompts import get_prompt_with_config
-    import json
-
-    llm = CachedLLMService()
-    raw_input = enriched_input.get("raw_input", {})
-    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
-    experience_level = raw_input.get("experience_level", "미들")
-
-    # Summarize analysis for the prompt
-    analysis_summary = json.dumps({
-        k: v.get("summary", str(v)[:500]) if isinstance(v, dict) else str(v)[:500]
-        for k, v in analysis.items()
-    }, ensure_ascii=False, default=str)
-
-    categories = ["role_fit", "technical_depth", "execution_ownership", "communication", "risk_flags"]
-    category_summary = json.dumps(categories, ensure_ascii=False)
-
-    prompt_config = get_prompt_with_config(
-        "question_generation.yaml", "generate_decision_guide",
-        output_language=output_language,
-        experience_level=experience_level,
-        analysis_summary=analysis_summary,
-        category_summary=category_summary,
-    )
-    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
-    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
-    from app.services.cached_llm import validate_llm_output
-    return validate_llm_output(result, activity_name="generate_decision_guide")
-
-
-@activity.defn
-@observe_activity(name="revise_questions", phase="question_generation")
-async def revise_questions(questions: list[dict], review_feedback: dict, enriched_input: dict) -> list[dict]:
-    """3h. Quality Review revision — 피드백 기반 질문 수정"""
-    from app.services.cached_llm import CachedLLMService
-    from app.prompts import get_prompt_with_config
-    import json
-
-    llm = CachedLLMService()
-    raw_input = enriched_input.get("raw_input", {})
-    output_language = raw_input.get("language_config", {}).get("output_language", "ko")
-
-    prompt_config = get_prompt_with_config(
-        "question_generation.yaml", "revise_questions",
-        output_language=output_language,
-        questions_json=json.dumps(questions, ensure_ascii=False, default=str),
-        review_feedback=json.dumps(review_feedback, ensure_ascii=False, default=str),
-    )
-    # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
-    result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
-    return result if isinstance(result, list) else questions
-
-
-def _format_candidates(candidates: list[dict]) -> str:
-    lines = []
-    for i, c in enumerate(candidates[:30]):
-        lines.append(f"{i+1}. [{c['source']}] {c['topic']} (score: {c['score']})")
-    return "\n".join(lines)

--- a/backend/app/workflows/activities/question_generation_utils.py
+++ b/backend/app/workflows/activities/question_generation_utils.py
@@ -1,0 +1,211 @@
+"""
+backend/app/workflows/activities/question_generation_utils.py
+질문 생성 유틸리티 — 카테고리 배분 상수 + 프롬프트 컨텍스트 빌더
+
+Extracted from question_generation.py for SRP compliance.
+"""
+
+# ── 경험 레벨별 퍼센트 기반 카테고리 배분 ──
+# 각 레벨에서 중요한 질문 유형에 더 높은 비율 할당
+TOTAL_QUESTIONS = 20
+
+CATEGORY_DISTRIBUTION: dict[str, dict[str, dict]] = {
+    # 신입: 기초 기술력 + 성장 가능성 + 커뮤니케이션 중심
+    "신입": {
+        "role_fit":             {"count": 6, "difficulty": ["Easy", "Easy", "Easy", "Medium", "Medium", "Hard"]},
+        "technical_depth":      {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
+        "execution_ownership":  {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Easy", "Easy", "Medium", "Hard"]},
+        "risk_flags":           {"count": 2, "difficulty": ["Easy", "Medium"]},
+    },
+    # 주니어: 성장 가능성 + 기초 기술력 중심
+    "주니어": {
+        "role_fit":             {"count": 6, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Medium", "Hard"]},
+        "technical_depth":      {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
+        "execution_ownership":  {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
+        "risk_flags":           {"count": 2, "difficulty": ["Easy", "Medium"]},
+    },
+    # 미들: 균형 잡힌 배분
+    "미들": {
+        "role_fit":             {"count": 5, "difficulty": ["Easy", "Easy", "Medium", "Medium", "Hard"]},
+        "technical_depth":      {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
+        "execution_ownership":  {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Easy", "Medium", "Medium", "Hard"]},
+        "risk_flags":           {"count": 3, "difficulty": ["Easy", "Medium", "Hard"]},
+    },
+    # 시니어: 실행력 + 리스크 + 기술 깊이 중심
+    "시니어": {
+        "role_fit":             {"count": 3, "difficulty": ["Medium", "Medium", "Hard"]},
+        "technical_depth":      {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
+        "execution_ownership":  {"count": 5, "difficulty": ["Easy", "Medium", "Medium", "Hard", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
+        "risk_flags":           {"count": 4, "difficulty": ["Easy", "Medium", "Hard", "Hard"]},
+    },
+    # CTO/VP: 리더십 + 전략적 실행력 + 리스크 관리 중심
+    "CTO/VP": {
+        "role_fit":             {"count": 3, "difficulty": ["Medium", "Hard", "Hard"]},
+        "technical_depth":      {"count": 3, "difficulty": ["Medium", "Hard", "Hard"]},
+        "execution_ownership":  {"count": 5, "difficulty": ["Medium", "Medium", "Hard", "Hard", "Hard"]},
+        "communication":        {"count": 4, "difficulty": ["Medium", "Medium", "Hard", "Hard"]},
+        "risk_flags":           {"count": 5, "difficulty": ["Medium", "Medium", "Hard", "Hard", "Hard"]},
+    },
+}
+
+
+def get_distribution(experience_level: str) -> dict[str, dict]:
+    """경험 레벨에 맞는 카테고리 배분 반환 (fallback: 미들)"""
+    return CATEGORY_DISTRIBUTION.get(experience_level, CATEGORY_DISTRIBUTION["미들"])
+
+
+def format_distribution_for_prompt(dist: dict[str, dict]) -> tuple[str, str]:
+    """프롬프트용 카테고리 배분 + 난이도 배분 텍스트 생성"""
+    from collections import Counter
+
+    cat_lines = []
+    diff_lines = []
+    for cat, info in dist.items():
+        count = info["count"]
+        pct = round(count / TOTAL_QUESTIONS * 100)
+        cat_desc = {
+            "role_fit": "Culture fit, motivation, career goals, growth potential",
+            "technical_depth": "Technical skills, problem-solving, architecture",
+            "execution_ownership": "Project delivery, ownership, impact, leadership",
+            "communication": "Collaboration, explanation ability, conflict resolution",
+            "risk_flags": "Gaps, concerns, areas needing clarification",
+        }
+        cat_lines.append(f"- **{cat}** ({pct}%): {count} topics — {cat_desc.get(cat, '')}")
+
+        # 난이도 카운트
+        diff_count = Counter(info["difficulty"])
+        diff_str = ", ".join(f"{d}:{c}" for d, c in sorted(diff_count.items(), key=lambda x: ["Easy", "Medium", "Hard"].index(x[0])))
+        diff_lines.append(f"- **{cat}** ({count} topics): {diff_str}")
+
+    return "\n      ".join(cat_lines), "\n      ".join(diff_lines)
+
+
+def build_candidate_context(analysis: dict, enriched_input: dict) -> str:
+    """
+    후보자 정보를 LLM 프롬프트용 요약 텍스트로 조합.
+    document_analysis, code_analysis, linkedin_profile, jd_analysis에서 핵심 정보 추출.
+    각 섹션은 graceful degradation (데이터 없으면 스킵).
+    """
+    sections = []
+
+    # 1. 이력서/포트폴리오 프로필
+    doc = analysis.get("document_analysis", {})
+    profile = doc.get("profile", {})
+    if profile:
+        parts = []
+        if profile.get("name"):
+            parts.append(f"Name: {profile['name']}")
+        if profile.get("summary"):
+            parts.append(f"Summary: {profile['summary'][:200]}")
+        skills = profile.get("skills", [])
+        if skills:
+            parts.append(f"Skills: {', '.join(skills[:15])}")
+        experience = profile.get("work_experience") or profile.get("experience", [])
+        if experience and isinstance(experience, list):
+            exp_lines = []
+            for exp in experience[:3]:
+                if isinstance(exp, dict):
+                    role = exp.get("title") or exp.get("role", "")
+                    company = exp.get("company", "")
+                    if role or company:
+                        exp_lines.append(f"  - {role} @ {company}")
+                elif isinstance(exp, str):
+                    exp_lines.append(f"  - {exp[:100]}")
+            if exp_lines:
+                parts.append("Work Experience:\n" + "\n".join(exp_lines))
+        projects = profile.get("projects", [])
+        if projects and isinstance(projects, list):
+            proj_lines = []
+            for proj in projects[:3]:
+                if isinstance(proj, dict):
+                    proj_lines.append(f"  - {proj.get('name', proj.get('title', ''))}: {proj.get('description', '')[:80]}")
+                elif isinstance(proj, str):
+                    proj_lines.append(f"  - {proj[:100]}")
+            if proj_lines:
+                parts.append("Projects:\n" + "\n".join(proj_lines))
+        if parts:
+            sections.append("## Resume/Portfolio\n" + "\n".join(parts))
+
+    # 2. LinkedIn 프로필
+    raw_input = enriched_input.get("raw_input", {})
+    linkedin = raw_input.get("linkedin_profile") or enriched_input.get("linkedin_profile", {})
+    if linkedin and isinstance(linkedin, dict):
+        parts = []
+        name = linkedin.get("full_name") or linkedin.get("name", "")
+        headline = linkedin.get("headline", "")
+        if name:
+            parts.append(f"Name: {name}")
+        if headline:
+            parts.append(f"Headline: {headline}")
+        experiences = linkedin.get("experiences") or linkedin.get("experience", [])
+        if experiences and isinstance(experiences, list):
+            for exp in experiences[:3]:
+                if isinstance(exp, dict):
+                    title = exp.get("title", "")
+                    company = exp.get("company_name") or exp.get("company", "")
+                    if title or company:
+                        parts.append(f"  - {title} @ {company}")
+        li_skills = linkedin.get("skills", [])
+        if li_skills and isinstance(li_skills, list):
+            skill_names = []
+            for s in li_skills[:10]:
+                skill_names.append(s.get("name", str(s)) if isinstance(s, dict) else str(s))
+            parts.append(f"Skills: {', '.join(skill_names)}")
+        if parts:
+            sections.append("## LinkedIn Profile\n" + "\n".join(parts))
+
+    # 3. 코드 분석
+    code = analysis.get("code_analysis", {})
+    if code:
+        parts = []
+        langs = code.get("languages") or code.get("tech_stack", [])
+        if langs:
+            if isinstance(langs, dict):
+                parts.append(f"Languages: {', '.join(list(langs.keys())[:10])}")
+            elif isinstance(langs, list):
+                parts.append(f"Tech Stack: {', '.join(str(l) for l in langs[:10])}")
+        repo_summary = code.get("summary") or code.get("repo_summary", "")
+        if repo_summary and isinstance(repo_summary, str):
+            parts.append(f"Summary: {repo_summary[:200]}")
+        top_candidates = code.get("top_question_candidates", [])
+        if top_candidates:
+            cand_lines = [f"  - {c.get('title', '')}" for c in top_candidates[:5] if isinstance(c, dict)]
+            if cand_lines:
+                parts.append("Notable Implementations:\n" + "\n".join(cand_lines))
+        if parts:
+            sections.append("## Code Analysis (GitHub)\n" + "\n".join(parts))
+
+    # 4. JD 매칭 요약
+    jd = analysis.get("jd_analysis", {})
+    if jd:
+        parts = []
+        title = jd.get("job_title", "")
+        if title:
+            parts.append(f"Target Role: {title}")
+        reqs = jd.get("requirements", [])
+        if reqs:
+            req_skills = []
+            for r in reqs[:8]:
+                if isinstance(r, dict):
+                    req_skills.append(r.get("skill", str(r)))
+                else:
+                    req_skills.append(str(r))
+            parts.append(f"Key Requirements: {', '.join(req_skills)}")
+        if parts:
+            sections.append("## JD Requirements\n" + "\n".join(parts))
+
+    if not sections:
+        return ""
+
+    return "\n\n".join(sections)
+
+
+def format_candidates(candidates: list[dict]) -> str:
+    lines = []
+    for i, c in enumerate(candidates[:30]):
+        lines.append(f"{i+1}. [{c['source']}] {c['topic']} (score: {c['score']})")
+    return "\n".join(lines)


### PR DESCRIPTION
## 요약
- `question_generation.py` (746줄) → 3파일 분리 (SRP 적용)
- `question_generation_utils.py` (211줄): 상수 + 헬퍼 함수 4개
- `question_enhancement.py` (163줄): Enhancement Activity 6개
- `question_generation.py` (411줄): 핵심 Activity만 유지 + re-export

## 수정 파일
| 파일 | 변경 |
|------|------|
| `question_generation.py` | 746→411줄 (-45%), import 변경 + re-export 추가 |
| `question_generation_utils.py` | 신규 211줄 (상수, 배분 계산, 컨텍스트 빌더) |
| `question_enhancement.py` | 신규 163줄 (Enhancement Activity 6개) |

## 테스트 결과
- 474 passed, 4 skipped (베이스라인 동일)
- Docker import 테스트 통과 (worker.py import 호환)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)