### PR TITLE
improve: craft_question evidence_source 필수화 + 범용 질문 비율 억제

### DIFF
--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -191,11 +191,18 @@ prompts:
       - follow_ups MUST probe deeper into candidate-specific experiences
       - If candidate_context is empty, create a reasonable question based on topic alone
 
+      # EVIDENCE-BASED QUESTION REQUIREMENT
+      - EVERY question MUST reference specific candidate data (project, code, company, technology)
+      - Generic questions like "경험을 설명해주세요" or "어떻게 접근하시겠습니까?" are UNACCEPTABLE
+      - evidence_source MUST specify where this question came from: "GitHub", "Resume", "LinkedIn", "Portfolio", "Code", or "KnowledgeGraph"
+      - If you cannot ground the question in specific evidence, set evidence_source to "General" (target: ≤20% of questions)
+
       # OUTPUT FORMAT (v2 JSON)
       ```json
       {
         "title": "짧은 제목 (2-4 단어)",
         "question_text": "Main question in {{output_language}}",
+        "evidence_source": "GitHub|Resume|LinkedIn|Portfolio|Code|KnowledgeGraph|General",
         "why_matters": "이 질문이 중요한 이유 (비즈니스 관점)",
         "listen_for": "핵심 키워드와 개념",
         "is_risk": false,

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -430,6 +430,25 @@ async def craft_question(
         "poor": "",
     })
 
+    # evidence_source 보강 — LLM이 미제공 시 topic 소스에서 자동 유추
+    if not question.get("evidence_source"):
+        source = topic.get("source", "")
+        if source.startswith("kg_"):
+            question["evidence_source"] = "KnowledgeGraph"
+        elif source == "code":
+            question["evidence_source"] = "Code"
+        elif source in ("resume", "document"):
+            question["evidence_source"] = "Resume"
+        elif source == "linkedin":
+            question["evidence_source"] = "LinkedIn"
+        elif source == "portfolio":
+            question["evidence_source"] = "Portfolio"
+        elif source == "github":
+            question["evidence_source"] = "GitHub"
+        else:
+            question["evidence_source"] = "General"
+            logger.info(f"craft_question: no evidence_source for topic '{topic.get('topic', '')[:40]}', marked as General")
+
     # Add KG provenance metadata
     if topic.get("source", "").startswith("kg_"):
         question["kg_source"] = topic.get("source")

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -205,6 +205,17 @@ class InterviewGenerationWorkflow:
             questions = await asyncio.gather(*question_tasks)
             questions = list(questions)
 
+            # evidence_source 분포 로깅 — 범용 질문 비율 모니터링
+            source_dist: dict[str, int] = {}
+            for q in questions:
+                src = q.get("evidence_source", "Unknown") if isinstance(q, dict) else "Unknown"
+                source_dist[src] = source_dist.get(src, 0) + 1
+            total_q = len(questions)
+            general_ratio = round(source_dist.get("General", 0) / total_q * 100, 1) if total_q > 0 else 0
+            logger.info(f"Question evidence_source distribution: {source_dist} (General: {general_ratio}%)")
+            if general_ratio > 20:
+                logger.warning(f"Generic question ratio {general_ratio}% exceeds 20% target")
+
             # Phase 3c-3g: Enhancement Agents (병렬)
             self._update_status(JobStatus.GENERATING, "Phase 3: Enhancement", 70)
 


### PR DESCRIPTION
## Summary
- craft_question 프롬프트에 `evidence_source` 필드 필수화 + 반범용 질문 지시 추가
- LLM이 evidence_source 미제공 시 topic.source에서 자동 유추 (GitHub/Resume/LinkedIn 등)
- 워크플로우에서 evidence_source 분포 로깅 + General 비율 20% 초과 시 경고

## Test plan
- [x] pytest 474 passed, 4 skipped
- [x] tsc --noEmit 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)