### PR TITLE
improve: Engineering DNA 툴팁 너비 확장 — 비개발자 가독성

### DIFF
--- a/frontend/src/components/charts/ProgressBar.tsx
+++ b/frontend/src/components/charts/ProgressBar.tsx
@@ -86,7 +86,7 @@ export function ProgressBar({
                   d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                 />
               </svg>
-              <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-48 p-2 bg-gray-900 text-white text-xs rounded-lg shadow-lg z-10">
+              <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-64 p-2 bg-gray-900 text-white text-xs rounded-lg shadow-lg z-10 leading-relaxed">
                 {tooltip}
               </span>
             </span>


### PR DESCRIPTION
## 변경 사항
- ProgressBar 컴포넌트 tooltip: w-48 → w-64 + leading-relaxed
- 비개발자용 한국어 설명이 잘리지 않도록 개선

## 검증
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (500ms)

Closes #226