### PR TITLE
improve: 비개발자를 위한 점수 투명성 강화 (P1)

### DIFF
--- a/frontend/src/components/tabs/DecisionTab.tsx
+++ b/frontend/src/components/tabs/DecisionTab.tsx
@@ -33,10 +33,10 @@ export const DecisionTab = memo(function DecisionTab({
 
   // Determine recommendation based on score
   const getRecommendation = () => {
-    if (scorePercent >= 80) return { label: t('rec_strong_hire'), color: 'emerald', icon: '🌟' }
-    if (scorePercent >= 60) return { label: t('rec_hire'), color: 'green', icon: '✅' }
-    if (scorePercent >= 40) return { label: t('rec_leaning_no'), color: 'amber', icon: '⚠️' }
-    return { label: t('rec_no_hire'), color: 'red', icon: '❌' }
+    if (scorePercent >= 80) return { label: t('rec_strong_hire'), desc: t('rec_strong_hire_desc'), color: 'emerald', icon: '🌟' }
+    if (scorePercent >= 60) return { label: t('rec_hire'), desc: t('rec_hire_desc'), color: 'green', icon: '✅' }
+    if (scorePercent >= 40) return { label: t('rec_leaning_no'), desc: t('rec_leaning_no_desc'), color: 'amber', icon: '⚠️' }
+    return { label: t('rec_no_hire'), desc: t('rec_no_hire_desc'), color: 'red', icon: '❌' }
   }
 
   const recommendation = getRecommendation()
@@ -72,6 +72,7 @@ export const DecisionTab = memo(function DecisionTab({
             <div>
               <h3 className="text-lg font-medium opacity-90">{t('decision_recommendation')}</h3>
               <p className="text-2xl sm:text-4xl font-bold mt-1">{recommendation.icon} {recommendation.label}</p>
+              <p className="text-sm opacity-70 mt-1">{recommendation.desc}</p>
               {candidate && (
                 <p className="text-sm opacity-80 mt-2">{candidate.name} · {candidate.role || candidate.current_title}</p>
               )}

--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -15,13 +15,14 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
   const { radar_candidate, radar_required, engineering_dna, risk_flags, skill_table, overall_match, score_sources, data_confidence, data_confidence_score } = analysis
   const [showSources, setShowSources] = useState(false)
 
-  const radarLabels = [
-    t('deep_role_fit'),
-    t('deep_technical'),
-    t('deep_execution'),
-    t('deep_communication'),
-    t('deep_code_quality')
+  const radarAxisConfig = [
+    { label: t('deep_role_fit'), desc: t('deep_role_fit_desc') },
+    { label: t('deep_technical'), desc: t('deep_technical_desc') },
+    { label: t('deep_execution'), desc: t('deep_execution_desc') },
+    { label: t('deep_communication'), desc: t('deep_communication_desc') },
+    { label: t('deep_code_quality'), desc: t('deep_code_quality_desc') },
   ]
+  const radarLabels = radarAxisConfig.map(a => a.label)
 
   return (
     <div className="space-y-6">
@@ -67,13 +68,23 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
 
           {/* Score breakdown */}
           <div className="space-y-3 w-full lg:w-auto">
-            {radarLabels.map((label, i) => {
+            {radarAxisConfig.map((axis, i) => {
               const candidate = radar_candidate?.[i] ?? 0
               const required = radar_required?.[i] ?? 0
               const diff = candidate - required
               return (
-                <div key={label} className="flex items-center gap-3">
-                  <span className="w-28 text-sm text-gray-600">{label}</span>
+                <div key={axis.label} className="flex items-center gap-3">
+                  <span className="w-28 text-sm text-gray-600 flex items-center gap-1">
+                    {axis.label}
+                    <span className="group relative">
+                      <svg className="w-3.5 h-3.5 text-gray-400 cursor-help flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 px-3 py-2 bg-gray-900 text-white text-xs rounded-lg shadow-lg hidden group-hover:block z-10 pointer-events-none">
+                        {axis.desc}
+                      </span>
+                    </span>
+                  </span>
                   <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
                     <div
                       className="h-full bg-emerald-500 rounded-full"

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -323,6 +323,17 @@ const resources = {
       evidence_high: '근거 충분',
       evidence_medium: '근거 보통',
       evidence_low: '근거 부족',
+      // Score Transparency - Axis Explanations (for non-developers)
+      deep_role_fit_desc: '채용공고(JD)의 요구사항과 후보자의 경험/스킬이 얼마나 일치하는지',
+      deep_technical_desc: '프로그래밍 언어, 프레임워크, 도구 등 기술적 깊이와 폭',
+      deep_execution_desc: '문제를 정의하고 해결책을 실행하는 능력 (코드 복잡도, 프로젝트 완성도)',
+      deep_communication_desc: '문서화, 코드 리뷰, 팀 협업 등 소통 역량',
+      deep_code_quality_desc: '코드의 가독성, 테스트 커버리지, 유지보수성',
+      // Score Transparency - Recommendation Explanations
+      rec_strong_hire_desc: '80% 이상 매칭 — 핵심 요구사항을 모두 충족하며 강력 추천',
+      rec_hire_desc: '60~79% 매칭 — 대부분의 요구사항을 충족하며 추천',
+      rec_leaning_no_desc: '40~59% 매칭 — 일부 요구사항만 충족, 신중한 검토 필요',
+      rec_no_hire_desc: '40% 미만 매칭 — 요구사항 충족 부족, 추천하지 않음',
       // Dev login
       dev_login: '테스트 로그인 (개발 전용)',
     },
@@ -648,6 +659,17 @@ const resources = {
       evidence_high: 'Strong Evidence',
       evidence_medium: 'Moderate Evidence',
       evidence_low: 'Weak Evidence',
+      // Score Transparency - Axis Explanations (for non-developers)
+      deep_role_fit_desc: 'How well the candidate\'s experience/skills match the JD requirements',
+      deep_technical_desc: 'Depth and breadth of programming languages, frameworks, and tools',
+      deep_execution_desc: 'Ability to define problems and deliver solutions (code complexity, project completion)',
+      deep_communication_desc: 'Documentation, code reviews, team collaboration skills',
+      deep_code_quality_desc: 'Code readability, test coverage, and maintainability',
+      // Score Transparency - Recommendation Explanations
+      rec_strong_hire_desc: '80%+ match — Meets all key requirements, strongly recommended',
+      rec_hire_desc: '60-79% match — Meets most requirements, recommended',
+      rec_leaning_no_desc: '40-59% match — Meets some requirements, careful review needed',
+      rec_no_hire_desc: 'Below 40% match — Insufficient requirements coverage, not recommended',
       // Dev login
       dev_login: 'Dev Login (Development Only)',
     },


### PR DESCRIPTION
## 개선 사이클 #18: 비개발자를 위한 점수 투명성 강화

Closes #150

### 문제
비개발자 면접관이 레이더 차트 축 이름(역할 적합도, 기술 역량 등)과 채용 추천 등급(Strong Hire 등)의 의미/기준을 알 수 없음

### 수정 내역

| 파일 | 변경 |
|------|------|
| `i18n.ts` | 레이더 5축 설명 + 추천 4등급 설명 번역 키 추가 (ko/en 총 18키) |
| `DeepAnalysisTab.tsx` | 각 축 이름 옆 ⓘ hover 툴팁으로 비개발자용 설명 표시 |
| `DecisionTab.tsx` | 추천 등급 아래에 기준 설명 텍스트(매칭 % 기준) 상시 표시 |

### 예시
- **역할 적합도** ⓘ → 툴팁: "채용공고(JD)의 요구사항과 후보자의 경험/스킬이 얼마나 일치하는지"
- **🌟 Strong Hire** → 아래: "80% 이상 매칭 — 핵심 요구사항을 모두 충족하며 강력 추천"

### 검증
- `npx tsc --noEmit`: 0 errors

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>