### PR TITLE
improve: General 질문 비율 감소 + DNA 한영 불일치 + tech_stack fallback

### DIFF
--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -223,7 +223,12 @@ async def _llm_analyze_engineering_dna(code_analysis: dict | None, output_langua
             # === Post-processing 품질 검증 ===
             no_note = sum(1 for i in items if not i.note or len(str(i.note).strip()) < 5)
             no_tooltip = sum(1 for i in items if not i.tooltip or len(str(i.tooltip).strip()) < 10)
-            zero_value = sum(1 for i in items if i.value == 0 and i.note and "not available" not in str(i.note).lower())
+            zero_value = sum(
+                1 for i in items
+                if i.value == 0 and i.note
+                and "not available" not in str(i.note).lower()
+                and "이용할 수 없" not in str(i.note)
+            )
             if no_note > 0:
                 logger.warning(
                     f"Engineering DNA: {no_note}/{len(items)} items have empty/short note — metric citation missing"

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -168,7 +168,13 @@ async def analyze_code(
 
     # Build code analysis result
     # target_repos 포함: 워크플로우에서 병렬 처리 활성화 기반
-    combined_tech = list(set(tech for repo in repositories for tech in repo.get("analysis", {}).get("tech_stack", [])))
+    # LLM tech_stack + 레포 primary_language 합산 (LLM이 누락해도 GitHub API 언어는 보장)
+    combined_tech_set = set(tech for repo in repositories for tech in repo.get("analysis", {}).get("tech_stack", []))
+    for repo in repositories:
+        lang = repo.get("language")
+        if lang and lang not in combined_tech_set:
+            combined_tech_set.add(lang)
+    combined_tech = list(combined_tech_set)
     code_analysis_result = {
         "repositories": repositories,
         "target_repos": target_repos,  # Step 2 병렬 처리용

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -458,7 +458,17 @@ async def craft_question(
         elif source == "github":
             question["evidence_source"] = "GitHub"
         elif source.startswith("vector_"):
-            question["evidence_source"] = "SemanticSearch"
+            # vector_ 하위 소스를 구체적 evidence_source로 매핑
+            if source in ("vector_code", "vector_github"):
+                question["evidence_source"] = "GitHub"
+            elif source in ("vector_profile", "vector_linkedin"):
+                question["evidence_source"] = "LinkedIn"
+            elif source in ("vector_resume", "vector_document"):
+                question["evidence_source"] = "Resume"
+            elif source == "vector_portfolio":
+                question["evidence_source"] = "Portfolio"
+            else:
+                question["evidence_source"] = "SemanticSearch"
         elif source == "jd_match":
             question["evidence_source"] = "JD"
         else:


### PR DESCRIPTION
## Summary
- evidence_source `vector_*` 매핑을 구체적 소스(GitHub/LinkedIn/Resume)로 분리하여 General 질문 비율 대폭 감소
- Engineering DNA 한/영 불일치 false positive 경고 수정
- LLM tech_stack 누락 시 GitHub API language 필드 fallback 추가

## 변경 파일 (3개)
| 파일 | 변경 |
|------|------|
| `question_generation.py` | `vector_code` → GitHub, `vector_profile` → LinkedIn 등 5개 하위 매핑 |
| `analysis_generation.py` | `"이용할 수 없"` Korean 패턴 추가 |
| `code_analysis.py` | `combined_tech`에 레포 `language` fallback |

## Test plan
- [x] Python syntax 검증 (ast.parse) 통과
- [x] pytest 동기 테스트 통과 (비동기 실패는 pytest-asyncio 미설치로 기존 문제)
- [ ] Worker 재시작 후 테스트 Job 실행으로 evidence_source 분포 검증
- [ ] Engineering DNA 경고 메시지 사라짐 확인

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)