### PR TITLE
improve: 프론트엔드-백엔드 필드명 불일치 수정 + interviewer_note deep-merge

### DIFF
--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -1550,7 +1550,7 @@ prompts:
           {
             "term": "Technical term",
             "plain_language_explanation": "Everyday analogy or simple description",
-            "business_relevance": "Why this matters for business outcomes",
+            "business_context": "Why this matters for business outcomes",
             "pronunciation_guide": "How to say it (if non-obvious)"
           }
         ]
@@ -1563,7 +1563,7 @@ prompts:
       {
         "term": "마이크로서비스 아키텍처",
         "plain_language_explanation": "레고 블록처럼 작은 서비스들을 조립해서 큰 시스템을 만드는 방식. 하나가 고장나도 전체가 멈추지 않음",
-        "business_relevance": "시스템 일부만 업데이트할 수 있어 배포 속도가 빠르고, 장애 영향 범위가 작아 서비스 안정성이 높음",
+        "business_context": "시스템 일부만 업데이트할 수 있어 배포 속도가 빠르고, 장애 영향 범위가 작아 서비스 안정성이 높음",
         "pronunciation_guide": "마이크로-서비스 아키텍처"
       }
       ```
@@ -1572,7 +1572,7 @@ prompts:
       - plain_language_explanation MUST be ≥15 characters — short phrases are REJECTED
       - NEVER define a term by repeating itself: "API는 API입니다" ← REJECTED
       - Use everyday analogies that a non-technical person would understand
-      - business_relevance MUST explain real impact (cost, speed, reliability) — not just "중요합니다"
+      - business_context MUST explain real impact (cost, speed, reliability) — not just "중요합니다"
       - Do NOT duplicate the same term across different questions
 
       REMINDER: Return raw JSON only. Do NOT use markdown code blocks. Start with { and end with }.
@@ -1697,11 +1697,11 @@ prompts:
         "q-tech-a1b2c3d4": {
           "business_interpretation": "What this question reveals in business terms",
           "daily_analogy": "Everyday situation that parallels this technical concept",
+          "level_expectation": "What to expect from this experience level (e.g. 시니어: 구체적 사례+수치 | 주니어: 학습 의지+기본 이해)",
           "what_to_listen_for": "Key phrases or concepts that indicate competence",
           "red_flags": ["Warning signs in candidate's answer"],
           "green_flags": ["Positive indicators in candidate's answer"],
-          "time_guidance": "How long to spend, when to move on",
-          "note_to_self": "Quick reminder for interviewer"
+          "time_guidance": "How long to spend, when to move on"
         }
       }
       ```

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -289,7 +289,11 @@ class InterviewGenerationWorkflow:
                         continue
                     for q_key in q_keys:
                         if q_key and q_key in enhancement:
-                            q[field_name] = enhancement[q_key]
+                            # interviewer_note는 deep-merge (craft_question의 level_expectation 보존)
+                            if field_name == "interviewer_note" and isinstance(q.get(field_name), dict):
+                                q[field_name] = {**q[field_name], **enhancement[q_key]}
+                            else:
+                                q[field_name] = enhancement[q_key]
                             break
 
             # Phase 4: Quality Review + Finalization

--- a/frontend/src/components/tabs/InterviewQuestionCard.tsx
+++ b/frontend/src/components/tabs/InterviewQuestionCard.tsx
@@ -115,9 +115,9 @@ export function InterviewQuestionCard({
                 <div className="text-sm text-amber-800 mt-1">
                   {term.plain_language_explanation || term.definition}
                 </div>
-                {term.business_context && (
+                {(term.business_context || term.business_relevance) && (
                   <div className="text-xs text-amber-700 mt-1">
-                    <strong>{t('live_term_business')}</strong> {term.business_context}
+                    <strong>{t('live_term_business')}</strong> {term.business_context || term.business_relevance}
                   </div>
                 )}
               </div>
@@ -244,8 +244,42 @@ export function InterviewQuestionCard({
             </p>
           )}
           {question.interviewer_note.level_expectation && (
-            <p className="text-sm text-indigo-800">
+            <p className="text-sm text-indigo-800 mb-2">
               <strong>{t('live_level_expectation')}</strong> {question.interviewer_note.level_expectation}
+            </p>
+          )}
+          {question.interviewer_note.what_to_listen_for && (
+            <p className="text-sm text-indigo-800 mb-2">
+              <strong>{t('live_listen_for')}</strong> {question.interviewer_note.what_to_listen_for}
+            </p>
+          )}
+          {question.interviewer_note.green_flags && question.interviewer_note.green_flags.length > 0 && (
+            <div className="mt-2">
+              <strong className="text-xs text-emerald-700">{t('live_green_flags')}</strong>
+              <ul className="mt-1 space-y-1">
+                {question.interviewer_note.green_flags.map((flag, i) => (
+                  <li key={i} className="text-sm text-emerald-700 flex items-start gap-1.5">
+                    <span className="mt-0.5 shrink-0">✅</span> {flag}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {question.interviewer_note.red_flags && question.interviewer_note.red_flags.length > 0 && (
+            <div className="mt-2">
+              <strong className="text-xs text-red-700">{t('live_red_flags')}</strong>
+              <ul className="mt-1 space-y-1">
+                {question.interviewer_note.red_flags.map((flag, i) => (
+                  <li key={i} className="text-sm text-red-700 flex items-start gap-1.5">
+                    <span className="mt-0.5 shrink-0">⚠️</span> {flag}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {question.interviewer_note.time_guidance && (
+            <p className="text-xs text-indigo-600 mt-2 italic">
+              {question.interviewer_note.time_guidance}
             </p>
           )}
         </div>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -218,6 +218,9 @@ const resources = {
       live_business_interpretation: '비즈니스 해석:',
       live_daily_analogy: '일상 비유:',
       live_level_expectation: '레벨 기대치:',
+      live_listen_for: '핵심 관찰 포인트:',
+      live_green_flags: '✅ 긍정 신호',
+      live_red_flags: '⚠️ 주의 신호',
       live_prev_question: '← 이전 질문',
       live_next_question: '다음 질문 →',
       // RadarChart
@@ -554,6 +557,9 @@ const resources = {
       live_business_interpretation: 'Business Interpretation:',
       live_daily_analogy: 'Daily Analogy:',
       live_level_expectation: 'Level Expectation:',
+      live_listen_for: 'What to Listen For:',
+      live_green_flags: '✅ Positive Signals',
+      live_red_flags: '⚠️ Warning Signs',
       live_prev_question: '← Previous',
       live_next_question: 'Next →',
       // RadarChart

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -165,13 +165,19 @@ export interface TerminologyEntry {
   definition?: string
   plain_language_explanation?: string
   business_context?: string
+  business_relevance?: string // Legacy field name (pre-#214)
+  pronunciation_guide?: string
 }
 
 /** Interviewer note with business interpretation */
 export interface InterviewerNote {
   business_interpretation: string
   daily_analogy: string
-  level_expectation: string
+  level_expectation?: string
+  what_to_listen_for?: string
+  red_flags?: string[]
+  green_flags?: string[]
+  time_guidance?: string
 }
 
 /** Interview Question (v2 structure) */


### PR DESCRIPTION
## Summary
- terminology `business_context || business_relevance` 폴백 렌더링
- interviewer_note 덮어쓰기 → deep-merge로 `level_expectation` 보존 (0/19 → 20/20)
- interviewer_note 추가 5필드 렌더링: `what_to_listen_for`, `red_flags`, `green_flags`, `time_guidance`, `level_expectation`
- i18n 3키 추가 (한/영)

## Test plan
- [x] TypeScript 컴파일 에러 없음
- [x] 워크플로우 테스트 5/5 통과
- [x] 테스트 Job 실행 → level_expectation 20/20, 전체 필드 20/20 확인

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)