### PR TITLE
improve: Data Confidence + Score Transparency Pipeline (사이클 #13-14)

### DIFF
--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -472,6 +472,7 @@ async def generate_deep_analysis(
     job_id: str | None = None,
     output_language: str = "ko",
     experience_level: str = "미들",
+    linkedin_profile: dict | None = None,
 ) -> dict:
     """Deep Analysis 생성
 
@@ -482,6 +483,7 @@ async def generate_deep_analysis(
         job_id: Job ID (observability용)
         output_language: 출력 언어
         experience_level: 경험 레벨 (CTO/VP, 시니어, 미들, 주니어, 신입)
+        linkedin_profile: LinkedIn 프로필 데이터 (optional)
 
     Returns:
         DeepAnalysis 데이터 (Evidence-Based Scoring 적용)
@@ -553,12 +555,23 @@ async def generate_deep_analysis(
     score_sources.append(f"overall_match: {overall_result.source}")
 
     # 6. 데이터 신뢰도 계산
+    has_linkedin = linkedin_profile is not None and bool(linkedin_profile)
     linkedin_positions = 0
+    if has_linkedin:
+        experiences = linkedin_profile.get("experiences") or linkedin_profile.get("experience") or []
+        linkedin_positions = len(experiences) if isinstance(experiences, list) else 0
+
+    has_resume = bool(
+        profile.get("skills")
+        or profile.get("experiences")
+        or profile.get("experience_years")
+    )
+
     github_commits = code_stats.get("total_commits", 0) if code_stats else 0
     data_conf_tier, data_conf_score = calculate_data_confidence(
         has_github=code_analysis is not None and github_commits > 0,
-        has_linkedin=False,  # LinkedIn 여부는 caller에서 판단
-        has_resume=bool(profile.get("skills")),
+        has_linkedin=has_linkedin,
+        has_resume=has_resume,
         github_commits=github_commits,
         linkedin_positions=linkedin_positions,
     )

--- a/backend/app/workflows/activities/quality_review.py
+++ b/backend/app/workflows/activities/quality_review.py
@@ -63,6 +63,7 @@ async def review_questions(questions: list[dict], output_language: str = "ko") -
             issues.append({"type": "too_many_hard", "ratio": hard_ratio})
 
     # 3. LLM 기반 중복/품질 검토
+    all_question_reviews: list[dict] = []
     if len(questions) > 0:
         question_texts = [q.get("question_text", "") for q in questions[:25]]
         from app.prompts import get_prompt_with_config
@@ -73,10 +74,13 @@ async def review_questions(questions: list[dict], output_language: str = "ko") -
         if isinstance(review_result, dict):
             if review_result.get("duplicates"):
                 issues.append({"type": "duplicates", "details": review_result["duplicates"]})
-            # LLM이 식별한 개별 질문 문제
+            # LLM이 식별한 개별 질문 문제 + 전체 품질 메트릭 보존
+            all_question_reviews = []
             for qr in review_result.get("question_reviews", []):
-                if isinstance(qr, dict) and qr.get("issue"):
-                    questions_to_revise.append(qr)
+                if isinstance(qr, dict):
+                    all_question_reviews.append(qr)
+                    if qr.get("issue"):
+                        questions_to_revise.append(qr)
             # 환각 위험 질문 검출
             for hr in review_result.get("hallucination_risks", []):
                 if isinstance(hr, dict):
@@ -94,6 +98,7 @@ async def review_questions(questions: list[dict], output_language: str = "ko") -
         "verdict": verdict,
         "issues": issues,
         "questions_to_revise": questions_to_revise,
+        "question_reviews": all_question_reviews,
         "category_distribution": category_counts,
         "difficulty_distribution": difficulty_counts,
     }

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -309,6 +309,24 @@ class InterviewGenerationWorkflow:
                     retry_policy=LLM_RETRY,
                 )
 
+            # 4a-2. Merge evidence quality data from review into questions
+            if isinstance(review, dict):
+                for qr in review.get("question_reviews", []):
+                    if not isinstance(qr, dict):
+                        continue
+                    q_idx = qr.get("question_index")
+                    if q_idx is not None and isinstance(q_idx, int) and 0 <= q_idx < len(questions):
+                        q = questions[q_idx]
+                        if isinstance(q, dict):
+                            if qr.get("evidence_score") is not None:
+                                q["evidence_score"] = qr["evidence_score"]
+                            if qr.get("hallucination_risk"):
+                                q["evidence_quality"] = (
+                                    "high" if qr["hallucination_risk"] == "low"
+                                    else "low" if qr["hallucination_risk"] == "high"
+                                    else "medium"
+                                )
+
             # 4b. 최종화
             self._update_status(JobStatus.REVIEWING, "Phase 4: Finalization", 90)
             final_script = await workflow.execute_activity(
@@ -361,6 +379,7 @@ class InterviewGenerationWorkflow:
                         job_id,
                         output_language,
                         input_data.get("experience_level", "미들"),
+                        linkedin_profile,
                     ],
                     start_to_close_timeout=timedelta(minutes=2),
                     heartbeat_timeout=timedelta(seconds=60),

--- a/frontend/src/components/tabs/DecisionTab.tsx
+++ b/frontend/src/components/tabs/DecisionTab.tsx
@@ -12,6 +12,8 @@ interface DecisionTabProps {
   totalScore?: number
   maxScore?: number
   riskFlags?: RiskFlag[]
+  dataConfidence?: 'high' | 'medium' | 'low'
+  dataConfidenceScore?: number
 }
 
 export const DecisionTab = memo(function DecisionTab({
@@ -20,7 +22,9 @@ export const DecisionTab = memo(function DecisionTab({
   categoryWeights,
   totalScore = 0,
   maxScore = 100,
-  riskFlags
+  riskFlags,
+  dataConfidence,
+  dataConfidenceScore
 }: DecisionTabProps) {
   const { t } = useTranslation()
   const { summary, interviewer_guide, jd_competency_map } = decision
@@ -76,6 +80,15 @@ export const DecisionTab = memo(function DecisionTab({
           <div className="text-right">
             <div className="text-3xl sm:text-5xl font-bold">{scorePercent}%</div>
             <div className="text-sm opacity-80">{t('decision_points', { score: totalScore, max: maxScore })}</div>
+            {dataConfidence && (
+              <div className={`text-xs font-medium mt-1 ${
+                dataConfidence === 'high' ? 'text-emerald-200'
+                : dataConfidence === 'medium' ? 'text-amber-200'
+                : 'text-red-200'
+              }`}>
+                {t('data_confidence_label')}: {t(`data_confidence_${dataConfidence}`)}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -1,7 +1,7 @@
 /**
  * DeepAnalysisTab - Radar Chart + Engineering DNA + Skill Matching Table
  */
-import { memo } from 'react'
+import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DeepAnalysis } from '../../types/interview'
 import { RadarChart, ProgressBarGroup } from '../charts'
@@ -12,7 +12,8 @@ interface DeepAnalysisTabProps {
 
 export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepAnalysisTabProps) {
   const { t } = useTranslation()
-  const { radar_candidate, radar_required, engineering_dna, risk_flags, skill_table, overall_match } = analysis
+  const { radar_candidate, radar_required, engineering_dna, risk_flags, skill_table, overall_match, score_sources, data_confidence, data_confidence_score } = analysis
+  const [showSources, setShowSources] = useState(false)
 
   const radarLabels = [
     t('deep_role_fit'),
@@ -31,6 +32,16 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
             <div>
               <h3 className="text-lg font-medium text-indigo-100">{t('deep_overall_match')}</h3>
               <p className="text-2xl sm:text-4xl font-bold mt-1">{overall_match}%</p>
+              {data_confidence && (
+                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium mt-2 ${
+                  data_confidence === 'high' ? 'bg-emerald-400/20 text-emerald-100'
+                  : data_confidence === 'medium' ? 'bg-amber-400/20 text-amber-100'
+                  : 'bg-red-400/20 text-red-100'
+                }`}>
+                  {t('data_confidence_label')}: {t(`data_confidence_${data_confidence}`)}
+                  {data_confidence_score != null && ` (${data_confidence_score}%)`}
+                </span>
+              )}
             </div>
             <div className="text-6xl opacity-20">📊</div>
           </div>
@@ -81,6 +92,42 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
           </div>
         </div>
       </div>
+
+      {/* Score Sources (collapsible) */}
+      {score_sources && score_sources.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <button
+            onClick={() => setShowSources(prev => !prev)}
+            className="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors"
+          >
+            <div className="flex items-center gap-2">
+              <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <span className="text-sm font-semibold text-gray-900">{t('score_sources_title')}</span>
+              <span className="text-xs text-gray-400">({score_sources.length})</span>
+            </div>
+            <svg className={`w-5 h-5 text-gray-400 transition-transform ${showSources ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {showSources && (
+            <div className="px-4 pb-4 border-t border-gray-100">
+              <p className="text-xs text-gray-500 mt-3 mb-3">{t('score_sources_desc')}</p>
+              <div className="space-y-2">
+                {score_sources.map((source, i) => (
+                  <div key={i} className="flex items-start gap-2 text-sm">
+                    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-100 text-indigo-600 flex items-center justify-center text-xs font-medium mt-0.5">
+                      {i + 1}
+                    </span>
+                    <span className="text-gray-700 font-mono text-xs leading-relaxed">{source}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Engineering DNA */}
       {engineering_dna && engineering_dna.length > 0 && (

--- a/frontend/src/components/tabs/LiveInterviewTab.tsx
+++ b/frontend/src/components/tabs/LiveInterviewTab.tsx
@@ -200,6 +200,15 @@ export const LiveInterviewTab = memo(function LiveInterviewTab({ questions, cate
                           {q.time_allocation_minutes} {t('live_minutes')}
                         </span>
                       )}
+                      {q.evidence_quality && (
+                        <span className={`px-1.5 py-0.5 text-xs rounded ${
+                          q.evidence_quality === 'high' ? 'bg-emerald-100 text-emerald-700' :
+                          q.evidence_quality === 'medium' ? 'bg-blue-100 text-blue-700' :
+                          'bg-orange-100 text-orange-700'
+                        }`}>
+                          {t(`evidence_${q.evidence_quality}`)}
+                        </span>
+                      )}
                     </div>
                     <p className="text-sm text-gray-600 line-clamp-2">{q.question_text}</p>
                   </div>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -299,6 +299,16 @@ const resources = {
       scenario_low: '📉 Low',
       // DeepAnalysisTab
       engineering_dna: 'Engineering DNA',
+      data_confidence_label: '데이터 신뢰도',
+      data_confidence_high: '높음',
+      data_confidence_medium: '보통',
+      data_confidence_low: '낮음',
+      // Score Transparency
+      score_sources_title: '점수 산출 근거',
+      score_sources_desc: '각 축의 점수가 어떤 데이터를 기반으로 계산되었는지 보여줍니다',
+      evidence_high: '근거 충분',
+      evidence_medium: '근거 보통',
+      evidence_low: '근거 부족',
       // Dev login
       dev_login: '테스트 로그인 (개발 전용)',
     },
@@ -600,6 +610,16 @@ const resources = {
       scenario_low: '📉 Low',
       // DeepAnalysisTab
       engineering_dna: 'Engineering DNA',
+      data_confidence_label: 'Data Confidence',
+      data_confidence_high: 'High',
+      data_confidence_medium: 'Medium',
+      data_confidence_low: 'Low',
+      // Score Transparency
+      score_sources_title: 'Score Breakdown',
+      score_sources_desc: 'Shows how each axis score was calculated from the available data',
+      evidence_high: 'Strong Evidence',
+      evidence_medium: 'Moderate Evidence',
+      evidence_low: 'Weak Evidence',
       // Dev login
       dev_login: 'Dev Login (Development Only)',
     },

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -352,6 +352,8 @@ export function ResultPage() {
               totalScore={hasV2Data && script?.analysis?.overall_match != null ? script.analysis.overall_match : totalScore}
               maxScore={hasV2Data && script?.analysis?.overall_match != null ? 100 : (maxScore || 100)}
               riskFlags={script.analysis?.risk_flags}
+              dataConfidence={script.analysis?.data_confidence}
+              dataConfidenceScore={script.analysis?.data_confidence_score}
             />
           )}
         </div>

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -112,6 +112,9 @@ export interface DeepAnalysis {
   risk_flags: RiskFlag[]
   skill_table: SkillMatchRow[]
   overall_match?: number
+  score_sources?: string[]
+  data_confidence?: 'high' | 'medium' | 'low'
+  data_confidence_score?: number
 }
 
 // =============================================================================
@@ -203,6 +206,10 @@ export interface InterviewQuestion {
     low?: Record<string, unknown>
   }
   follow_up_questions?: Array<Record<string, unknown>>
+
+  // Evidence quality from quality review
+  evidence_score?: number
+  evidence_quality?: 'high' | 'medium' | 'low'
 
   // Finalization output fields
   revised_question?: string


### PR DESCRIPTION
## Summary
- **사이클 #13**: LinkedIn 데이터 하드코딩 제거, has_resume 개선, 프론트엔드 data_confidence 배지 렌더링
- **사이클 #14**: quality_review evidence 파이프라인 연결, score_sources 접이식 UI, evidence quality 배지

## 변경 파일 (9개)

### Backend (3개)
- `analysis_generation.py`: LinkedIn 데이터 연결 + has_resume 개선
- `quality_review.py`: 전체 question_reviews 보존 (issue 있는 것만 → 전체)
- `interview_workflow.py`: linkedin_profile 전달 + evidence 데이터 병합

### Frontend (6개)
- `interview.ts`: data_confidence, score_sources, evidence_score 타입
- `i18n.ts`: 신뢰도/증거 번역 키 10개 (ko+en)
- `DeepAnalysisTab.tsx`: 신뢰도 배지 + 접이식 점수 근거 아코디언
- `DecisionTab.tsx`: 점수 옆 신뢰도 표시
- `LiveInterviewTab.tsx`: evidence quality 배지
- `ResultPage.tsx`: dataConfidence props 전달

## Test plan
- [x] `npx tsc --noEmit` → 0 errors
- [x] `pytest` → 474 passed, 4 skipped
- [x] quality_review 테스트 → 9/9 passed

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)