### PR TITLE
refactor: Engineering DNA 섹션 제거 (DeepAnalysisTab)

### DIFF
--- a/frontend/src/components/tabs/DeepAnalysisTab.tsx
+++ b/frontend/src/components/tabs/DeepAnalysisTab.tsx
@@ -1,10 +1,10 @@
 /**
- * DeepAnalysisTab - Radar Chart + Engineering DNA + Skill Matching Table
+ * DeepAnalysisTab - Radar Chart + Skill Matching Table
  */
 import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DeepAnalysis } from '../../types/interview'
-import { RadarChart, ProgressBarGroup } from '../charts'
+import { RadarChart } from '../charts'
 
 interface DeepAnalysisTabProps {
   analysis: DeepAnalysis
@@ -12,7 +12,7 @@ interface DeepAnalysisTabProps {
 
 export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepAnalysisTabProps) {
   const { t } = useTranslation()
-  const { radar_candidate, radar_required, engineering_dna, risk_flags, skill_table, overall_match, score_sources, data_confidence, data_confidence_score } = analysis
+  const { radar_candidate, radar_required, risk_flags, skill_table, overall_match, score_sources, data_confidence, data_confidence_score } = analysis
   const [showSources, setShowSources] = useState(false)
   const [showMatchBreakdown, setShowMatchBreakdown] = useState(false)
   const [showConfidenceDetail, setShowConfidenceDetail] = useState(false)
@@ -202,21 +202,6 @@ export const DeepAnalysisTab = memo(function DeepAnalysisTab({ analysis }: DeepA
             </div>
           )}
         </div>
-      )}
-
-      {/* Engineering DNA */}
-      {engineering_dna && engineering_dna.length > 0 && (
-        <ProgressBarGroup
-          title={t('engineering_dna')}
-          items={engineering_dna.map(item => ({
-            label: item.label,
-            value: item.value,
-            display: item.display,
-            color: item.color,
-            note: item.note,
-            tooltip: item.tooltip
-          }))}
-        />
       )}
 
       {/* Risk Flags */}

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -327,7 +327,6 @@ const resources = {
       live_followup_poor: '주의 답변',
       live_followup_pts: '점',
       // DeepAnalysisTab
-      engineering_dna: 'Engineering DNA',
       data_confidence_label: '데이터 신뢰도',
       data_confidence_high: '높음',
       data_confidence_medium: '보통',
@@ -831,7 +830,6 @@ const resources = {
       live_followup_poor: 'Poor',
       live_followup_pts: 'pts',
       // DeepAnalysisTab
-      engineering_dna: 'Engineering DNA',
       data_confidence_label: 'Data Confidence',
       data_confidence_high: 'High',
       data_confidence_medium: 'Medium',


### PR DESCRIPTION
## Summary
- DeepAnalysisTab에서 Engineering DNA ProgressBarGroup 블록 제거
- 레이더 차트 "코드 품질" 축과 실질적 중복 + 비개발자에게 혼란 유발하는 메트릭 제거
- i18n `engineering_dna` 키 제거 (ko/en)
- `EngineeringDNAItem` 타입은 백엔드 호환을 위해 유지

Closes #12

## Test plan
- [ ] Deep Analysis 탭: Engineering DNA 프로그레스바 없음
- [ ] 레이더 차트 + 스킬매칭 테이블만 정상 표시
- [ ] `npx tsc --noEmit` 통과 ✅
- [ ] `npm run build` 통과 ✅ (ResultPage 103KB → 101KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)