### PR TITLE
improve: 점수 체계 3대 문제 해결 — JD 기반 가중 스킬 매칭 + 비개발자 친화 점수 근거

### DIFF
--- a/backend/app/services/i18n_labels.py
+++ b/backend/app/services/i18n_labels.py
@@ -89,6 +89,31 @@ _LABELS: dict[str, dict[str, str]] = {
         "en": "Specific team collaboration examples",
     },
     "competency_n": {"ko": "역량{n}", "en": "Competency {n}"},
+    # scoring_formulas.py -- human_source (비개발자 친화 점수 근거)
+    "score_role_fit": {
+        "ko": "직무 적합도 {total}점: JD 요구사항 매칭 {jd_pct}% (비중 70%) + 핵심 스킬 일치율 {skill_pct}% (비중 30%)",
+        "en": "Role Fit {total}pts: JD requirement match {jd_pct}% (weight 70%) + key skill overlap {skill_pct}% (weight 30%)",
+    },
+    "score_technical": {
+        "ko": "기술 역량 {total}점: 코드 품질 {cq}점 (40%) + 기술 스택 폭 {tb}점 (30%) + 꾸준한 활동 {cc}점 (30%)",
+        "en": "Technical {total}pts: code quality {cq} (40%) + tech breadth {tb} (30%) + consistency {cc} (30%)",
+    },
+    "score_execution": {
+        "ko": "실행력 {total}점: 경력 수준 {exp}점 (40%) + 개발 꾸준함 {cc}점 (30%) + 코드 작성량 {vol}점 (30%)",
+        "en": "Execution {total}pts: experience {exp} (40%) + consistency {cc} (30%) + code volume {vol} (30%)",
+    },
+    "score_communication": {
+        "ko": "소통/문서화 {total}점: 코드 문서화 수준 {doc}점 (50%) + 코드 가독성 {read}점 (50%)",
+        "en": "Communication {total}pts: documentation {doc} (50%) + readability {read} (50%)",
+    },
+    "score_code_quality": {
+        "ko": "코드 품질 {total}점: 테스트·문서화·복잡도·안정성 종합",
+        "en": "Code Quality {total}pts: composite of tests, docs, complexity, stability",
+    },
+    "score_overall_match": {
+        "ko": "종합 매칭 {total}점: 스킬({skill}점)×35% + 코드({code}점)×25% + 경력({exp}점)×25% + JD({jd}점)×15%",
+        "en": "Overall Match {total}pts: skill({skill})×35% + code({code})×25% + exp({exp})×25% + JD({jd})×15%",
+    },
 }
 
 

--- a/backend/app/services/scoring_formulas.py
+++ b/backend/app/services/scoring_formulas.py
@@ -31,9 +31,10 @@ logger = logging.getLogger(__name__)
 class ScoringResult:
     """점수 계산 결과 (투명성 보장)"""
     score: int          # 0-100
-    source: str         # 점수 산출 근거 설명
+    source: str         # 점수 산출 근거 설명 (기술적, 로깅/디버그용)
     confidence: str     # "high" | "medium" | "low"
     components: dict = field(default_factory=dict)  # 세부 항목별 점수
+    human_source: str = ""  # 비개발자 친화 설명 (UI 표시용)
 
 
 @dataclass
@@ -41,8 +42,9 @@ class RadarScores:
     """레이더 차트 점수 (5축)"""
     candidate: list[int]    # [role_fit, technical, execution, communication, code_quality]
     required: list[int]     # 경험 레벨별 기대 점수
-    sources: list[str]      # 각 축의 산출 근거
+    sources: list[str]      # 각 축의 산출 근거 (기술적)
     confidence: str         # 전체 데이터 신뢰도
+    human_sources: list[str] = field(default_factory=list)  # 비개발자 친화 설명
 
 
 # ============================================================
@@ -232,11 +234,109 @@ def calculate_code_quality_score(
 #    Each axis has a transparent formula with cited weights.
 # ============================================================
 
+# Trivial skills — low weight in JD matching (Issue #245)
+# These skills are universal/tooling and don't differentiate candidates
+_TRIVIAL_SKILLS: set[str] = {
+    "git", "github", "gitlab", "csv", "json", "xml", "yaml", "toml",
+    "html", "css", "markdown", "http", "rest", "api",
+    "linux", "macos", "windows", "terminal", "cli", "bash", "shell",
+    "npm", "pip", "yarn", "vscode", "ide", "jira", "slack", "notion",
+    "agile", "scrum", "kanban",
+}
+
+
+def _fuzzy_skill_match(jd_skill: str, candidate_skill: str) -> float:
+    """퍼지 스킬 매칭 점수 (0.0-1.0)
+
+    - 정확 매칭: 1.0
+    - 부분 문자열 (길이 비율 ≥50%): 0.8 — "Java"→"JavaScript" 방지
+    - 토큰 50% 일치: 0.6
+    """
+    jd_lower = jd_skill.lower().strip()
+    cand_lower = candidate_skill.lower().strip()
+
+    if not jd_lower or not cand_lower:
+        return 0.0
+
+    # Exact match
+    if jd_lower == cand_lower:
+        return 1.0
+
+    # Substring match with length guard (≥50% length ratio)
+    shorter, longer = (jd_lower, cand_lower) if len(jd_lower) <= len(cand_lower) else (cand_lower, jd_lower)
+    if len(shorter) >= 3 and shorter in longer:
+        ratio = len(shorter) / len(longer)
+        if ratio >= 0.50:
+            return 0.8
+
+    # Token overlap (≥50%)
+    jd_tokens = set(jd_lower.replace("-", " ").replace(".", " ").split())
+    cand_tokens = set(cand_lower.replace("-", " ").replace(".", " ").split())
+    if jd_tokens and cand_tokens:
+        overlap = len(jd_tokens & cand_tokens)
+        if overlap / max(len(jd_tokens), 1) >= 0.5:
+            return 0.6
+
+    return 0.0
+
+
+def _weighted_skill_overlap(
+    jd_requirements: list[dict],
+    candidate_skills: set[str],
+    code_techs: set[str],
+) -> float:
+    """JD 카테고리 가중치 기반 스킬 오버랩 (Issue #245)
+
+    가중치: 필수 1.0, 우대 0.5, 사소한 스킬 0.1
+
+    Returns:
+        가중 매칭 비율 (0.0-1.0)
+    """
+    if not jd_requirements:
+        return 0.0
+
+    all_candidate = candidate_skills | code_techs
+    total_weight = 0.0
+    matched_weight = 0.0
+
+    for req in jd_requirements:
+        skill = req.get("skill", "").strip()
+        if not skill:
+            continue
+        category = req.get("category", "우대")
+
+        # Determine weight: trivial overrides category
+        skill_lower = skill.lower()
+        if skill_lower in _TRIVIAL_SKILLS:
+            weight = 0.1
+        elif category in ("필수", "required", "must"):
+            weight = 1.0
+        else:  # 우대, preferred, nice-to-have
+            weight = 0.5
+
+        total_weight += weight
+
+        # Find best fuzzy match among candidate skills
+        best_match = 0.0
+        for cs in all_candidate:
+            score = _fuzzy_skill_match(skill, cs)
+            if score > best_match:
+                best_match = score
+                if score >= 1.0:
+                    break  # Perfect match, no need to continue
+
+        matched_weight += weight * best_match
+
+    return matched_weight / max(total_weight, 0.001)
+
+
 def calculate_radar_scores(
     jd_analysis: dict,
     code_analysis: dict | None,
     document_analysis: dict,
     experience_level: str = "미들",
+    linkedin_profile: dict | None = None,
+    output_language: str = "ko",
 ) -> RadarScores:
     """5축 레이더 점수 계산 (결정론적)
 
@@ -247,49 +347,82 @@ def calculate_radar_scores(
         code_analysis: 코드 분석 결과 (optional)
         document_analysis: 문서 분석 결과
         experience_level: 경험 레벨 (CTO/VP, 시니어, 미들, 주니어, 신입)
+        linkedin_profile: LinkedIn 프로필 데이터 (optional)
+        output_language: 출력 언어 (ko/en)
 
     Returns:
-        RadarScores with candidate/required scores and sources
+        RadarScores with candidate/required scores, sources, and human_sources
     """
+    from app.services.i18n_labels import _t
+
     profile = document_analysis.get("profile", {})
     quality, stats = extract_code_stats(code_analysis)
 
     sources = []
+    human_sources = []
 
-    # --- Axis 0: Role Fit ---
-    # Primary: JD match score (70%), Skill overlap ratio (30%)
-    jd_match = document_analysis.get("jd_match_score", 0.5)
-    jd_component = int(jd_match * 100) * 0.70
-
-    # Skill overlap
-    jd_skills = {r.get("skill", "").lower() for r in jd_analysis.get("requirements", [])}
+    # Collect all candidate skills (resume + code + linkedin)
     raw_skills = profile.get("skills", [])
-    candidate_skills = set()
+    candidate_skills: set[str] = set()
     if isinstance(raw_skills, dict):
         candidate_skills = {s.lower() for s in raw_skills.keys()}
     elif isinstance(raw_skills, list):
         candidate_skills = {s.lower() for s in raw_skills if isinstance(s, str)}
 
-    code_techs = set()
+    code_techs: set[str] = set()
     if code_analysis:
         code_techs = {s.lower() for s in code_analysis.get("tech_stack", [])}
+
+    # LinkedIn skills integration
+    if linkedin_profile:
+        linkedin_skills_raw = linkedin_profile.get("skills") or []
+        for ls in linkedin_skills_raw:
+            s = ls if isinstance(ls, str) else (ls.get("name", "") if isinstance(ls, dict) else "")
+            if s:
+                candidate_skills.add(s.lower())
+
     all_candidate = candidate_skills | code_techs
 
-    overlap = len(jd_skills & all_candidate) / max(len(jd_skills), 1)
-    skill_component = int(overlap * 100) * 0.30
+    # --- Axis 0: Role Fit ---
+    # Primary: JD match score (70%), Weighted skill overlap (30%)
+    jd_match = document_analysis.get("jd_match_score", 0.5)
+    jd_pct = int(jd_match * 100)
+    jd_component = jd_pct * 0.70
+
+    # Weighted skill overlap (필수/우대/사소한 스킬 가중치 적용)
+    jd_requirements = jd_analysis.get("requirements", [])
+    overlap = _weighted_skill_overlap(jd_requirements, candidate_skills, code_techs)
+    skill_pct = int(overlap * 100)
+    skill_component = skill_pct * 0.30
 
     role_fit = max(0, min(100, int(jd_component + skill_component)))
     sources.append(
-        f"role_fit: jd_match({jd_match:.2f})×70% + skill_overlap({overlap:.2f})×30%"
+        f"role_fit: jd_match({jd_match:.2f})×70% + weighted_skill_overlap({overlap:.2f})×30%"
+    )
+    human_sources.append(
+        _t("score_role_fit", output_language, total=role_fit, jd_pct=jd_pct, skill_pct=skill_pct)
     )
 
     # --- Axis 1: Technical Depth ---
-    # Code quality (40%), Tech breadth (30%), Contribution consistency (30%)
+    # Code quality (40%), JD-based tech breadth (30%), Contribution consistency (30%)
     cq = calculate_code_quality_score(quality, stats)
     cq_component = cq.score * 0.40
 
-    tech_stack = code_analysis.get("tech_stack", []) if code_analysis else []
-    tech_breadth = min(100, len(tech_stack) * 12)  # 8+ techs = ~100
+    # tech_breadth: JD 요구 기술(사소한 스킬 제외) 중 후보자 보유 비율
+    jd_nontrivial_techs = [
+        r.get("skill", "").lower() for r in jd_requirements
+        if r.get("skill", "").lower() not in _TRIVIAL_SKILLS
+    ]
+    if jd_nontrivial_techs:
+        matched_techs = sum(
+            1 for jt in jd_nontrivial_techs
+            if any(_fuzzy_skill_match(jt, cs) >= 0.6 for cs in all_candidate)
+        )
+        tech_breadth = min(100, int((matched_techs / len(jd_nontrivial_techs)) * 100))
+    else:
+        # JD에 기술 요구사항 없으면 기존 방식 fallback
+        tech_stack = code_analysis.get("tech_stack", []) if code_analysis else []
+        tech_breadth = min(100, len(tech_stack) * 12)
     tb_component = tech_breadth * 0.30
 
     monthly = code_analysis.get("monthly_contributions", []) if code_analysis else []
@@ -299,12 +432,22 @@ def calculate_radar_scores(
 
     technical = max(0, min(100, int(cq_component + tb_component + cc_component)))
     sources.append(
-        f"technical: code_quality({cq.score})×40% + tech_breadth({tech_breadth})×30% + consistency({consistency})×30%"
+        f"technical: code_quality({cq.score})×40% + jd_tech_breadth({tech_breadth})×30% + consistency({consistency})×30%"
+    )
+    human_sources.append(
+        _t("score_technical", output_language, total=technical, cq=cq.score, tb=tech_breadth, cc=consistency)
     )
 
     # --- Axis 2: Execution & Delivery ---
     # Experience SFIA score (40%), Commit consistency (30%), Code volume (30%)
     exp_years = profile.get("experience_years", 0) or 0
+
+    # LinkedIn 경력 연수 보강
+    if not exp_years and linkedin_profile:
+        linkedin_exp = linkedin_profile.get("experience_years") or linkedin_profile.get("years_of_experience") or 0
+        if linkedin_exp:
+            exp_years = linkedin_exp
+
     _, sfia_score = classify_experience_level(exp_years)
     exp_component = sfia_score * 0.40
 
@@ -318,6 +461,9 @@ def calculate_radar_scores(
     execution = max(0, min(100, int(exp_component + commit_consistency_component + vol_component)))
     sources.append(
         f"execution: sfia_exp({sfia_score})×40% + commit_consistency({consistency})×30% + code_volume({code_volume})×30%"
+    )
+    human_sources.append(
+        _t("score_execution", output_language, total=execution, exp=sfia_score, cc=consistency, vol=code_volume)
     )
 
     # --- Axis 3: Communication ---
@@ -333,12 +479,18 @@ def calculate_radar_scores(
     sources.append(
         f"communication: doc_score({doc_score})×50% + readability({cc_norm})×50%"
     )
+    human_sources.append(
+        _t("score_communication", output_language, total=communication, doc=doc_score, read=cc_norm)
+    )
 
     # --- Axis 4: Code Quality ---
     # Direct composite code quality score
     code_quality = cq.score
     sources.append(
         f"code_quality: composite({cq.score}) = {cq.source}"
+    )
+    human_sources.append(
+        _t("score_code_quality", output_language, total=code_quality)
     )
 
     # No-code fallback: reasonable defaults when GitHub data unavailable
@@ -358,6 +510,8 @@ def calculate_radar_scores(
         data_sources += 1
     if document_analysis.get("jd_match_score") is not None:
         data_sources += 1
+    if linkedin_profile:
+        data_sources += 1
     if data_sources >= 3:
         confidence = "high"
     elif data_sources >= 2:
@@ -368,6 +522,7 @@ def calculate_radar_scores(
         required=required,
         sources=sources,
         confidence=confidence,
+        human_sources=human_sources,
     )
 
 
@@ -480,6 +635,7 @@ def calculate_overall_match(
     code_quality_score: int,
     experience_fit_score: int,
     jd_match_score: float,
+    output_language: str = "ko",
 ) -> ScoringResult:
     """전체 매칭 점수 계산 (가중 평균)
 
@@ -488,6 +644,7 @@ def calculate_overall_match(
         code_quality_score: 코드 품질 점수 (0-100)
         experience_fit_score: 경험 적합도 점수 (0-100)
         jd_match_score: JD 매칭 점수 (0.0-1.0)
+        output_language: 출력 언어 (ko/en)
 
     Returns:
         ScoringResult
@@ -495,6 +652,8 @@ def calculate_overall_match(
     Reference: Weighted scoring model (daily.dev, Scale.jobs)
                Score = Σ(wi × si) / Σ(wi) where Σ(wi) = 1.0
     """
+    from app.services.i18n_labels import _t
+
     jd_normalized = int(jd_match_score * 100)
 
     composite = (
@@ -518,6 +677,11 @@ def calculate_overall_match(
             "experience_fit": experience_fit_score,
             "jd_match": jd_normalized,
         },
+        human_source=_t(
+            "score_overall_match", output_language,
+            total=final, skill=skill_match_score, code=code_quality_score,
+            exp=experience_fit_score, jd=jd_normalized,
+        ),
     )
 
 

--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -53,7 +53,10 @@ async def _llm_calculate_radar_scores(
         from app.services.scoring_formulas import (
             calculate_radar_scores as _formula_radar,
         )
-        formula_radar = _formula_radar(jd_analysis, code_analysis or {}, document_analysis)
+        formula_radar = _formula_radar(
+            jd_analysis, code_analysis or {}, document_analysis,
+            output_language=output_language,
+        )
         formula_base = {
             "role_fit": formula_radar.candidate[0],
             "technical": formula_radar.candidate[1],
@@ -255,7 +258,9 @@ def _calculate_radar_scores(
     code_analysis: dict | None,
     document_analysis: dict,
     experience_level: str = "미들",
-) -> tuple[list[int], list[int], list[str], str]:
+    linkedin_profile: dict | None = None,
+    output_language: str = "ko",
+) -> tuple[list[int], list[int], list[str], str, list[str]]:
     """5축 레이더 점수 계산 (Evidence-Based Scoring)
 
     축: [role_fit, technical, execution, communication, code_quality]
@@ -267,12 +272,15 @@ def _calculate_radar_scores(
     - Bird et al. (2011): Code ownership & stability
 
     Returns:
-        (candidate_scores, required_scores, sources, confidence)
+        (candidate_scores, required_scores, sources, confidence, human_sources)
     """
     from app.services.scoring_formulas import calculate_radar_scores as _formula_radar
 
-    radar = _formula_radar(jd_analysis, code_analysis, document_analysis, experience_level)
-    return radar.candidate, radar.required, radar.sources, radar.confidence
+    radar = _formula_radar(
+        jd_analysis, code_analysis, document_analysis, experience_level,
+        linkedin_profile=linkedin_profile, output_language=output_language,
+    )
+    return radar.candidate, radar.required, radar.sources, radar.confidence, radar.human_sources
 
 
 def _analyze_engineering_dna(code_analysis: dict | None, lang: str = "ko") -> list[EngineeringDNAItem]:
@@ -393,6 +401,12 @@ async def _llm_build_skill_table(
         if not jd_requirements:
             return None
 
+        # 필수 스킬 우선 정렬 + 최대 15개 (Issue #245)
+        sorted_requirements = sorted(
+            jd_requirements,
+            key=lambda r: 0 if r.get("category") in ("필수", "required", "must") else 1,
+        )
+
         raw_candidate_skills = document_analysis.get("profile", {}).get("skills", [])
         candidate_skills = (
             list(raw_candidate_skills.keys()) if isinstance(raw_candidate_skills, dict)
@@ -401,7 +415,7 @@ async def _llm_build_skill_table(
         code_skills = code_analysis.get("tech_stack", []) if code_analysis else []
 
         jd_text = json.dumps(
-            [r.get("skill", r.get("text", "")) for r in jd_requirements[:6]],
+            [{"skill": r.get("skill", r.get("text", "")), "category": r.get("category", "우대")} for r in sorted_requirements[:15]],
             ensure_ascii=False,
         )
         candidate_text = json.dumps(candidate_skills[:15], ensure_ascii=False) if candidate_skills else "[]"
@@ -435,7 +449,7 @@ async def _llm_build_skill_table(
         }
         corrected_count = 0
         rows = []
-        for item in result[:6]:
+        for item in result[:15]:
             if not isinstance(item, dict):
                 continue
             match_type = item.get("type", "none")
@@ -494,7 +508,12 @@ def _build_skill_table(
 
     all_candidate_skills = set(s.lower() for s in candidate_skills + code_skills)
 
-    for req in jd_requirements[:6]:  # 상위 6개
+    # 필수 스킬 우선 정렬 + 최대 15개 (Issue #245)
+    sorted_reqs = sorted(
+        jd_requirements,
+        key=lambda r: 0 if r.get("category") in ("필수", "required", "must") else 1,
+    )
+    for req in sorted_reqs[:15]:
         skill = req.get("skill", req.get("text", ""))
         skill_lower = skill.lower()
 
@@ -603,17 +622,31 @@ async def generate_deep_analysis(
     llm_radar = await _llm_calculate_radar_scores(jd_analysis, code_analysis, document_analysis, output_language, job_id=job_id)
     if llm_radar:
         radar_candidate, radar_required, axis_sources, llm_reasoning = llm_radar
-        # 축별 공식 근거 + LLM 추론 결합
-        for i, src in enumerate(axis_sources):
-            axis_name = ["role_fit", "technical", "execution", "communication", "code_quality"][i] if i < 5 else f"axis_{i}"
-            llm_note = llm_reasoning.get(axis_name, "")
-            combined = f"{src} | LLM: {llm_note}" if llm_note else f"{src} | LLM-bounded"
-            score_sources.append(combined)
+        # human_sources 가져오기 (formula_radar에서)
+        from app.services.scoring_formulas import calculate_radar_scores as _formula_radar_fn
+        _hr = _formula_radar_fn(
+            jd_analysis, code_analysis or {}, document_analysis,
+            experience_level, linkedin_profile=linkedin_profile,
+            output_language=output_language,
+        )
+        # 비개발자 친화 human_sources 우선 사용 (Issue #245)
+        if _hr.human_sources:
+            score_sources.extend(_hr.human_sources)
+        else:
+            for i, src in enumerate(axis_sources):
+                axis_name = ["role_fit", "technical", "execution", "communication", "code_quality"][i] if i < 5 else f"axis_{i}"
+                llm_note = llm_reasoning.get(axis_name, "")
+                combined = f"{src} | LLM: {llm_note}" if llm_note else f"{src} | LLM-bounded"
+                score_sources.append(combined)
     else:
-        radar_candidate, radar_required, axis_sources, confidence = _calculate_radar_scores(
+        radar_candidate, radar_required, axis_sources, confidence, human_sources = _calculate_radar_scores(
             jd_analysis, code_analysis, document_analysis, experience_level
         )
-        score_sources.extend(axis_sources)
+        # human_sources 우선 사용 (Issue #245)
+        if human_sources:
+            score_sources.extend(human_sources)
+        else:
+            score_sources.extend(axis_sources)
     activity.heartbeat()
 
     # 2. Engineering DNA 분석 (LLM 우선, 규칙 기반 fallback)
@@ -644,10 +677,24 @@ async def generate_deep_analysis(
         extract_code_stats,
     )
 
-    # 스킬 매칭 평균
+    # 스킬 매칭 평균 — JD 카테고리 가중 (Issue #245)
+    # 필수 스킬의 exact match가 우대 스킬의 partial match보다 높은 가중치
     skill_match_avg = 0
     if skill_table:
-        skill_match_avg = sum(row.confidence for row in skill_table) // len(skill_table)
+        jd_req_map = {}
+        for req in jd_analysis.get("requirements", []):
+            s = req.get("skill", "").lower()
+            if s:
+                jd_req_map[s] = req.get("category", "우대")
+
+        total_w = 0.0
+        weighted_sum = 0.0
+        for row in skill_table:
+            cat = jd_req_map.get(row.skill.lower(), "우대")
+            w = 1.0 if cat in ("필수", "required", "must") else 0.5
+            weighted_sum += row.confidence * w
+            total_w += w
+        skill_match_avg = int(weighted_sum / max(total_w, 0.001))
 
     # 코드 품질 점수 (repositories에서 stats 집계)
     quality_metrics, code_stats = extract_code_stats(code_analysis)
@@ -661,9 +708,13 @@ async def generate_deep_analysis(
     # JD 매칭 점수
     jd_match = document_analysis.get("jd_match_score", 0.5)
 
-    overall_result = calculate_overall_match(skill_match_avg, cq.score, exp_score, jd_match)
+    overall_result = calculate_overall_match(
+        skill_match_avg, cq.score, exp_score, jd_match,
+        output_language=output_language,
+    )
     overall_match = overall_result.score
-    score_sources.append(f"overall_match: {overall_result.source}")
+    # human_source 우선 사용 (Issue #245)
+    score_sources.append(overall_result.human_source or f"overall_match: {overall_result.source}")
 
     # 6. 데이터 신뢰도 계산
     has_linkedin = linkedin_profile is not None and bool(linkedin_profile)

--- a/backend/app/workflows/activities/intel_generation.py
+++ b/backend/app/workflows/activities/intel_generation.py
@@ -54,7 +54,12 @@ async def _llm_match_competencies(
             try:
                 from app.services.vector_store import get_vector_store
                 vs = get_vector_store(job_id)
-                for req in jd_requirements[:6]:
+                # 필수 스킬 우선 정렬 (Issue #245)
+                sorted_reqs = sorted(
+                    jd_requirements,
+                    key=lambda r: 0 if r.get("category") in ("필수", "required", "must") else 1,
+                )
+                for req in sorted_reqs[:15]:
                     skill = req.get("skill", "") if isinstance(req, dict) else str(req)
                     if skill:
                         matches = await vs.search_profile(skill, limit=2)
@@ -70,7 +75,7 @@ async def _llm_match_competencies(
 
         prompt_config = get_prompt_with_config(
             "v2_generation.yaml", "competency_matching",
-            jd_requirements=json.dumps(jd_requirements[:6], ensure_ascii=False, default=str),
+            jd_requirements=json.dumps(sorted_reqs[:15], ensure_ascii=False, default=str),
             candidate_skills=json.dumps(candidate_skills[:20], ensure_ascii=False, default=str),
             code_skills=json.dumps(code_skills[:20], ensure_ascii=False, default=str),
             output_language=output_language,
@@ -97,7 +102,7 @@ async def _llm_match_competencies(
         VALID_SOURCES = {"resume", "github", "resume+github", "vector_store", "none", "llm"}
 
         competencies = []
-        for item in result[:6]:
+        for item in result[:15]:
             if not isinstance(item, dict):
                 continue
             match_level = item.get("match", "none")
@@ -188,8 +193,13 @@ def _extract_jd_summary(jd_analysis: dict, lang: str = "ko") -> JDSummary:
     """JD 분석에서 요약 정보 추출"""
     from app.services.i18n_labels import _t
     requirements = jd_analysis.get("requirements") or []
+    # 필수 스킬 우선 정렬 (Issue #245)
+    sorted_requirements = sorted(
+        requirements,
+        key=lambda r: 0 if r.get("category") in ("필수", "required", "must") else 1,
+    )
     req_matches = []
-    for req in requirements[:5]:  # 상위 5개 요구사항
+    for req in sorted_requirements[:10]:
         req_matches.append(RequirementMatch(
             text=req.get("skill", req.get("text", "")),
             desc=req.get("description", req.get("desc", "")),
@@ -229,7 +239,12 @@ def _match_competencies(
         "none": ("red", "❌"),
     }
 
-    for req in jd_requirements[:6]:  # 상위 6개 역량
+    # 필수 스킬 우선 정렬 + 최대 15개 (Issue #245)
+    sorted_reqs = sorted(
+        jd_requirements,
+        key=lambda r: 0 if r.get("category") in ("필수", "required", "must") else 1,
+    )
+    for req in sorted_reqs[:15]:
         skill = req.get("skill", req.get("text", ""))
         desc = req.get("description", req.get("desc", ""))
         why = req.get("importance", req.get("why", ""))


### PR DESCRIPTION
## Summary
- **점수 근거 비개발자 친화**: `human_source` 필드 + i18n 키 6개 추가 → `_t("score_role_fit", lang, ...)` 형태로 "직무 적합도 72점: JD 요구사항 매칭 65% + 핵심 스킬 일치율 81%" 같은 자연어 근거 제공
- **JD 카테고리 가중 스킬 매칭**: `_weighted_skill_overlap()` — 필수 1.0, 우대 0.5, 사소한 스킬(Git, CSV 등) 0.1 가중치 + `_fuzzy_skill_match()` 퍼지 매칭
- **스킬 정렬 확대**: 4개 파일에서 `[:6]` → 필수 스킬 우선 정렬 + 최대 15개

### 핵심 변경 효과
| 시나리오 | 기존 | 변경 후 |
|---------|------|---------|
| Git만 매칭 | ~100% (동등 가중) | ~5% (사소한 스킬) |
| React(필수) 퍼지 매칭 | 0 (불일치) | 80% (React.js→React) |
| tech_breadth (JD 무관 기술) | 96점 (8개×12) | 0점 (JD 매칭 0) |
| 점수 근거 | `jd_match(0.50)×70%` 공식 | "직무 적합도 72점: ..." 자연어 |

## 수정 파일 (4개)
- `backend/app/services/i18n_labels.py` — 점수 근거 번역 키 6개
- `backend/app/services/scoring_formulas.py` — 핵심 공식 변경
- `backend/app/workflows/activities/analysis_generation.py` — 스킬 테이블 + score_sources
- `backend/app/workflows/activities/intel_generation.py` — 역량 매칭 정렬

## Test plan
- [x] `_fuzzy_skill_match` 단위 테스트 (정확/퍼지/Java→JavaScript 방지)
- [x] `_weighted_skill_overlap` 가중 매칭 테스트 (Git-only → ~5%)
- [x] `calculate_radar_scores` human_sources 5축 검증
- [x] `calculate_overall_match` human_source 검증
- [x] Git-only inflation 방지 (role_fit < 30)
- [x] 기존 pytest 통과 (164 passed, 기존 async 실패만 제외)
- [x] 워커 재시작 완료

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)