### PR TITLE
fix: LinkedIn 경고 검사 TypeError — title None 방어

### DIFF
--- a/backend/app/workflows/activities/intel_generation.py
+++ b/backend/app/workflows/activities/intel_generation.py
@@ -395,7 +395,7 @@ async def generate_intel_brief(
     if linkedin_profile:
         warnings = []
         experiences = linkedin_profile.get("experiences") or linkedin_profile.get("experience") or []
-        if not any("CTO" in e.get("title", "") or "VP" in e.get("title", "") for e in experiences):
+        if not any("CTO" in (e.get("title") or "") or "VP" in (e.get("title") or "") for e in experiences):
             from app.services.i18n_labels import _t
             warnings.append(_t("no_cto_vp_experience", output_language))
         if warnings:


### PR DESCRIPTION
## Summary
- `generate_intel_brief()` line 398에서 LinkedIn 경력 `title`이 `None`일 때 `"CTO" in None` → `TypeError` 발생
- `dict.get("title", "")` → `(e.get("title") or "")` 패턴으로 전환하여 None 방어
- PR #241과 동일한 근본 원인: Bright Data fallback 경력 데이터에서 title이 None

## Test plan
- [ ] Worker 재시작 후 테스트 Job 생성
- [ ] LinkedIn 프로필이 있는 후보자에서 TypeError 없이 Phase 4 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)