### PR TITLE
fix: LinkedIn experience fallback — current_company 기반 최소 경력

### DIFF
--- a/backend/app/services/linkedin_service.py
+++ b/backend/app/services/linkedin_service.py
@@ -200,6 +200,8 @@ class LinkedInService:
         # 단일 형식: experience[].title (직책이 바로 있는 경우)
         experiences = []
         raw_exp = data.get("experience") or data.get("experiences") or []
+        if not raw_exp:
+            logger.warning("Bright Data returned empty experience array")
         if raw_exp:
             for exp in raw_exp[:10]:
                 if not isinstance(exp, dict):
@@ -235,9 +237,24 @@ class LinkedInService:
                     })
         experiences = experiences[:10]  # 최대 10개
 
+        # Fallback: experience가 비었지만 current_company가 있으면 최소 1개 구성
+        if not experiences and current_company:
+            headline = data.get("headline") or data.get("position") or ""
+            experiences.append({
+                "title": headline if headline else None,
+                "company": current_company,
+                "description": None,
+                "starts_at": None,
+                "ends_at": None,
+                "duration": None,
+                "location": data.get("city") or data.get("location"),
+            })
+
         # 학력 정규화 — Bright Data는 start_year/end_year 사용, title이 학교명
         education = []
         raw_edu = data.get("education") or []
+        if not raw_edu:
+            logger.warning("Bright Data returned empty education array")
         if raw_edu:
             for edu in raw_edu[:5]:
                 if not isinstance(edu, dict):


### PR DESCRIPTION
## 요약

Bright Data API가 `experience: []` (빈 배열)을 반환하는 경우에도
`current_company`/`current_company_name` 필드가 있으면 최소 1개의
경력 항목을 자동 구성하여 Intel Brief 탭에 현재 직장을 표시합니다.

### 배경

- PR #239에서 Bright Data 중첩 구조 처리를 수정했으나, 특정 프로필은
  experience 자체가 빈 배열로 반환됨 (프로필 공개 설정에 따라 다름)
- `current_company: "HireReady"` 같은 요약 정보는 별도 필드로 제공되므로
  이를 활용하여 fallback 경력 구성

### 변경

- `linkedin_service.py`: experience 빈 배열 + current_company 존재 시 fallback
- 임시 디버그 로깅 제거 → 간결한 경고 로깅

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)