### PR TITLE
improve: follow_ups good/poor 점수 구조 fallback 추가

### DIFF
--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -535,6 +535,15 @@ async def craft_question(
             "snippet": code_reference.get("code_snippet") or code_reference.get("snippet"),
         }
 
+    # follow_ups good/poor 보강 — LLM이 생략하면 기본 구조 삽입
+    for fu in question.get("follow_ups", []):
+        if not isinstance(fu, dict):
+            continue
+        if "good" not in fu or not isinstance(fu.get("good"), dict):
+            fu["good"] = {"text": fu.get("listen_for", ""), "score": 7}
+        if "poor" not in fu or not isinstance(fu.get("poor"), dict):
+            fu["poor"] = {"text": "", "score": 2}
+
     # Use recommended probe if available and question_text is generic
     if recommended_probe and question.get("question_text", "").startswith("["):
         question["alternative_phrasing"] = question.get("alternative_phrasing", [])


### PR DESCRIPTION
## Summary
- craft_question 후처리에서 LLM이 생략한 follow_ups good/poor 구조를 자동 삽입
- good 누락 시: `{"text": listen_for, "score": 7}`, poor 누락 시: `{"text": "", "score": 2}`

## 검증
- 테스트 Job `4817d932`: 18/18 질문 모두 good/poor score 존재
- 워크플로우 테스트 38/38 passed
- TypeScript 타입 체크 에러 없음

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)