### PR TITLE
improve: DecisionTab 추천 등급 기준 게이지 바 추가

### DIFF
--- a/frontend/src/components/tabs/DecisionTab.tsx
+++ b/frontend/src/components/tabs/DecisionTab.tsx
@@ -93,6 +93,45 @@ export const DecisionTab = memo(function DecisionTab({
         </div>
       </div>
 
+      {/* Score Threshold Guide - shows how score maps to recommendation */}
+      <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+        <h4 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+          <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {t('decision_score_guide')}
+        </h4>
+        <div className="relative h-3 rounded-full overflow-hidden flex">
+          <div className="h-full bg-red-400" style={{ width: '40%' }} />
+          <div className="h-full bg-amber-400" style={{ width: '20%' }} />
+          <div className="h-full bg-green-400" style={{ width: '20%' }} />
+          <div className="h-full bg-emerald-400" style={{ width: '20%' }} />
+          {/* Score indicator */}
+          <div
+            className="absolute top-0 h-full w-0.5 bg-gray-900"
+            style={{ left: `${Math.min(scorePercent, 100)}%` }}
+          />
+        </div>
+        <div className="flex text-[10px] text-gray-500 mt-1.5">
+          <div className="w-[40%] text-center">
+            <span className="text-red-600 font-medium">{t('rec_no_hire')}</span>
+            <span className="text-gray-400 ml-1">0-39%</span>
+          </div>
+          <div className="w-[20%] text-center">
+            <span className="text-amber-600 font-medium">{t('rec_leaning_no')}</span>
+            <span className="text-gray-400 ml-1">40-59%</span>
+          </div>
+          <div className="w-[20%] text-center">
+            <span className="text-green-600 font-medium">{t('rec_hire')}</span>
+            <span className="text-gray-400 ml-1">60-79%</span>
+          </div>
+          <div className="w-[20%] text-center">
+            <span className="text-emerald-600 font-medium">{t('rec_strong_hire')}</span>
+            <span className="text-gray-400 ml-1">80%+</span>
+          </div>
+        </div>
+      </div>
+
       {/* Decision Summary */}
       <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
         <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -176,6 +176,7 @@ const resources = {
       // Result tabs - Decision
       decision_recommendation: '채용 추천',
       decision_points: '{{score}} / {{max}} 점',
+      decision_score_guide: '추천 등급 기준',
       decision_candidate_summary: '후보자 요약',
       decision_experience: '경력',
       decision_jd_match: 'JD 매칭',
@@ -532,6 +533,7 @@ const resources = {
       // Result tabs - Decision
       decision_recommendation: 'Hiring Recommendation',
       decision_points: '{{score}} / {{max}} pts',
+      decision_score_guide: 'Recommendation Criteria',
       decision_candidate_summary: 'Candidate Summary',
       decision_experience: 'Experience',
       decision_jd_match: 'JD Match',


### PR DESCRIPTION
## Summary
- DecisionTab 점수 카드 아래에 추천 등급 기준 게이지 바 추가
- 비개발자가 점수의 의미를 직관적으로 이해 가능

## 변경
- `DecisionTab.tsx` — 4구간 게이지 바 + 점수 인디케이터
- `i18n.ts` — `decision_score_guide` 키 추가 (한/영)

## 검증
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (497ms)

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)