### PR TITLE
improve: finalization 분석 데이터 절단 경고 + 품질 메타데이터 전파

### DIFF
--- a/backend/app/workflows/activities/finalization.py
+++ b/backend/app/workflows/activities/finalization.py
@@ -37,6 +37,28 @@ def _is_avatar_url_allowed(url: str) -> bool:
         return False
 
 
+def _extract_quality_metadata(questions: list[dict]) -> dict:
+    """질문 목록에서 품질 메타데이터 집계 (quality_review에서 병합된 데이터 활용)"""
+    evidence_scores = []
+    quality_counts = {"high": 0, "medium": 0, "low": 0}
+    for q in questions:
+        if not isinstance(q, dict):
+            continue
+        es = q.get("evidence_score")
+        if es is not None and isinstance(es, (int, float)):
+            evidence_scores.append(es)
+        eq = q.get("evidence_quality", "")
+        if eq in quality_counts:
+            quality_counts[eq] += 1
+
+    avg_evidence = round(sum(evidence_scores) / len(evidence_scores), 1) if evidence_scores else None
+    return {
+        "avg_evidence_score": avg_evidence,
+        "evidence_score_count": len(evidence_scores),
+        "evidence_quality_distribution": quality_counts,
+    }
+
+
 async def _download_and_store_avatar(avatar_url: str, job_id: str) -> str | None:
     """LinkedIn avatar를 다운로드하여 S3에 저장, 영구 URL 반환.
 
@@ -257,10 +279,21 @@ async def finalize_output(
     linkedin_summary = _format_linkedin_summary(linkedin_profile)
 
     from app.prompts import get_prompt_with_config
+    # 분석 데이터 직렬화 + 절단 (LLM 컨텍스트 제한)
+    MAX_ANALYSIS_CHARS = 2000
+    doc_json = json.dumps(analysis.get("document_analysis", {}), default=str)
+    code_json = json.dumps(analysis.get("code_analysis", {}), default=str)
+    doc_truncated = len(doc_json) > MAX_ANALYSIS_CHARS
+    code_truncated = len(code_json) > MAX_ANALYSIS_CHARS
+    if doc_truncated:
+        logger.warning(f"document_analysis truncated for summary: {len(doc_json)} → {MAX_ANALYSIS_CHARS} chars")
+    if code_truncated:
+        logger.warning(f"code_analysis truncated for summary: {len(code_json)} → {MAX_ANALYSIS_CHARS} chars")
+
     summary_config = get_prompt_with_config(
         "finalization.yaml", "candidate_summary",
-        document_analysis=json.dumps(analysis.get("document_analysis", {}), default=str)[:2000],
-        code_analysis=json.dumps(analysis.get("code_analysis", {}), default=str)[:2000],
+        document_analysis=doc_json[:MAX_ANALYSIS_CHARS],
+        code_analysis=code_json[:MAX_ANALYSIS_CHARS],
         linkedin_profile=linkedin_summary,
         output_language=output_language,
     )
@@ -339,6 +372,11 @@ async def finalize_output(
                 if isinstance((analysis.get("document_analysis") or {}).get("profile", {}).get("skills"), list)
                 else []
             ),
+            "data_truncation": {
+                "document_analysis": doc_truncated,
+                "code_analysis": code_truncated,
+            },
+            "quality": _extract_quality_metadata(questions),
         },
     }
 

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -336,9 +336,16 @@ class InterviewGenerationWorkflow:
                 heartbeat_timeout=timedelta(seconds=60),
                 retry_policy=LLM_RETRY,
             )
-            # Attach decision guide to final output
+            # Attach decision guide + quality review metadata to final output
             if isinstance(final_script, dict) and decision_guide:
                 final_script["decision_guide"] = decision_guide
+            if isinstance(final_script, dict):
+                meta = final_script.get("metadata", {})
+                if isinstance(meta, dict):
+                    quality = meta.get("quality", {})
+                    if isinstance(quality, dict):
+                        quality["review_verdict"] = review.get("verdict") if isinstance(review, dict) else None
+                        quality["revision_count"] = revision_count
 
             # Phase 4c: Generate v2 Intel and Analysis (병렬)
             self._update_status(JobStatus.REVIEWING, "Phase 4: Intel/Analysis", 92)


### PR DESCRIPTION
## Summary
- `finalize_output`: document_analysis/code_analysis 2K 절단 시 WARNING 로그 출력 + `metadata.data_truncation` 기록
- `_extract_quality_metadata()`: 질문별 evidence_score 집계 (평균, 품질 분포)
- 워크플로우에서 `review_verdict`, `revision_count`를 `metadata.quality`에 병합

## Test plan
- [x] `python -m pytest tests/ -x --tb=short` — 474 passed, 4 skipped
- [x] `npx tsc --noEmit` — 에러 없음

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)