### PR TITLE
improve: 레이더 차트 축별 점수 근거를 인라인 표시

### DIFF
--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -70,31 +70,40 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
               const candidate = radar_candidate?.[i] ?? 0
               const required = radar_required?.[i] ?? 0
               const diff = candidate - required
+              const sourceText = score_sources?.[i]
+              const llmExplanation = sourceText?.includes('| LLM:')
+                ? sourceText.split('| LLM:')[1]?.trim()
+                : null
               return (
-                <div key={axis.label} className="flex items-center gap-3">
-                  <span className="w-28 text-sm text-gray-600 flex items-center gap-1">
-                    {axis.label}
-                    <span className="group relative">
-                      <svg className="w-3.5 h-3.5 text-gray-400 cursor-help flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                      <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 px-3 py-2 bg-gray-900 text-white text-xs rounded-lg shadow-lg hidden group-hover:block z-10 pointer-events-none">
-                        {axis.desc}
+                <div key={axis.label}>
+                  <div className="flex items-center gap-3">
+                    <span className="w-28 text-sm text-gray-600 flex items-center gap-1">
+                      {axis.label}
+                      <span className="group relative">
+                        <svg className="w-3.5 h-3.5 text-gray-400 cursor-help flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 px-3 py-2 bg-gray-900 text-white text-xs rounded-lg shadow-lg hidden group-hover:block z-10 pointer-events-none">
+                          {axis.desc}
+                        </span>
                       </span>
                     </span>
-                  </span>
-                  <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-emerald-500 rounded-full"
-                      style={{ width: `${candidate}%` }}
-                    />
+                    <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-emerald-500 rounded-full"
+                        style={{ width: `${candidate}%` }}
+                      />
+                    </div>
+                    <span className={`text-sm font-medium w-16 text-right ${
+                      diff >= 0 ? 'text-emerald-600' : 'text-red-600'
+                    }`}>
+                      {candidate}
+                      <span className="text-xs text-gray-400 ml-1">/ {required}</span>
+                    </span>
                   </div>
-                  <span className={`text-sm font-medium w-16 text-right ${
-                    diff >= 0 ? 'text-emerald-600' : 'text-red-600'
-                  }`}>
-                    {candidate}
-                    <span className="text-xs text-gray-400 ml-1">/ {required}</span>
-                  </span>
+                  {llmExplanation && (
+                    <p className="ml-[7.5rem] text-[11px] text-gray-500 mt-0.5 leading-relaxed">{llmExplanation}</p>
+                  )}
                 </div>
               )
             })}


### PR DESCRIPTION
## Summary
- 레이더 차트 5축 점수 아래에 score_sources의 LLM 설명을 인라인 표시
- 비개발자가 "왜 이 점수인지" 즉시 파악 가능

## 변경
- `DeepAnalysisTab.tsx` — score_sources[i]에서 `| LLM:` 이후 텍스트 파싱하여 축 아래 표시

## 검증
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (504ms)

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)