### PR TITLE
refactor: LLM 프롬프트 최적화 — competency_matching, engineering_dna 제거

### DIFF
--- a/backend/app/models/decision.py
+++ b/backend/app/models/decision.py
@@ -34,13 +34,10 @@ class CoverLetterInsight(BaseModel):
 
 
 class InterviewerGuideTips(BaseModel):
-    """면접관 가이드 팁"""
-    interview_flow: str
-    time_allocation: dict[str, str] = Field(default_factory=dict)
+    """면접관 가이드 팁 (JIT-14/16: interview_flow, time_allocation, positive_signals 제거)"""
     resume_based_tips: list[ResumeTip] = Field(default_factory=list)
     cover_letter_insights: list[CoverLetterInsight] = Field(default_factory=list)
     red_flags_to_watch: list[str] = Field(default_factory=list)
-    positive_signals: list[str] = Field(default_factory=list)
 
 
 class JDCompetencyWeight(BaseModel):

--- a/backend/app/prompts/__init__.py
+++ b/backend/app/prompts/__init__.py
@@ -328,9 +328,7 @@ def _prompt_key_to_activity_name(filename: str, key: str) -> str:
         ("finalization.yaml", "generate_intel_brief"): "generate_intel_brief",
         ("finalization.yaml", "generate_deep_analysis"): "generate_deep_analysis",
         ("finalization.yaml", "generate_decision_support"): "generate_decision_support",
-        ("v2_generation.yaml", "competency_matching"): "intel_competency_matching",
         ("v2_generation.yaml", "radar_analysis"): "radar_analysis",
-        ("v2_generation.yaml", "engineering_dna"): "engineering_dna",
         ("v2_generation.yaml", "decision_summary"): "decision_summary",
         ("v2_generation.yaml", "interviewer_tips"): "interviewer_tips",
     }

--- a/backend/app/prompts/v2_generation.yaml
+++ b/backend/app/prompts/v2_generation.yaml
@@ -1,74 +1,4 @@
 prompts:
-  competency_matching:
-    description: "JD 역량과 후보자 시맨틱 매칭 분석 (근거 기반)"
-    template: |
-      # CRITICAL OUTPUT RULES
-      - Return ONLY raw JSON, NO markdown formatting
-      - Start your response with [ and end with ]
-
-      # ROLE
-      You are an expert technical recruiter analyzing candidate-job fit with evidence-based assessment.
-
-      # TASK
-      Compare each JD requirement against the candidate's skills from resume and code analysis.
-      Determine match level using semantic understanding, not just keyword matching.
-      EVERY match_label MUST cite the specific evidence source (Resume skill list, GitHub tech stack, etc.).
-
-      # OUTPUT LANGUAGE (CRITICAL)
-      Write ALL output text in {{output_language}}.
-      The fields "name", "match_label", "desc", and "why" MUST be written in {{output_language}}.
-      JSON keys must remain in English. The "match" field must be one of: strong|partial|unknown|none.
-      Even if the input data is in another language, ALL output values MUST be in {{output_language}}.
-
-      # MATCH LEVELS AND EVIDENCE REQUIREMENTS
-      - "strong": Candidate has direct, proven experience — MUST cite specific skill from Resume OR GitHub
-        Example match_label: "Resume에서 Python 3년 확인 + GitHub에서 FastAPI 프로젝트 탐지"
-      - "partial": Candidate has related but not exact experience — cite the related skill
-        Example match_label: "Resume에서 Django 경험 확인 (Flask 요구사항과 유사 프레임워크)"
-      - "unknown": Cannot determine from available data — explain what data is missing
-        Example match_label: "이력서/GitHub에서 관련 경험 확인 불가"
-      - "none": No evidence of this skill — state clearly
-        Example match_label: "제공된 데이터에서 해당 스킬 근거 없음"
-
-      # ANTI-HALLUCINATION RULES
-      - NEVER claim the candidate has a skill that is not in the provided input data
-      - If a skill is not listed in Resume skills OR GitHub code_skills, it is "unknown" or "none"
-      - Do NOT infer skills from job titles alone — only use the explicit skill lists provided
-
-      # INPUT
-      JD Requirements:
-      {{jd_requirements}}
-
-      Candidate Skills (Resume):
-      {{candidate_skills}}
-
-      Candidate Skills (GitHub):
-      {{code_skills}}
-
-      # ADDITIONAL CONTEXT (may be empty)
-      {{kg_context}}
-
-      # FORBIDDEN PATTERNS (will cause rejection)
-      - NEVER write vague match_labels like "관련 경험 있음", "적합해 보임", "가능성 높음", "충분한 역량", "다양한 경험"
-      - EVERY match_label MUST name the specific skill/technology found in the data
-      - match_label for "strong"/"partial" MUST be ≥15 characters with concrete skill name
-      - If evidence_source is "none", match MUST be "unknown" or "none" (never "strong" or "partial")
-      - "why" field MUST explain the business impact in ≥10 characters — NEVER leave empty or generic
-      - "why" REJECTED examples: "중요함", "필요함", "essential" ← too vague
-      - "why" ACCEPTED example: "실시간 데이터 처리가 핵심이므로 Kafka 경험이 서비스 안정성에 직결" ← specific
-
-      # OUTPUT FORMAT (JSON array)
-      [
-        {{
-          "name": "requirement name in {{output_language}}",
-          "match": "strong|partial|unknown|none",
-          "match_label": "evidence-cited explanation in {{output_language}} — MUST name specific skill from Resume/GitHub",
-          "desc": "requirement description in {{output_language}}",
-          "why": "why this matters for the role in {{output_language}}",
-          "evidence_source": "resume|github|resume+github|vector_store|none — MUST be exactly one of these values"
-        }}
-      ]
-
   radar_analysis:
     description: "5축 레이더 차트 점수 산출 (LLM 기반, 공식 기준 참조)"
     template: |
@@ -223,77 +153,6 @@ prompts:
         }}
       ]
 
-  engineering_dna:
-    description: "Engineering DNA 심층 분석 (메트릭 기반)"
-    template: |
-      # CRITICAL OUTPUT RULES
-      - Return ONLY raw JSON array, NO markdown formatting
-      - Start your response with [ and end with ]
-
-      # ROLE
-      You are a senior engineering manager assessing a candidate's engineering practices based on code metrics.
-
-      # TASK
-      Analyze the candidate's code metrics to assess their engineering DNA.
-      Scores MUST be derived from the actual metrics in the input data, not general impressions.
-      If a metric is not available, set value to 0 and note "Data not available".
-
-      # OUTPUT LANGUAGE (CRITICAL)
-      Write ALL output text in {{output_language}}.
-      The fields "label", "display", "note", and "tooltip" MUST be written in {{output_language}}.
-      JSON keys must remain in English.
-      Even if the input data is in another language, ALL output values MUST be in {{output_language}}.
-
-      # INPUT
-      Code Analysis Data:
-      {{code_analysis}}
-
-      # ADDITIONAL CONTEXT (may be empty)
-      {{kg_context}}
-
-      # DIMENSIONS AND SCORING CRITERIA
-      1. Test Coverage — Use test_coverage metric directly
-         - ≥70: emerald, "Excellent" | 40-69: amber, "Moderate" | <40: red, "Poor"
-      2. Documentation Quality — Use documentation_score metric
-         - ≥80: blue, "Excellent" | 50-79: amber, "Moderate" | <50: red, "Poor"
-      3. IaC Usage — Check for infrastructure patterns (Dockerfile, CI/CD, Terraform)
-         - ≥50: emerald, "Confirmed" | <50: red, "Not detected"
-      4. Code Complexity — Use complexity_score (lower is better for readability)
-         - ≤30: emerald, "Low" | 31-70: amber, "Moderate" | >70: red, "High"
-      5. Design Patterns — Assess from code structure if detectable
-         - Only score if patterns are detectable in the data, otherwise value=0 color="slate"
-
-      # COLOR RULES
-      - emerald: Good/positive metric
-      - blue: Informational/good documentation
-      - amber: Moderate/needs improvement
-      - red: Poor/concerning
-      - slate: Data unavailable or not applicable
-
-      # tooltip FIELD
-      The "tooltip" field is for non-technical users. Explain what this metric means in simple terms.
-      Example: "Test coverage measures how much of the code is verified by automated tests — higher is better"
-
-      # FORBIDDEN PATTERNS (will cause rejection)
-      - note without specific metric: "좋은 품질" ← REJECTED (no metric citation)
-      - note without source: "테스트가 잘 작성됨" ← REJECTED (no parenthesized source)
-      - EVERY note MUST cite the actual metric value + (GitHub): "test_coverage: 72% (GitHub)" ← ACCEPTED
-      - If metric is unavailable, note MUST say: "Data not available" ← ACCEPTED
-      - tooltip that repeats label: "테스트 커버리지는 테스트 커버리지입니다" ← REJECTED
-      - EVERY tooltip MUST explain the metric in non-technical terms for HR managers
-
-      # OUTPUT FORMAT (JSON array)
-      [
-        {{
-          "label": "dimension label in {{output_language}}",
-          "value": 0-100,
-          "display": "quality rating in {{output_language}} following the criteria above",
-          "color": "emerald|blue|amber|red|slate",
-          "note": "specific metric citation in {{output_language}} (e.g., 'test_coverage: 72%') or null",
-          "tooltip": "non-tech explanation in {{output_language}} or null"
-        }}
-      ]
-
   decision_summary:
     description: "후보자 Decision Summary 생성 (근거 기반 레벨/강점/우려사항)"
     template: |
@@ -399,19 +258,16 @@ prompts:
 
       # OUTPUT LANGUAGE (CRITICAL)
       Write ALL output text in {{output_language}}.
-      ALL fields (interview_flow, time_allocation, resume_based_tips, cover_letter_insights, red_flags_to_watch, positive_signals) MUST be in {{output_language}}.
+      ALL fields (resume_based_tips, cover_letter_insights, red_flags_to_watch) MUST be in {{output_language}}.
       JSON keys must remain in English.
       Even if the input data is in another language, ALL output values MUST be in {{output_language}}.
 
       # TASK
       Based on the candidate's profile and generated questions, create:
-      1. Recommended interview flow (category order with time allocation)
-      2. Resume-based verification tips (specific claims to verify)
-      3. Cover letter insights (claims to validate)
-      4. Red flags to watch for during interview — each MUST include the data source in parentheses
+      1. Resume-based verification tips (specific claims to verify)
+      2. Cover letter insights (claims to validate)
+      3. Red flags to watch for during interview — each MUST include the data source in parentheses
          Example: "GitHub 활동이 최근 6개월간 없음 (GitHub)" or "이력서 경력 갭 2023-2024 (Resume)"
-      5. Positive signals indicating strong fit — each MUST include the data source in parentheses
-         Example: "12개 레포에서 일관된 코드 품질 (GitHub)" or "Google 3년 재직 (Resume)"
 
       # INPUT
       Questions:
@@ -431,20 +287,15 @@ prompts:
 
       # FORBIDDEN PATTERNS (will cause rejection)
       - Red flags WITHOUT data source: "기술 부족 우려" ← REJECTED (no parenthesized source)
-      - Positive signals WITHOUT data source: "훌륭한 경력" ← REJECTED (no evidence)
       - EVERY red flag MUST end with (Resume), (GitHub), or (LinkedIn): "경력 갭 2023-2024 (Resume)" ← ACCEPTED
-      - EVERY positive signal MUST end with source: "12개 레포에서 일관된 코드 품질 (GitHub)" ← ACCEPTED
 
       # OUTPUT FORMAT
       {{
-        "interview_flow": "category1(time) → category2(time) → ... (in {{output_language}})",
-        "time_allocation": {{"category": "time in {{output_language}} (e.g., '10 min')"}},
         "resume_based_tips": [
           {{"section": "area to verify in {{output_language}}", "insight": "specific verification method in {{output_language}}", "question_link": "related question ref (e.g., Q1, Q3) or null"}}
         ],
         "cover_letter_insights": [
           {{"highlight": "key claim in {{output_language}}", "interpretation": "verification question in {{output_language}}", "follow_up_opportunity": "follow-up opportunity in {{output_language}} or null"}}
         ],
-        "red_flags_to_watch": ["concern1 in {{output_language}}", "concern2"],
-        "positive_signals": ["positive signal1 in {{output_language}}", "positive signal2"]
+        "red_flags_to_watch": ["concern1 in {{output_language}}", "concern2"]
       }}

--- a/backend/app/services/llm_config.py
+++ b/backend/app/services/llm_config.py
@@ -97,9 +97,7 @@ ACTIVITY_MODEL_CONFIG: dict[str, str] = {
     "generate_decision_support": KIMI_CHAT_MODEL,      # v2 Decision Support 생성
 
     # Phase 4: v2 Generation (Intel/Analysis/Decision) - Kimi K2
-    "intel_competency_matching": KIMI_CHAT_MODEL,
     "radar_analysis": KIMI_CHAT_MODEL,
-    "engineering_dna": KIMI_CHAT_MODEL,
     "skill_matching": KIMI_CHAT_MODEL,
     "decision_summary": KIMI_CHAT_MODEL,
     "interviewer_tips": KIMI_CHAT_MODEL,

--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -668,10 +668,8 @@ async def generate_deep_analysis(
             score_sources.extend(axis_sources)
     activity.heartbeat()
 
-    # 2. Engineering DNA 분석 (LLM 우선, 규칙 기반 fallback)
-    engineering_dna = await _llm_analyze_engineering_dna(code_analysis, output_language, job_id=job_id)
-    if engineering_dna is None:
-        engineering_dna = _analyze_engineering_dna(code_analysis, lang=output_language)
+    # 2. Engineering DNA — JIT-16: 프론트엔드에서 제거됨, 빈 리스트 반환
+    engineering_dna: list = []
     activity.heartbeat()
 
     # 3. 리스크 플래그 추출

--- a/backend/app/workflows/activities/decision_generation.py
+++ b/backend/app/workflows/activities/decision_generation.py
@@ -188,7 +188,7 @@ async def _llm_generate_interviewer_tips(
                     follow_up_opportunity=ins.get("follow_up_opportunity"),
                 ))
 
-        # red_flags/positive_signals 소스 태그 자동 보강
+        # red_flags 소스 태그 자동 보강
         SOURCE_TAGS = ("(Resume)", "(GitHub)", "(LinkedIn)", "(Resume + GitHub)", "(Multi-source)")
 
         def _enrich_source_tag(items: list) -> list:
@@ -206,14 +206,11 @@ async def _llm_generate_interviewer_tips(
             return enriched
 
         tips = InterviewerGuideTips(
-            interview_flow=result.get("interview_flow", ""),
-            time_allocation=result.get("time_allocation", {}),
             resume_based_tips=resume_tips,
             cover_letter_insights=cl_insights,
             red_flags_to_watch=_enrich_source_tag(result.get("red_flags_to_watch", [])),
-            positive_signals=_enrich_source_tag(result.get("positive_signals", [])),
         )
-        logger.info(f"LLM interviewer tips: {len(resume_tips)} tips, {len(tips.positive_signals)} signals")
+        logger.info(f"LLM interviewer tips: {len(resume_tips)} tips, {len(tips.red_flags_to_watch)} red flags")
         return tips
 
     except Exception as e:
@@ -342,25 +339,6 @@ def _build_interviewer_tips(
     """면접관 팁 구성"""
     from app.services.i18n_labels import _t
 
-    # 시간 배분 계산
-    category_counts = {}
-    for q in questions:
-        cat = q.get("category", _t("other", lang))
-        category_counts[cat] = category_counts.get(cat, 0) + 1
-
-    total_time = 60  # 기본 60분
-    time_allocation = {}
-    for cat, count in category_counts.items():
-        cat_time = int((count / len(questions)) * total_time) if questions else 10
-        time_allocation[cat] = _t("minutes_n", lang, n=cat_time)
-
-    # 면접 진행 순서
-    category_order = ["role_fit", "technical_depth", "execution_ownership", "communication", "risk_flags"]
-    existing_cats = [c for c in category_order if c in category_counts]
-    interview_flow = " → ".join(
-        f"{cat}({time_allocation.get(cat, _t('minutes_n', lang, n=10))})" for cat in existing_cats
-    )
-
     # 이력서 기반 팁
     resume_tips = []
     profile = document_analysis.get("profile", {})
@@ -411,20 +389,10 @@ def _build_interviewer_tips(
         if flag_text:
             red_flags.append(flag_text)
 
-    # Positive signals
-    positive_signals = [
-        _t("positive_quantified_achievements", lang),
-        _t("positive_failure_learning", lang),
-        _t("positive_team_collaboration", lang),
-    ]
-
     return InterviewerGuideTips(
-        interview_flow=interview_flow,
-        time_allocation=time_allocation,
         resume_based_tips=resume_tips[:5],
         cover_letter_insights=cover_letter_insights[:3],
         red_flags_to_watch=red_flags[:5],
-        positive_signals=positive_signals,
     )
 
 
@@ -588,7 +556,7 @@ async def generate_decision_support(
             f"but strengths({strengths_count}) >> concerns({concerns_count})"
         )
 
-    # Interviewer Guide: red_flags/positive_signals 소스 어노테이션 확인
+    # Interviewer Guide: red_flags 소스 어노테이션 확인
     if interviewer_guide.red_flags_to_watch:
         flags_with_source = sum(1 for f in interviewer_guide.red_flags_to_watch if "(Resume)" in f or "(GitHub)" in f or "(LinkedIn)" in f)
         if flags_with_source < len(interviewer_guide.red_flags_to_watch) // 2:

--- a/backend/app/workflows/activities/intel_generation.py
+++ b/backend/app/workflows/activities/intel_generation.py
@@ -390,13 +390,8 @@ async def generate_intel_brief(
     jd_summary = _extract_jd_summary(jd_analysis, lang=output_language)
     activity.heartbeat()
 
-    # 2. 역량 매칭 분석 (LLM 우선, 규칙 기반 fallback) — LinkedIn 스킬 포함
-    competencies = await _llm_match_competencies(
-        jd_analysis, document_analysis, code_analysis, output_language,
-        job_id=job_id, linkedin_profile=linkedin_profile,
-    )
-    if competencies is None:
-        competencies = _match_competencies(jd_analysis, document_analysis, code_analysis, lang=output_language)
+    # 2. 역량 매칭 분석 (규칙 기반 — JIT-16: LLM competency_matching 프롬프트 제거)
+    competencies = _match_competencies(jd_analysis, document_analysis, code_analysis, lang=output_language)
     activity.heartbeat()
 
     # 2b. candidate_profile 있으면 역량 매칭 보강 (정규화 스킬 + implied 관계)

--- a/backend/tests/test_workflow_v2.py
+++ b/backend/tests/test_workflow_v2.py
@@ -89,25 +89,20 @@ class TestV2ActivitySignatures:
 class TestV2LLMFallbackPattern:
     """v2 Activity들이 LLM + fallback 패턴을 따르는지 검증"""
 
-    def test_intel_generation_has_llm_and_fallback(self):
+    def test_intel_generation_has_rule_based_competency_matching(self):
         from app.workflows.activities import intel_generation
         source = inspect.getsource(intel_generation)
-        # LLM 함수 존재
-        assert "_llm_match_competencies" in source
-        # 규칙 기반 fallback 존재
+        # 규칙 기반 매칭 함수 존재 (JIT-16: LLM 제거, rules-only)
         assert "_match_competencies" in source
-        # fallback 패턴 (LLM 실패 시 규칙 기반)
-        assert "if competencies is None:" in source
 
     def test_analysis_generation_has_llm_and_fallback(self):
         from app.workflows.activities import analysis_generation
         source = inspect.getsource(analysis_generation)
         # LLM 함수 존재
         assert "_llm_calculate_radar_scores" in source
-        assert "_llm_analyze_engineering_dna" in source
         # 규칙 기반 fallback 존재
         assert "_calculate_radar_scores" in source
-        assert "_analyze_engineering_dna" in source
+        # JIT-16: engineering_dna는 빈 리스트로 대체됨
 
     def test_decision_generation_has_llm_and_fallback(self):
         from app.workflows.activities import decision_generation
@@ -140,9 +135,7 @@ class TestV2PromptTemplates:
 
         prompts = data.get("prompts", {})
         expected_keys = [
-            "competency_matching",
             "radar_analysis",
-            "engineering_dna",
             "decision_summary",
             "interviewer_tips",
         ]

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -277,12 +277,9 @@ export interface DecisionSummary {
 
 /** Interviewer guide tips */
 export interface InterviewerGuideTips {
-  interview_flow: string
-  time_allocation: Record<string, string>
   resume_based_tips: ResumeTip[]
   cover_letter_insights: CoverLetterInsight[]
   red_flags_to_watch: string[]
-  positive_signals: string[]
 }
 
 /** JD competency weight */


### PR DESCRIPTION
## Summary
- competency_matching LLM 프롬프트 제거 → 규칙 기반 매칭만 사용 (intel_generation)
- engineering_dna LLM 프롬프트 제거 → 빈 리스트 (analysis_generation)
- interviewer_tips에서 interview_flow, time_allocation, positive_signals 필드 제거
- InterviewerGuideTips Pydantic 모델 + TypeScript 인터페이스 동기화
- YAML 프롬프트 211줄 삭감, ACTIVITY_MODEL_CONFIG/special_mappings 정리

## Test plan
- [x] backend pytest: v2 테스트 25개 전부 패스
- [x] frontend tsc --noEmit 통과
- [x] 기존 실패 4개는 JIT-16 무관 (Gemini OCR, LinkedIn, question_generation)

Closes JIT-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)