### PR TITLE
improve: InterviewQuestionCard Good/Poor 라벨 i18n 전환

### DIFF
--- a/frontend/src/components/tabs/InterviewQuestionCard.tsx
+++ b/frontend/src/components/tabs/InterviewQuestionCard.tsx
@@ -262,11 +262,11 @@ export function InterviewQuestionCard({
                   <p className="font-medium text-gray-900 mb-2">{followUp.question_text}</p>
                   <div className="grid sm:grid-cols-2 gap-3 mb-3">
                     <div className="p-2 bg-green-50 rounded-lg border border-green-200">
-                      <span className="text-xs font-semibold text-green-700">Good ({followUp.good.score}pts)</span>
+                      <span className="text-xs font-semibold text-green-700">{t('live_followup_good')} ({followUp.good.score}{t('live_followup_pts')})</span>
                       <p className="text-sm text-green-800 mt-1">{followUp.good.text}</p>
                     </div>
                     <div className="p-2 bg-red-50 rounded-lg border border-red-200">
-                      <span className="text-xs font-semibold text-red-700">Poor ({followUp.poor.score}pts)</span>
+                      <span className="text-xs font-semibold text-red-700">{t('live_followup_poor')} ({followUp.poor.score}{t('live_followup_pts')})</span>
                       <p className="text-sm text-red-800 mt-1">{followUp.poor.text}</p>
                     </div>
                   </div>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -327,6 +327,10 @@ const resources = {
       scenario_expert: '🌟 Expert',
       scenario_mid: '📊 Mid',
       scenario_low: '📉 Low',
+      // LiveInterviewTab - follow-up answer quality labels
+      live_followup_good: '좋은 답변',
+      live_followup_poor: '주의 답변',
+      live_followup_pts: '점',
       // DeepAnalysisTab
       engineering_dna: 'Engineering DNA',
       data_confidence_label: '데이터 신뢰도',
@@ -679,6 +683,10 @@ const resources = {
       scenario_expert: '🌟 Expert',
       scenario_mid: '📊 Mid',
       scenario_low: '📉 Low',
+      // LiveInterviewTab - follow-up answer quality labels
+      live_followup_good: 'Good',
+      live_followup_poor: 'Poor',
+      live_followup_pts: 'pts',
       // DeepAnalysisTab
       engineering_dna: 'Engineering DNA',
       data_confidence_label: 'Data Confidence',


### PR DESCRIPTION
## Summary
- InterviewQuestionCard follow-up 답변 품질 라벨 하드코딩 → i18n 전환
- 한국어/영어 키 3개씩 추가 (`live_followup_good`, `live_followup_poor`, `live_followup_pts`)

## 변경 파일
- `frontend/src/components/tabs/InterviewQuestionCard.tsx` — `Good`/`Poor`/`pts` → `t()` 전환
- `frontend/src/i18n.ts` — 한국어+영어 키 추가

## 검증
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (500ms)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)