### PR TITLE
improve: 후속질문 트리거 검증 + 3탭 교차 일관성 검증

### DIFF
--- a/backend/app/workflows/activities/question_enhancement.py
+++ b/backend/app/workflows/activities/question_enhancement.py
@@ -122,7 +122,31 @@ async def design_follow_ups(questions: list[dict], enriched_input: dict) -> dict
     # LLM 호출 중 주기적 heartbeat 전송 (타임아웃 방지)
     result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
     from app.services.cached_llm import validate_llm_output
-    return validate_llm_output(result, activity_name="design_follow_ups")
+    validated = validate_llm_output(result, activity_name="design_follow_ups")
+
+    # 후속질문 트리거 커버리지 + 구조 검증
+    EXPECTED_TRIGGERS = {"expert", "mid", "low"}
+    if isinstance(validated, dict):
+        total_questions = 0
+        missing_trigger_coverage = 0
+        empty_text_count = 0
+        for q_key, follow_ups in validated.items():
+            if not isinstance(follow_ups, list):
+                continue
+            total_questions += 1
+            triggers_present = {fu.get("trigger", "").lower() for fu in follow_ups if isinstance(fu, dict)}
+            if not triggers_present & EXPECTED_TRIGGERS:
+                missing_trigger_coverage += 1
+            for fu in follow_ups:
+                if isinstance(fu, dict) and not fu.get("question_text", "").strip():
+                    empty_text_count += 1
+        if total_questions > 0:
+            coverage = round((total_questions - missing_trigger_coverage) / total_questions * 100, 1)
+            logger.info(f"design_follow_ups: {total_questions} questions, {coverage}% have trigger-based follow-ups")
+            if empty_text_count > 0:
+                logger.warning(f"design_follow_ups: {empty_text_count} follow-ups have empty question_text")
+
+    return validated
 
 
 @activity.defn

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -425,6 +425,46 @@ class InterviewGenerationWorkflow:
                     exp_level, CATEGORY_WEIGHTS_BY_LEVEL["미들"]
                 )
 
+                # 교차 일관성 검증 (Intel ↔ Deep Analysis ↔ Decision)
+                inconsistencies = []
+                intel_data = intel_brief if isinstance(intel_brief, dict) else {}
+                analysis_data = deep_analysis if isinstance(deep_analysis, dict) else {}
+                decision_data = decision_support if isinstance(decision_support, dict) else {}
+
+                # 레이더 점수 ↔ Decision 추천 일관성
+                radar = analysis_data.get("radar_candidate", {})
+                if isinstance(radar, dict) and decision_data:
+                    avg_radar = 0
+                    radar_values = [v for v in radar.values() if isinstance(v, (int, float))]
+                    if radar_values:
+                        avg_radar = sum(radar_values) / len(radar_values)
+                    summary = decision_data.get("summary", {})
+                    if isinstance(summary, dict):
+                        jd_match = summary.get("jd_match", "")
+                        # 평균 레이더 ≤ 30인데 jd_match에 "높" or "strong" → 불일치
+                        if avg_radar > 0 and avg_radar <= 30 and any(w in str(jd_match).lower() for w in ["높", "strong", "excellent"]):
+                            inconsistencies.append(f"radar_avg={avg_radar:.0f} but jd_match='{jd_match}'")
+                        # 평균 레이더 ≥ 80인데 jd_match에 "낮" or "weak" → 불일치
+                        if avg_radar >= 80 and any(w in str(jd_match).lower() for w in ["낮", "weak", "poor"]):
+                            inconsistencies.append(f"radar_avg={avg_radar:.0f} but jd_match='{jd_match}'")
+
+                # Intel 스킬 매칭 수 ↔ Deep Analysis 스킬 테이블 수 비교
+                intel_skills = intel_data.get("competency_match", [])
+                analysis_skills = analysis_data.get("skill_table", [])
+                if isinstance(intel_skills, list) and isinstance(analysis_skills, list):
+                    if len(intel_skills) > 0 and len(analysis_skills) > 0:
+                        ratio = min(len(intel_skills), len(analysis_skills)) / max(len(intel_skills), len(analysis_skills))
+                        if ratio < 0.3:
+                            inconsistencies.append(
+                                f"intel competency_match({len(intel_skills)}) vs analysis skill_table({len(analysis_skills)}) ratio={ratio:.2f}"
+                            )
+
+                if inconsistencies:
+                    logger.warning(f"Cross-tab inconsistencies detected: {inconsistencies}")
+                    meta = final_script.get("metadata", {})
+                    if isinstance(meta, dict):
+                        meta["cross_tab_inconsistencies"] = inconsistencies
+
             # DB에 결과 저장
             job_id = input_data.get("job_id")
             if job_id:


### PR DESCRIPTION
## 변경 내용

### question_enhancement.py
- `design_follow_ups`: expert/mid/low 트리거 커버리지 검증 + 빈 question_text 감지 WARNING 로깅

### interview_workflow.py
- 3탭 교차 일관성 검증 (Intel ↔ Deep Analysis ↔ Decision)
  - 레이더 평균 점수 ↔ Decision 추천 방향 불일치 감지
  - Intel competency_match 수 ↔ Analysis skill_table 수 비율 불일치 감지
  - 불일치 감지 시 metadata.cross_tab_inconsistencies에 기록

## 테스트
- 474 passed, 4 skipped
- tsc clean

Closes #186