### PR TITLE
improve: Decision 탭 수준 판단 근거(level_evidence) 렌더링

### DIFF
--- a/frontend/src/components/tabs/DecisionTab.tsx
+++ b/frontend/src/components/tabs/DecisionTab.tsx
@@ -24,7 +24,6 @@ export const DecisionTab = memo(function DecisionTab({
   maxScore = 100,
   riskFlags,
   dataConfidence,
-  dataConfidenceScore
 }: DecisionTabProps) {
   const { t } = useTranslation()
   const { summary, interviewer_guide, jd_competency_map } = decision
@@ -115,6 +114,9 @@ export const DecisionTab = memo(function DecisionTab({
           <div className="p-4 bg-gray-50 rounded-lg">
             <div className="text-sm text-gray-500">{t('decision_level')}</div>
             <div className="font-semibold text-gray-900">{summary.level}</div>
+            {summary.level_evidence && (
+              <div className="text-xs text-gray-500 mt-1">{summary.level_evidence}</div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## 변경 사항
- Decision 탭 `summary.level` 아래에 `level_evidence` 텍스트를 회색 소글씨로 표시
- 비개발자가 "왜 이 수준인지" 근거를 즉시 확인 가능
- 예시: "SFIA Level 1: 경력 0년 (Resume)"

## 검증
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (500ms)

Closes #224