### PR TITLE
improve: interview_workflow.py 모듈 분리 (723→493줄)

### DIFF
--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -1,24 +1,21 @@
 """
 backend/app/workflows/interview_workflow.py
 메인 워크플로우: InterviewGenerationWorkflow
+
+코드 분석 병렬 오케스트레이션은 workflow_code_analysis.py로 분리됨.
+상수(Retry 정책, 버전, 가중치)는 workflow_constants.py로 분리됨.
 """
 import asyncio
 import logging
 from datetime import timedelta
 
 from temporalio import workflow
-from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
     from app.models.enums import JobStatus
     from app.workflows.activities.input_enrichment import enrich_input
     from app.workflows.activities.planning import create_execution_plan
     from app.workflows.activities.document_analysis import analyze_documents
-    from app.workflows.activities.code_analysis import (
-        analyze_code,
-        analyze_single_repo,
-        validate_code_analysis,
-    )
     from app.workflows.activities.jd_analysis import analyze_jd
     from app.workflows.activities.question_generation import (
         select_topics, craft_question,
@@ -38,35 +35,18 @@ with workflow.unsafe.imports_passed_through():
     from app.workflows.activities.analysis_generation import generate_deep_analysis
     from app.workflows.activities.decision_generation import generate_decision_support
     from app.workflows.activities.knowledge_graph_activities import build_knowledge_graph
+    from app.workflows.workflow_code_analysis import run_parallel_code_analysis
+
+# ── 분리된 모듈 re-export (backwards compatibility) ──
+from app.workflows.workflow_constants import (  # noqa: F401, E402
+    WORKFLOW_VERSION,
+    DEFAULT_RETRY,
+    LLM_RETRY,
+    EXTERNAL_API_RETRY,
+    CATEGORY_WEIGHTS_BY_LEVEL,
+)
 
 logger = logging.getLogger(__name__)
-
-# Workflow version — increment when making breaking changes to the workflow logic.
-# Use workflow.patched() for backward-compatible changes to running workflows.
-WORKFLOW_VERSION = "1.0.0"
-
-# Retry policies
-DEFAULT_RETRY = RetryPolicy(
-    initial_interval=timedelta(seconds=1),
-    backoff_coefficient=2.0,
-    maximum_interval=timedelta(seconds=30),
-    maximum_attempts=3,
-)
-
-LLM_RETRY = RetryPolicy(
-    initial_interval=timedelta(seconds=2),
-    backoff_coefficient=2.0,
-    maximum_interval=timedelta(seconds=60),
-    maximum_attempts=3,
-    non_retryable_error_types=["ValueError"],
-)
-
-EXTERNAL_API_RETRY = RetryPolicy(
-    initial_interval=timedelta(seconds=3),
-    backoff_coefficient=2.0,
-    maximum_interval=timedelta(seconds=120),
-    maximum_attempts=4,
-)
 
 
 @workflow.defn
@@ -155,7 +135,7 @@ class InterviewGenerationWorkflow:
             # JD/Doc 분석과 코드 분석을 동시에 실행하여 총 소요시간 단축
             code_analysis_coro = None
             if phases.get("code_analysis"):
-                code_analysis_coro = self._run_parallel_code_analysis(
+                code_analysis_coro = run_parallel_code_analysis(
                     enriched=enriched,
                     raw_input=raw_input,
                     execution_plan=execution_plan,
@@ -414,13 +394,6 @@ class InterviewGenerationWorkflow:
                 final_script["decision"] = decision_support
                 # Category weights for scoring — 경험 레벨별 차등 배분
                 exp_level = input_data.get("experience_level", "미들")
-                CATEGORY_WEIGHTS_BY_LEVEL = {
-                    "신입":   {"role_fit": 0.30, "technical_depth": 0.25, "execution_ownership": 0.15, "communication": 0.20, "risk_flags": 0.10},
-                    "주니어": {"role_fit": 0.30, "technical_depth": 0.25, "execution_ownership": 0.15, "communication": 0.20, "risk_flags": 0.10},
-                    "미들":   {"role_fit": 0.25, "technical_depth": 0.20, "execution_ownership": 0.20, "communication": 0.20, "risk_flags": 0.15},
-                    "시니어": {"role_fit": 0.15, "technical_depth": 0.20, "execution_ownership": 0.25, "communication": 0.20, "risk_flags": 0.20},
-                    "CTO/VP": {"role_fit": 0.15, "technical_depth": 0.15, "execution_ownership": 0.25, "communication": 0.20, "risk_flags": 0.25},
-                }
                 final_script["category_weights"] = CATEGORY_WEIGHTS_BY_LEVEL.get(
                     exp_level, CATEGORY_WEIGHTS_BY_LEVEL["미들"]
                 )
@@ -518,206 +491,3 @@ class InterviewGenerationWorkflow:
         self._progress = progress
         logger.info(f"Phase: {phase} ({progress}%)")
 
-    async def _run_parallel_code_analysis(
-        self,
-        enriched: dict,
-        raw_input: dict,
-        execution_plan: dict,
-        job_id: str | None,
-    ) -> dict:
-        """HYBRID 병렬 코드 분석 실행
-
-        Step 1: Manager가 레포 필터링
-        Step 2: 각 레포 병렬 분석 (Sub-Agents)
-        Step 3: 품질 검증 (Quality Gate)
-        Step 4: 실패한 레포 재분석 (최대 1회)
-        Step 5: 결과 집계
-        """
-        github_urls = enriched.get("github_urls", [])
-        if not github_urls:
-            return {"repositories": [], "top_question_candidates": []}
-
-        # Step 1: Manager가 레포 필터링 + 분석
-        # 타임아웃 증가: 여러 레포 분석 시 5분 초과 가능
-        manager_result = await workflow.execute_activity(
-            analyze_code,
-            args=[github_urls, raw_input, execution_plan],
-            start_to_close_timeout=timedelta(minutes=15),
-            heartbeat_timeout=timedelta(seconds=120),
-            retry_policy=EXTERNAL_API_RETRY,
-        )
-
-        target_repos = manager_result.get("target_repos", [])
-        repositories = manager_result.get("repositories", [])
-
-        # Case 1: 분석 결과가 이미 있으면 바로 반환 (analyze_code가 완료한 경우)
-        if repositories:
-            logger.info(f"Code analysis already completed with {len(repositories)} repos")
-            return manager_result
-
-        # Case 2: target_repos가 없으면 빈 결과 반환
-        if not target_repos:
-            logger.info("No target repos found for parallel analysis")
-            return manager_result
-
-        jd_tech_stack = manager_result.get("jd_tech_stack", [])
-        candidate_username = manager_result.get("candidate_username")
-
-        # Step 2: 각 레포 병렬 분석 (Sub-Agents) - repositories가 없을 때만 실행
-        repo_tasks = []
-        for repo in target_repos:
-            task = workflow.execute_activity(
-                analyze_single_repo,
-                args=[repo, jd_tech_stack, candidate_username, job_id],
-                start_to_close_timeout=timedelta(minutes=10),
-                heartbeat_timeout=timedelta(seconds=120),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=2),
-                    backoff_coefficient=2.0,
-                    maximum_interval=timedelta(seconds=60),
-                    maximum_attempts=2,
-                ),
-            )
-            repo_tasks.append(task)
-
-        repo_results = await asyncio.gather(*repo_tasks, return_exceptions=True)
-
-        # 성공한 결과만 필터링
-        successful_results = []
-        failed_indices = []
-        for i, result in enumerate(repo_results):
-            if isinstance(result, Exception):
-                logger.warning(f"Repo analysis failed: {target_repos[i].get('name')}: {result}")
-                failed_indices.append(i)
-            else:
-                successful_results.append(result)
-
-        # Step 3: 품질 검증 (Quality Gate)
-        validation_tasks = []
-        for result in successful_results:
-            task = workflow.execute_activity(
-                validate_code_analysis,
-                args=[result],
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=DEFAULT_RETRY,
-            )
-            validation_tasks.append(task)
-
-        validations = await asyncio.gather(*validation_tasks, return_exceptions=True)
-
-        # Step 4: 실패한 레포 재분석 (최대 1회)
-        final_results = []
-        for i, (result, validation) in enumerate(zip(successful_results, validations)):
-            if isinstance(validation, Exception):
-                logger.warning(f"Validation failed for {result.get('repo_name')}: {validation}")
-                final_results.append(result)
-                continue
-
-            if validation.get("valid", True):
-                final_results.append(result)
-            else:
-                # 재분석 시도
-                repo_name = result.get("repo_name", "unknown")
-                logger.warning(f"Re-analyzing {repo_name}: {validation.get('issues')}")
-
-                # 원본 repo_info 찾기
-                original_repo = next(
-                    (r for r in target_repos if r.get("name") == repo_name),
-                    target_repos[i] if i < len(target_repos) else None
-                )
-
-                if original_repo:
-                    try:
-                        retry_result = await workflow.execute_activity(
-                            analyze_single_repo,
-                            args=[original_repo, jd_tech_stack, candidate_username, job_id],
-                            start_to_close_timeout=timedelta(minutes=15),
-                            heartbeat_timeout=timedelta(seconds=120),
-                            retry_policy=RetryPolicy(
-                                initial_interval=timedelta(seconds=3),
-                                backoff_coefficient=2.0,
-                                maximum_interval=timedelta(seconds=90),
-                                maximum_attempts=1,
-                            ),
-                        )
-                        final_results.append(retry_result)
-                    except Exception as e:
-                        logger.warning(f"Retry failed for {repo_name}: {e}")
-                        final_results.append(result)  # 원본 결과 사용
-                else:
-                    final_results.append(result)
-
-        # Step 5: 결과 집계
-        return _aggregate_code_analysis(final_results)
-
-
-def _aggregate_code_analysis(repo_results: list[dict]) -> dict:
-    """레포별 결과를 종합
-
-    Args:
-        repo_results: 각 레포의 분석 결과 리스트
-
-    Returns:
-        종합된 코드 분석 결과
-    """
-    if not repo_results:
-        return {
-            "repositories": [],
-            "combined_tech_stack": [],
-            "total_patterns": 0,
-            "total_notable_implementations": 0,
-            "top_question_candidates": [],
-        }
-
-    all_notables = []
-    all_tech_stack = set()
-    total_patterns = 0
-
-    for repo in repo_results:
-        # Notable implementations 수집
-        notables = repo.get("notable_implementations", [])
-        if isinstance(notables, list):
-            all_notables.extend(notables)
-
-        # Tech stack 수집
-        analysis = repo.get("analysis", {})
-        tech_stack = analysis.get("tech_stack", [])
-        if isinstance(tech_stack, list):
-            all_tech_stack.update(tech_stack)
-
-        # Patterns 카운트
-        patterns = analysis.get("patterns", [])
-        if isinstance(patterns, list):
-            total_patterns += len(patterns)
-
-    # Notable implementations 정렬 (question_potential 기준)
-    sorted_notables = sorted(
-        all_notables,
-        key=lambda x: x.get("question_potential", 0) if isinstance(x, dict) else 0,
-        reverse=True,
-    )
-
-    # HYBRID 메타데이터 집계
-    hybrid_summary = {
-        "total_repos_analyzed": len(repo_results),
-        "repos_with_hybrid": sum(
-            1 for r in repo_results if r.get("hybrid_metadata")
-        ),
-        "total_key_files": sum(
-            r.get("hybrid_metadata", {}).get("key_files_count", 0)
-            for r in repo_results
-        ),
-        "total_deep_analyses": sum(
-            r.get("hybrid_metadata", {}).get("deep_analyses_count", 0)
-            for r in repo_results
-        ),
-    }
-
-    return {
-        "repositories": repo_results,
-        "combined_tech_stack": list(all_tech_stack),
-        "total_patterns": total_patterns,
-        "total_notable_implementations": len(all_notables),
-        "top_question_candidates": sorted_notables[:20],
-        "hybrid_summary": hybrid_summary,
-    }

--- a/backend/app/workflows/workflow_code_analysis.py
+++ b/backend/app/workflows/workflow_code_analysis.py
@@ -1,0 +1,218 @@
+"""
+backend/app/workflows/workflow_code_analysis.py
+코드 분석 병렬 오케스트레이션 — HYBRID 병렬 분석 + 결과 집계
+
+Extracted from interview_workflow.py for SRP compliance.
+"""
+import asyncio
+import logging
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from app.workflows.workflow_constants import DEFAULT_RETRY, EXTERNAL_API_RETRY
+from app.workflows.activities.code_analysis import (
+    analyze_code,
+    analyze_single_repo,
+    validate_code_analysis,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def run_parallel_code_analysis(
+    enriched: dict,
+    raw_input: dict,
+    execution_plan: dict,
+    job_id: str | None,
+) -> dict:
+    """HYBRID 병렬 코드 분석 실행
+
+    Step 1: Manager가 레포 필터링
+    Step 2: 각 레포 병렬 분석 (Sub-Agents)
+    Step 3: 품질 검증 (Quality Gate)
+    Step 4: 실패한 레포 재분석 (최대 1회)
+    Step 5: 결과 집계
+    """
+    github_urls = enriched.get("github_urls", [])
+    if not github_urls:
+        return {"repositories": [], "top_question_candidates": []}
+
+    # Step 1: Manager가 레포 필터링 + 분석
+    manager_result = await workflow.execute_activity(
+        analyze_code,
+        args=[github_urls, raw_input, execution_plan],
+        start_to_close_timeout=timedelta(minutes=15),
+        heartbeat_timeout=timedelta(seconds=120),
+        retry_policy=EXTERNAL_API_RETRY,
+    )
+
+    target_repos = manager_result.get("target_repos", [])
+    repositories = manager_result.get("repositories", [])
+
+    # Case 1: 분석 결과가 이미 있으면 바로 반환
+    if repositories:
+        logger.info(f"Code analysis already completed with {len(repositories)} repos")
+        return manager_result
+
+    # Case 2: target_repos가 없으면 빈 결과 반환
+    if not target_repos:
+        logger.info("No target repos found for parallel analysis")
+        return manager_result
+
+    jd_tech_stack = manager_result.get("jd_tech_stack", [])
+    candidate_username = manager_result.get("candidate_username")
+
+    # Step 2: 각 레포 병렬 분석 (Sub-Agents)
+    repo_tasks = []
+    for repo in target_repos:
+        task = workflow.execute_activity(
+            analyze_single_repo,
+            args=[repo, jd_tech_stack, candidate_username, job_id],
+            start_to_close_timeout=timedelta(minutes=10),
+            heartbeat_timeout=timedelta(seconds=120),
+            retry_policy=RetryPolicy(
+                initial_interval=timedelta(seconds=2),
+                backoff_coefficient=2.0,
+                maximum_interval=timedelta(seconds=60),
+                maximum_attempts=2,
+            ),
+        )
+        repo_tasks.append(task)
+
+    repo_results = await asyncio.gather(*repo_tasks, return_exceptions=True)
+
+    # 성공한 결과만 필터링
+    successful_results = []
+    failed_indices = []
+    for i, result in enumerate(repo_results):
+        if isinstance(result, Exception):
+            logger.warning(f"Repo analysis failed: {target_repos[i].get('name')}: {result}")
+            failed_indices.append(i)
+        else:
+            successful_results.append(result)
+
+    # Step 3: 품질 검증 (Quality Gate)
+    validation_tasks = []
+    for result in successful_results:
+        task = workflow.execute_activity(
+            validate_code_analysis,
+            args=[result],
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=DEFAULT_RETRY,
+        )
+        validation_tasks.append(task)
+
+    validations = await asyncio.gather(*validation_tasks, return_exceptions=True)
+
+    # Step 4: 실패한 레포 재분석 (최대 1회)
+    final_results = []
+    for i, (result, validation) in enumerate(zip(successful_results, validations)):
+        if isinstance(validation, Exception):
+            logger.warning(f"Validation failed for {result.get('repo_name')}: {validation}")
+            final_results.append(result)
+            continue
+
+        if validation.get("valid", True):
+            final_results.append(result)
+        else:
+            # 재분석 시도
+            repo_name = result.get("repo_name", "unknown")
+            logger.warning(f"Re-analyzing {repo_name}: {validation.get('issues')}")
+
+            original_repo = next(
+                (r for r in target_repos if r.get("name") == repo_name),
+                target_repos[i] if i < len(target_repos) else None
+            )
+
+            if original_repo:
+                try:
+                    retry_result = await workflow.execute_activity(
+                        analyze_single_repo,
+                        args=[original_repo, jd_tech_stack, candidate_username, job_id],
+                        start_to_close_timeout=timedelta(minutes=15),
+                        heartbeat_timeout=timedelta(seconds=120),
+                        retry_policy=RetryPolicy(
+                            initial_interval=timedelta(seconds=3),
+                            backoff_coefficient=2.0,
+                            maximum_interval=timedelta(seconds=90),
+                            maximum_attempts=1,
+                        ),
+                    )
+                    final_results.append(retry_result)
+                except Exception as e:
+                    logger.warning(f"Retry failed for {repo_name}: {e}")
+                    final_results.append(result)
+            else:
+                final_results.append(result)
+
+    # Step 5: 결과 집계
+    return aggregate_code_analysis(final_results)
+
+
+def aggregate_code_analysis(repo_results: list[dict]) -> dict:
+    """레포별 결과를 종합
+
+    Args:
+        repo_results: 각 레포의 분석 결과 리스트
+
+    Returns:
+        종합된 코드 분석 결과
+    """
+    if not repo_results:
+        return {
+            "repositories": [],
+            "combined_tech_stack": [],
+            "total_patterns": 0,
+            "total_notable_implementations": 0,
+            "top_question_candidates": [],
+        }
+
+    all_notables = []
+    all_tech_stack = set()
+    total_patterns = 0
+
+    for repo in repo_results:
+        notables = repo.get("notable_implementations", [])
+        if isinstance(notables, list):
+            all_notables.extend(notables)
+
+        analysis = repo.get("analysis", {})
+        tech_stack = analysis.get("tech_stack", [])
+        if isinstance(tech_stack, list):
+            all_tech_stack.update(tech_stack)
+
+        patterns = analysis.get("patterns", [])
+        if isinstance(patterns, list):
+            total_patterns += len(patterns)
+
+    sorted_notables = sorted(
+        all_notables,
+        key=lambda x: x.get("question_potential", 0) if isinstance(x, dict) else 0,
+        reverse=True,
+    )
+
+    hybrid_summary = {
+        "total_repos_analyzed": len(repo_results),
+        "repos_with_hybrid": sum(
+            1 for r in repo_results if r.get("hybrid_metadata")
+        ),
+        "total_key_files": sum(
+            r.get("hybrid_metadata", {}).get("key_files_count", 0)
+            for r in repo_results
+        ),
+        "total_deep_analyses": sum(
+            r.get("hybrid_metadata", {}).get("deep_analyses_count", 0)
+            for r in repo_results
+        ),
+    }
+
+    return {
+        "repositories": repo_results,
+        "combined_tech_stack": list(all_tech_stack),
+        "total_patterns": total_patterns,
+        "total_notable_implementations": len(all_notables),
+        "top_question_candidates": sorted_notables[:20],
+        "hybrid_summary": hybrid_summary,
+    }

--- a/backend/app/workflows/workflow_constants.py
+++ b/backend/app/workflows/workflow_constants.py
@@ -1,0 +1,46 @@
+"""
+backend/app/workflows/workflow_constants.py
+워크플로우 공유 상수 — Retry 정책, 버전, 카테고리 가중치
+
+Extracted from interview_workflow.py for SRP compliance.
+"""
+from datetime import timedelta
+
+from temporalio.common import RetryPolicy
+
+# Workflow version — increment when making breaking changes to the workflow logic.
+WORKFLOW_VERSION = "1.0.0"
+
+# ── Retry policies ──
+
+DEFAULT_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=30),
+    maximum_attempts=3,
+)
+
+LLM_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=2),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=60),
+    maximum_attempts=3,
+    non_retryable_error_types=["ValueError"],
+)
+
+EXTERNAL_API_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=3),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=120),
+    maximum_attempts=4,
+)
+
+# ── 경험 레벨별 카테고리 가중치 ──
+
+CATEGORY_WEIGHTS_BY_LEVEL = {
+    "신입":   {"role_fit": 0.30, "technical_depth": 0.25, "execution_ownership": 0.15, "communication": 0.20, "risk_flags": 0.10},
+    "주니어": {"role_fit": 0.30, "technical_depth": 0.25, "execution_ownership": 0.15, "communication": 0.20, "risk_flags": 0.10},
+    "미들":   {"role_fit": 0.25, "technical_depth": 0.20, "execution_ownership": 0.20, "communication": 0.20, "risk_flags": 0.15},
+    "시니어": {"role_fit": 0.15, "technical_depth": 0.20, "execution_ownership": 0.25, "communication": 0.20, "risk_flags": 0.20},
+    "CTO/VP": {"role_fit": 0.15, "technical_depth": 0.15, "execution_ownership": 0.25, "communication": 0.20, "risk_flags": 0.25},
+}


### PR DESCRIPTION
## 요약
- `interview_workflow.py` (723줄) → 3파일 분리 (SRP 적용)
- `workflow_constants.py` (46줄): Retry 정책 3개 + 버전 + 카테고리 가중치
- `workflow_code_analysis.py` (218줄): HYBRID 병렬 코드 분석 오케스트레이션 + 결과 집계
- `interview_workflow.py` (493줄): 핵심 워크플로우 오케스트레이션만 유지 + re-export

## 수정 파일
| 파일 | 변경 |
|------|------|
| `interview_workflow.py` | 723→493줄 (-32%), 코드 분석 로직 제거 + import 변경 |
| `workflow_constants.py` | 신규 46줄 (Retry 정책, 버전, 가중치) |
| `workflow_code_analysis.py` | 신규 218줄 (병렬 분석 + 집계) |

## 테스트 결과
- 474 passed, 4 skipped (베이스라인 동일)
- Docker import 테스트 통과 (worker.py, health.py, 테스트 모두 호환)

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)