### PR TITLE
improve: 스킬 매칭 신뢰도 배지에 비개발자용 설명 툴팁 추가

### DIFF
--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -22,8 +22,6 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
     { label: t('deep_communication'), desc: t('deep_communication_desc') },
     { label: t('deep_code_quality'), desc: t('deep_code_quality_desc') },
   ]
-  const radarLabels = radarAxisConfig.map(a => a.label)
-
   return (
     <div className="space-y-6">
       {/* Overall Match Score */}
@@ -215,13 +213,19 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
                     </td>
                     <td className="px-6 py-4">
                       <div className="text-sm text-gray-500">{row.evidence}</div>
-                      <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium mt-1 ${
-                        row.confidence >= 80 ? 'bg-emerald-50 text-emerald-700' :
-                        row.confidence >= 50 ? 'bg-amber-50 text-amber-700' :
-                        'bg-red-50 text-red-700'
-                      }`}>
-                        {row.confidence >= 80 ? t('evidence_high') :
-                         row.confidence >= 50 ? t('evidence_medium') : t('evidence_low')}
+                      <span className="group relative inline-flex items-center">
+                        <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium mt-1 cursor-help ${
+                          row.confidence >= 80 ? 'bg-emerald-50 text-emerald-700' :
+                          row.confidence >= 50 ? 'bg-amber-50 text-amber-700' :
+                          'bg-red-50 text-red-700'
+                        }`}>
+                          {row.confidence >= 80 ? t('evidence_high') :
+                           row.confidence >= 50 ? t('evidence_medium') : t('evidence_low')}
+                        </span>
+                        <span className="invisible group-hover:visible absolute left-0 bottom-full mb-2 w-52 p-2 bg-gray-900 text-white text-xs rounded-lg shadow-lg z-10 leading-relaxed">
+                          {row.confidence >= 80 ? t('confidence_tooltip_high') :
+                           row.confidence >= 50 ? t('confidence_tooltip_medium') : t('confidence_tooltip_low')}
+                        </span>
                       </span>
                     </td>
                     <td className="px-6 py-4 text-right">

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -344,6 +344,9 @@ const resources = {
       evidence_high: '근거 충분',
       evidence_medium: '근거 보통',
       evidence_low: '근거 부족',
+      confidence_tooltip_high: '이력서, GitHub 코드 등 확실한 근거가 있어 매칭 결과를 신뢰할 수 있습니다.',
+      confidence_tooltip_medium: '일부 근거는 있지만 추가 확인이 필요할 수 있습니다.',
+      confidence_tooltip_low: '근거가 부족하여 면접에서 직접 확인이 필요합니다.',
       // Score Transparency - Axis Explanations (for non-developers)
       deep_role_fit_desc: '채용공고(JD)의 요구사항과 후보자의 경험/스킬이 얼마나 일치하는지',
       deep_technical_desc: '프로그래밍 언어, 프레임워크, 도구 등 기술적 깊이와 폭',
@@ -701,6 +704,9 @@ const resources = {
       evidence_high: 'Strong Evidence',
       evidence_medium: 'Moderate Evidence',
       evidence_low: 'Weak Evidence',
+      confidence_tooltip_high: 'Strong evidence from resume, GitHub code, etc. This match result is reliable.',
+      confidence_tooltip_medium: 'Some evidence exists but may need additional verification in the interview.',
+      confidence_tooltip_low: 'Limited evidence available. Direct confirmation in the interview is recommended.',
       // Score Transparency - Axis Explanations (for non-developers)
       deep_role_fit_desc: 'How well the candidate\'s experience/skills match the JD requirements',
       deep_technical_desc: 'Depth and breadth of programming languages, frameworks, and tools',


### PR DESCRIPTION
## Summary
- DeepAnalysisTab 스킬 매칭 confidence 배지에 hover 툴팁 추가
- 비개발자가 "신뢰도"의 의미를 직관적으로 이해 가능

## 변경
- `DeepAnalysisTab.tsx` — confidence 배지에 group hover 툴팁 래핑
- `i18n.ts` — `confidence_tooltip_high/medium/low` 키 추가 (한/영)

## 검증
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (510ms)

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)