### PR TITLE
improve: Intel Brief vague text 탐지 + Engineering DNA 품질 검증

### DIFF
--- a/backend/app/prompts/v2_generation.yaml
+++ b/backend/app/prompts/v2_generation.yaml
@@ -257,6 +257,14 @@ prompts:
       The "tooltip" field is for non-technical users. Explain what this metric means in simple terms.
       Example: "Test coverage measures how much of the code is verified by automated tests — higher is better"
 
+      # FORBIDDEN PATTERNS (will cause rejection)
+      - note without specific metric: "좋은 품질" ← REJECTED (no metric citation)
+      - note without source: "테스트가 잘 작성됨" ← REJECTED (no parenthesized source)
+      - EVERY note MUST cite the actual metric value + (GitHub): "test_coverage: 72% (GitHub)" ← ACCEPTED
+      - If metric is unavailable, note MUST say: "Data not available" ← ACCEPTED
+      - tooltip that repeats label: "테스트 커버리지는 테스트 커버리지입니다" ← REJECTED
+      - EVERY tooltip MUST explain the metric in non-technical terms for HR managers
+
       # OUTPUT FORMAT (JSON array)
       [
         {{

--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -220,6 +220,22 @@ async def _llm_analyze_engineering_dna(code_analysis: dict | None, output_langua
             ))
 
         if items:
+            # === Post-processing 품질 검증 ===
+            no_note = sum(1 for i in items if not i.note or len(str(i.note).strip()) < 5)
+            no_tooltip = sum(1 for i in items if not i.tooltip or len(str(i.tooltip).strip()) < 10)
+            zero_value = sum(1 for i in items if i.value == 0 and i.note and "not available" not in str(i.note).lower())
+            if no_note > 0:
+                logger.warning(
+                    f"Engineering DNA: {no_note}/{len(items)} items have empty/short note — metric citation missing"
+                )
+            if no_tooltip > 0:
+                logger.warning(
+                    f"Engineering DNA: {no_tooltip}/{len(items)} items have empty/short tooltip — non-tech explanation missing"
+                )
+            if zero_value > 0:
+                logger.warning(
+                    f"Engineering DNA: {zero_value}/{len(items)} items have value=0 but note doesn't say 'not available'"
+                )
             logger.info(f"LLM engineering DNA: {len(items)} items")
             return items
         return None

--- a/backend/app/workflows/activities/intel_generation.py
+++ b/backend/app/workflows/activities/intel_generation.py
@@ -126,6 +126,30 @@ async def _llm_match_competencies(
             ))
 
         if competencies:
+            # === Post-processing 품질 검증 ===
+            VAGUE_PATTERNS = (
+                "다양한 경험", "풍부한 경력", "excellent skills", "strong background",
+                "good experience", "sufficient capability", "적절한 역량",
+                "관련 경험 있음", "해당 기술 보유",
+            )
+            vague_count = 0
+            no_why_count = 0
+            for c in competencies:
+                label_lower = (c.match_label or "").lower().strip()
+                if any(vp in label_lower for vp in VAGUE_PATTERNS) or (
+                    c.match in ("strong", "match") and len(label_lower) < 10
+                ):
+                    vague_count += 1
+                if not c.why or len(c.why.strip()) < 5:
+                    no_why_count += 1
+            if vague_count > 0:
+                logger.warning(
+                    f"Competency matching: {vague_count}/{len(competencies)} items have vague match_label"
+                )
+            if no_why_count > 0:
+                logger.warning(
+                    f"Competency matching: {no_why_count}/{len(competencies)} items have empty/short 'why' field"
+                )
             logger.info(f"LLM competency matching: {len(competencies)} items")
             return competencies
         return None


### PR DESCRIPTION
## Summary
- Intel Brief 역량 매칭 match_label vague 패턴 탐지 + why 필드 빈값 경고
- Engineering DNA note/tooltip 품질 검증 (메트릭 인용 누락, 비개발자 설명 누락)
- engineering_dna 프롬프트 FORBIDDEN PATTERNS 추가

## 변경 내역
- **intel_generation.py**: VAGUE_PATTERNS 탐지 + match_label/why 품질 경고 로깅
- **analysis_generation.py**: Engineering DNA note (5자 미만), tooltip (10자 미만), value=0 불일치 탐지
- **v2_generation.yaml**: engineering_dna FORBIDDEN PATTERNS — note 메트릭 필수, tooltip 라벨 반복 금지

## 테스트
- pytest: 474 passed, 4 skipped ✅

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)