### PR TITLE
fix: data_confidence_score=0 버그 — code_analysis stats 추출 누락 수정

### DIFF
--- a/backend/app/services/scoring_formulas.py
+++ b/backend/app/services/scoring_formulas.py
@@ -102,6 +102,40 @@ CODE_QUALITY_WEIGHTS = {
 }
 
 
+def extract_code_stats(code_analysis: dict | None) -> tuple[dict, dict]:
+    """code_analysis에서 quality_metrics와 stats를 추출/집계
+
+    analyze_code Activity 결과는 per-repo 데이터를 repositories[] 안에 저장하며
+    top-level에 stats/quality_metrics 키가 없음.
+    이 함수는 repositories[]에서 집계하여 반환.
+
+    Returns:
+        (quality_metrics, stats) tuple
+    """
+    if not code_analysis:
+        return {}, {}
+
+    quality_metrics = code_analysis.get("quality_metrics", {})
+    stats = code_analysis.get("stats", {})
+
+    # top-level에 stats가 없으면 repositories에서 집계
+    if not stats:
+        repos = code_analysis.get("repositories", [])
+        if repos:
+            total_commits = sum(r.get("candidate_commits", 0) for r in repos)
+            total_additions = sum(r.get("candidate_additions", 0) for r in repos)
+            complexities = [r.get("avg_complexity", 0) for r in repos if r.get("avg_complexity", 0) > 0]
+            avg_complexity = sum(complexities) / len(complexities) if complexities else 0
+            stats = {
+                "total_commits": total_commits,
+                "total_additions": total_additions,
+                "total_deletions": 0,
+                "avg_complexity": avg_complexity,
+            }
+
+    return quality_metrics, stats
+
+
 def calculate_code_quality_score(
     quality_metrics: dict,
     stats: dict | None = None,
@@ -218,11 +252,7 @@ def calculate_radar_scores(
         RadarScores with candidate/required scores and sources
     """
     profile = document_analysis.get("profile", {})
-    quality = {}
-    stats = {}
-    if code_analysis:
-        quality = code_analysis.get("quality_metrics", {})
-        stats = code_analysis.get("stats", {})
+    quality, stats = extract_code_stats(code_analysis)
 
     sources = []
 

--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -528,6 +528,7 @@ async def generate_deep_analysis(
         calculate_code_quality_score,
         classify_experience_level,
         calculate_data_confidence,
+        extract_code_stats,
     )
 
     # 스킬 매칭 평균
@@ -535,9 +536,8 @@ async def generate_deep_analysis(
     if skill_table:
         skill_match_avg = sum(row.confidence for row in skill_table) // len(skill_table)
 
-    # 코드 품질 점수
-    quality_metrics = code_analysis.get("quality_metrics", {}) if code_analysis else {}
-    code_stats = code_analysis.get("stats", {}) if code_analysis else {}
+    # 코드 품질 점수 (repositories에서 stats 집계)
+    quality_metrics, code_stats = extract_code_stats(code_analysis)
     cq = calculate_code_quality_score(quality_metrics, code_stats)
 
     # 경험 적합도


### PR DESCRIPTION
## 요약

`code_analysis` 데이터에서 stats를 잘못된 키로 접근하여 `data_confidence_score`가 항상 0으로 계산되던 버그 수정.

- `scoring_formulas.py`: `extract_code_stats()` 헬퍼 추가 — `repositories[]`에서 stats 집계
- `calculate_radar_scores()`: `extract_code_stats()` 사용
- `analysis_generation.py`: `extract_code_stats()` import 및 적용

## 수정 전/후 비교

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| data_confidence_score | 0 | 40 |
| code_quality | 13 | 39 |
| overall_match | 29% | 36% |
| radar[code_quality] | 28 | 54 |

## 테스트

- 474 passed, 4 skipped
- 테스트 Job `282effcc` 완료 확인

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)