### PR TITLE
improve: decision_summary 프롬프트에 level_evidence 출력 필드 추가

### DIFF
--- a/backend/app/prompts/v2_generation.yaml
+++ b/backend/app/prompts/v2_generation.yaml
@@ -281,8 +281,9 @@ prompts:
       1. Experience summary (years + most recent role)
       2. JD match level (High/Medium/Low — translated to {{output_language}})
       3. Estimated level (Junior/Mid/Senior/Lead/Principal)
-      4. Key strengths — each MUST include evidence source in parentheses
-      5. Key concerns — each MUST cite what data is missing or problematic
+      4. Level classification evidence — cite SFIA/Dreyfus criteria + data source
+      5. Key strengths — each MUST include evidence source in parentheses
+      6. Key concerns — each MUST cite what data is missing or problematic
 
       # LEVEL ESTIMATION RULES (SFIA v9 / Dreyfus Model)
       - Junior: 0-2 years experience (SFIA 1-2)
@@ -338,6 +339,7 @@ prompts:
         "experience": "experience summary in {{output_language}} (e.g., '8년 (Senior Backend Engineer @ TechCorp)')",
         "jd_match": "High|Medium|Low (translated to {{output_language}})",
         "level": "Junior|Mid|Senior|Lead|Principal",
+        "level_evidence": "SFIA/Dreyfus classification reason in {{output_language}} — MUST cite data source (e.g., 'SFIA Level 4: 경력 8년 + 아키텍처 의사결정 경험 (Resume + GitHub)')",
         "strengths": ["strength1 (source) in {{output_language}}", "strength2 (source)", ...],
         "concerns": ["concern1 with evidence in {{output_language}}", "concern2 with evidence", ...]
       }}

--- a/backend/app/workflows/activities/decision_generation.py
+++ b/backend/app/workflows/activities/decision_generation.py
@@ -81,6 +81,7 @@ async def _llm_generate_decision_summary(
             experience=result.get("experience", ""),
             jd_match=result.get("jd_match", _t("jd_medium", output_language)),
             level=result.get("level", "Mid"),
+            level_evidence=result.get("level_evidence", ""),
             strengths=result.get("strengths", [])[:5],
             concerns=result.get("concerns", [])[:3],
         )


### PR DESCRIPTION
## Summary
- `decision_summary` 프롬프트에 `level_evidence` 필드 추가 — SFIA/Dreyfus 기준 분류 근거
- LLM 결과 파서에서 `level_evidence` 추출하여 `DecisionSummary`에 반영

## Test plan
- [x] pytest 474 passed, 4 skipped
- [x] tsc --noEmit clean

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)