### PR TITLE
improve: 스킬 매칭 근거 품질 배지 + i18n 수정

### DIFF
--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -213,7 +213,17 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
                          row.type === 'partial' ? t('deep_match_partial') : t('deep_match_none')}
                       </span>
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-500">{row.evidence}</td>
+                    <td className="px-6 py-4">
+                      <div className="text-sm text-gray-500">{row.evidence}</div>
+                      <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium mt-1 ${
+                        row.confidence >= 80 ? 'bg-emerald-50 text-emerald-700' :
+                        row.confidence >= 50 ? 'bg-amber-50 text-amber-700' :
+                        'bg-red-50 text-red-700'
+                      }`}>
+                        {row.confidence >= 80 ? t('evidence_high') :
+                         row.confidence >= 50 ? t('evidence_medium') : t('evidence_low')}
+                      </span>
+                    </td>
                     <td className="px-6 py-4 text-right">
                       <div className="flex items-center justify-end gap-2">
                         <div className="w-16 h-2 bg-gray-100 rounded-full overflow-hidden">

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -532,7 +532,7 @@ const resources = {
       live_select_all: 'Select All',
       live_start_interview: 'Start Interview →',
       live_risk: 'Risk',
-      live_minutes: ' min',
+      live_minutes: 'min',
       live_no_questions: 'No questions selected.',
       live_back_to_select: 'Back to Question Selection',
       live_go_select: '← Questions',


### PR DESCRIPTION
## 개선 사이클 #19

### 변경 내용

#### 1. 스킬 매칭 테이블 근거 품질 배지 (Gap 4.1)
- `DeepAnalysisTab.tsx` 스킬 매칭 테이블 evidence 칼럼에 품질 배지 추가
- confidence 값에서 파생: ≥80 → 근거 충분(초록), ≥50 → 근거 보통(노랑), <50 → 근거 부족(빨강)
- 기존 `evidence_high/medium/low` i18n 키 재활용 (백엔드 변경 불필요)

#### 2. i18n 영어 번역 수정 (Gap 3.1)
- `live_minutes`: `' min'` → `'min'` (불필요한 앞 공백 제거)

### 수정 파일
- `frontend/src/components/tabs/DeepAnalysisTab.tsx`
- `frontend/src/i18n.ts`

### 검증
- `npx tsc --noEmit` — 타입 에러 0개

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)