### PR TITLE
fix: LinkedInPosition None 값 방어 — str 변환 + or-chain 패턴

### DIFF
--- a/backend/app/workflows/activities/intel_generation.py
+++ b/backend/app/workflows/activities/intel_generation.py
@@ -322,9 +322,9 @@ def _extract_linkedin_positions(linkedin_profile: dict | None) -> list[LinkedInP
     positions = []
 
     for exp in experiences[:5]:  # 최근 5개
-        company = exp.get("company", exp.get("company_name", "Unknown"))
-        title = exp.get("title", exp.get("position", ""))
-        duration = exp.get("duration", exp.get("tenure", ""))
+        company = exp.get("company") or exp.get("company_name") or "Unknown"
+        title = exp.get("title") or exp.get("position") or ""
+        duration = exp.get("duration") or exp.get("tenure") or ""
 
         # duration이 없으면 starts_at/ends_at에서 계산
         if not duration:
@@ -335,9 +335,9 @@ def _extract_linkedin_positions(linkedin_profile: dict | None) -> list[LinkedInP
 
         positions.append(LinkedInPosition(
             initial=company[0].upper() if company else "?",
-            title=title,
-            company=company,
-            detail=duration,
+            title=str(title) if title else "",
+            company=str(company),
+            detail=str(duration) if duration else "",
         ))
 
     return positions


### PR DESCRIPTION
## Summary
- `dict.get(key, default)`는 키가 존재하되 값이 `None`이면 `None`을 반환하는 문제 → `or`-chain 패턴으로 전환
- `LinkedInPosition` Pydantic 모델의 모든 필드에 `str()` 래핑 + 빈 문자열 fallback 추가
- Bright Data `current_company` fallback 경력에서 `title: None` 시 `ValidationError` 발생하던 문제 해결

## Test plan
- [ ] Worker 재시작 후 테스트 Job 생성
- [ ] LinkedIn 프로필이 있는 후보자에서 ValidationError 없이 완료 확인
- [ ] Intel Brief 탭에서 경력 정보 렌더링 확인

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)