### PR TITLE
refactor: 면접관 가이드 근거 없는 섹션 제거 [JIT-14]

### DIFF
--- a/frontend/src/components/tabs/DecisionTab.tsx
+++ b/frontend/src/components/tabs/DecisionTab.tsx
@@ -166,28 +166,6 @@ export const DecisionTab = memo(function DecisionTab({
 
         {guideExpanded && (
         <div className="px-6 pb-6 space-y-6 animate-fadeIn">
-        {/* Interview Flow */}
-        {interviewer_guide.interview_flow && (
-          <div className="mb-6 p-4 bg-indigo-50 rounded-lg border border-indigo-200">
-            <h4 className="text-sm font-semibold text-indigo-900 mb-2">{t('decision_interview_flow')}</h4>
-            <p className="text-sm text-indigo-800">{interviewer_guide.interview_flow}</p>
-          </div>
-        )}
-
-        {/* Time Allocation */}
-        {interviewer_guide.time_allocation && Object.keys(interviewer_guide.time_allocation).length > 0 && (
-          <div className="mb-6">
-            <h4 className="text-sm font-semibold text-gray-700 mb-2">{t('decision_time_allocation')}</h4>
-            <div className="flex flex-wrap gap-2">
-              {Object.entries(interviewer_guide.time_allocation).map(([phase, time]) => (
-                <span key={phase} className="px-3 py-1 bg-gray-100 rounded-full text-sm">
-                  {phase}: {time}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
         {/* Resume Tips */}
         {interviewer_guide.resume_based_tips && interviewer_guide.resume_based_tips.length > 0 && (
           <div className="mb-6">
@@ -224,36 +202,20 @@ export const DecisionTab = memo(function DecisionTab({
           </div>
         )}
 
-        {/* Red/Green Flags */}
-        <div className="grid sm:grid-cols-2 gap-4">
-          {interviewer_guide.positive_signals && interviewer_guide.positive_signals.length > 0 && (
-            <div className="p-4 bg-green-50 rounded-lg border border-green-200">
-              <h4 className="text-sm font-semibold text-green-900 mb-2">✅ {t('decision_positive_signals')}</h4>
-              <ul className="space-y-1">
-                {interviewer_guide.positive_signals.map((signal, i) => (
-                  <li key={i} className="text-sm text-green-800 flex items-start gap-2">
-                    <span className="text-green-500">•</span>
-                    {signal}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {interviewer_guide.red_flags_to_watch && interviewer_guide.red_flags_to_watch.length > 0 && (
-            <div className="p-4 bg-red-50 rounded-lg border border-red-200">
-              <h4 className="text-sm font-semibold text-red-900 mb-2">🚩 {t('decision_red_flags')}</h4>
-              <ul className="space-y-1">
-                {interviewer_guide.red_flags_to_watch.map((flag, i) => (
-                  <li key={i} className="text-sm text-red-800 flex items-start gap-2">
-                    <span className="text-red-500">•</span>
-                    {flag}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
+        {/* Red Flags */}
+        {interviewer_guide.red_flags_to_watch && interviewer_guide.red_flags_to_watch.length > 0 && (
+          <div className="p-4 bg-red-50 rounded-lg border border-red-200">
+            <h4 className="text-sm font-semibold text-red-900 mb-2">🚩 {t('decision_red_flags')}</h4>
+            <ul className="space-y-1">
+              {interviewer_guide.red_flags_to_watch.map((flag, i) => (
+                <li key={i} className="text-sm text-red-800 flex items-start gap-2">
+                  <span className="text-red-500">•</span>
+                  {flag}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         </div>
         )}
       </div>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -178,11 +178,8 @@ const resources = {
       decision_concerns: '우려 사항',
 
       decision_interviewer_guide: '면접관 가이드',
-      decision_interview_flow: '면접 진행',
-      decision_time_allocation: '시간 배분',
       decision_resume_tips: '이력서 기반 팁',
       decision_cover_letter_insights: '자기소개서 인사이트',
-      decision_positive_signals: '긍정 신호',
       decision_red_flags: '주의 사항',
       // Result tabs - Live Interview
       live_other: '기타',
@@ -680,11 +677,8 @@ const resources = {
       decision_concerns: 'Concerns',
 
       decision_interviewer_guide: 'Interviewer Guide',
-      decision_interview_flow: 'Interview Flow',
-      decision_time_allocation: 'Time Allocation',
       decision_resume_tips: 'Resume-Based Tips',
       decision_cover_letter_insights: 'Cover Letter Insights',
-      decision_positive_signals: 'Positive Signals',
       decision_red_flags: 'Red Flags',
       // Result tabs - Live Interview
       live_other: 'Other',


### PR DESCRIPTION
## Summary
- DecisionTab 면접관 가이드에서 후보자 데이터와 무관한 고정 템플릿 섹션 3개 제거
  - `interview_flow`: 고정 순서 템플릿 (수치 근거 없음)
  - `time_allocation`: 공식 기반이지만 혼란 유발
  - `positive_signals`: 고정 텍스트 (후보자 무관)
- `red_flags_to_watch`는 단독 full-width로 표시
- i18n에서 3개 키 제거 (ko/en)

## Test plan
- [x] `tsc --noEmit` 타입 체크 통과
- [ ] Decision 탭 면접관 가이드에서 interview_flow, time_allocation, positive_signals 없음 확인
- [ ] resume_based_tips, cover_letter_insights, red_flags_to_watch 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)