### PR TITLE
improve: follow_up_questions 추가 꼬리질문 + evidence_quality 배지 렌더링

### DIFF
--- a/frontend/src/components/tabs/InterviewQuestionCard.tsx
+++ b/frontend/src/components/tabs/InterviewQuestionCard.tsx
@@ -8,7 +8,8 @@ import type {
   InterviewQuestion,
   ScenarioLevelType,
   QuestionScoreState,
-  EvaluationScenarioDetail
+  EvaluationScenarioDetail,
+  FollowUpQuestionExtra
 } from '../../types/interview'
 
 interface InterviewQuestionCardProps {
@@ -42,6 +43,15 @@ export function InterviewQuestionCard({
           )}
           {question.is_risk && (
             <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full">{t('live_risk_verify')}</span>
+          )}
+          {question.evidence_quality && (
+            <span className={`px-2 py-0.5 text-xs rounded-full ${
+              question.evidence_quality === 'high' ? 'bg-emerald-100 text-emerald-700' :
+              question.evidence_quality === 'medium' ? 'bg-blue-100 text-blue-700' :
+              'bg-gray-100 text-gray-500'
+            }`}>
+              {t(`evidence_${question.evidence_quality}`)}
+            </span>
           )}
           {question.time_allocation_minutes && (
             <span className="px-2 py-0.5 bg-gray-100 text-gray-600 text-xs rounded-full">
@@ -287,6 +297,36 @@ export function InterviewQuestionCard({
           </div>
         </div>
       )}
+
+      {/* Additional Follow-up Questions (purpose + expected insight) */}
+      {score?.selectedLevel && question.follow_up_questions && question.follow_up_questions.length > 0 && (() => {
+        const filtered = question.follow_up_questions.filter(
+          (fq: FollowUpQuestionExtra) => !fq.trigger || fq.trigger.toLowerCase() === 'any' || fq.trigger.toLowerCase() === score.selectedLevel?.toLowerCase()
+        )
+        if (filtered.length === 0) return null
+        return (
+          <div className="border-t border-gray-200 pt-6 mb-6">
+            <h5 className="text-sm font-semibold text-gray-700 mb-3">{t('live_extra_follow_ups')}</h5>
+            <div className="space-y-3">
+              {filtered.map((fq: FollowUpQuestionExtra, i: number) => (
+                <div key={i} className="p-4 bg-teal-50 rounded-xl border border-teal-200">
+                  <p className="font-medium text-gray-900 mb-2">{fq.question_text}</p>
+                  {fq.purpose && (
+                    <p className="text-sm text-teal-800 mb-1">
+                      <strong>{t('live_fuq_purpose')}</strong> {fq.purpose}
+                    </p>
+                  )}
+                  {fq.expected_insight && (
+                    <p className="text-sm text-teal-700">
+                      <strong>{t('live_fuq_expected')}</strong> {fq.expected_insight}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })()}
 
       {/* Interviewer Note */}
       {question.interviewer_note && (

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -226,6 +226,9 @@ const resources = {
       live_coaching_tip: '💡 코칭 팁: ',
       live_recovery_question: '🔄 회복 질문: ',
       live_follow_up_direction: '➡️ 후속 방향: ',
+      live_extra_follow_ups: '추가 꼬리질문',
+      live_fuq_purpose: '📌 목적: ',
+      live_fuq_expected: '💡 기대 인사이트: ',
       live_prev_question: '← 이전 질문',
       live_next_question: '다음 질문 →',
       // RadarChart
@@ -570,6 +573,9 @@ const resources = {
       live_coaching_tip: '💡 Coaching Tip: ',
       live_recovery_question: '🔄 Recovery Question: ',
       live_follow_up_direction: '➡️ Follow-up Direction: ',
+      live_extra_follow_ups: 'Additional Follow-ups',
+      live_fuq_purpose: '📌 Purpose: ',
+      live_fuq_expected: '💡 Expected Insight: ',
       live_prev_question: '← Previous',
       live_next_question: 'Next →',
       // RadarChart

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -190,6 +190,14 @@ export interface EvaluationScenarioDetail {
   follow_up_direction?: string
 }
 
+/** Additional follow-up question (enhanced structure from quality review) */
+export interface FollowUpQuestionExtra {
+  trigger?: string
+  question_text: string
+  purpose?: string
+  expected_insight?: string
+}
+
 /** Interview Question (v2 structure) */
 export interface InterviewQuestion {
   id: string
@@ -222,7 +230,7 @@ export interface InterviewQuestion {
     mid_level?: EvaluationScenarioDetail
     low_level?: EvaluationScenarioDetail
   }
-  follow_up_questions?: Array<Record<string, unknown>>
+  follow_up_questions?: FollowUpQuestionExtra[]
 
   // Evidence quality from quality review
   evidence_score?: number


### PR DESCRIPTION
## 개선 사이클 #55: follow_up_questions + evidence_quality 렌더링

### 문제
- 각 질문에 `follow_up_questions` (3개/질문, 총 54개) 데이터가 백엔드에서 생성되지만 프론트엔드에 미렌더링
- `evidence_quality` 배지가 질문 선택 목록(LiveInterviewTab)에만 있고, 실제 면접 카드에는 없음

### 변경 내용
- **`interview.ts`**: `FollowUpQuestionExtra` 인터페이스 추가, `follow_up_questions` 필드 타입 강화
- **`InterviewQuestionCard.tsx`**: 
  - 시나리오 선택 후 trigger 레벨 매칭되는 추가 꼬리질문 렌더링 (teal 색상)
  - purpose + expected_insight 비개발자 친화 표시
  - evidence_quality 배지를 질문 카드 헤더에 추가
- **`i18n.ts`**: 6개 번역 키 추가 (ko/en)

### DB 데이터 확인
- 18/18 질문에 follow_up_questions 3개씩 존재 (총 54개)
- follow_ups (기존 2개)와 별개의 추가 꼬리질문
- 구조: { trigger, question_text, purpose, expected_insight }

### 검증
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (499ms)

Closes #220

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>