### PR TITLE
refactor: Activity 코드 정리 — 불필요 생성 함수 제거 + 레거시 필드 삭제

### DIFF
--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -10,7 +10,7 @@ from temporalio import activity
 
 from app.core.observability import observe_activity
 from app.models.deep_analysis import (
-    DeepAnalysis, EngineeringDNAItem, RiskFlag, SkillMatchRow,
+    DeepAnalysis, RiskFlag, SkillMatchRow,
 )
 
 logger = logging.getLogger(__name__)
@@ -156,114 +156,6 @@ async def _llm_calculate_radar_scores(
         return None
 
 
-async def _llm_analyze_engineering_dna(code_analysis: dict | None, output_language: str = "ko", job_id: str | None = None) -> list[EngineeringDNAItem] | None:
-    """LLM 기반 Engineering DNA 분석 (실패 시 None 반환)"""
-    if not code_analysis:
-        return None
-
-    try:
-        from app.services.cached_llm import CachedLLMService
-        from app.prompts import get_prompt_with_config
-        from app.workflows.utils import run_llm_with_prompt_config_heartbeat
-
-        # VectorStore 코드 패턴 검색
-        kg_context = ""
-        if job_id:
-            try:
-                from app.services.vector_store import get_vector_store
-                vs = get_vector_store(job_id)
-                for query in ["test coverage", "code quality", "architecture patterns"][:3]:
-                    results = await vs.search_code(query, limit=2)
-                    for r in results:
-                        if r["similarity"] >= 0.5:
-                            kg_context += f"- {query}: {r['content_text'][:100]} (sim={r['similarity']:.2f})\n"
-            except Exception as e:
-                logger.debug(f"Vector code enrichment failed for engineering DNA: {e}")
-
-        code_data = json.dumps({
-            "quality_metrics": code_analysis.get("quality_metrics", {}),
-            "tech_stack": code_analysis.get("tech_stack", [])[:10],
-            "patterns": code_analysis.get("patterns", [])[:5] if isinstance(code_analysis.get("patterns"), list) else [],
-            "risk_flags": code_analysis.get("risk_flags", [])[:5],
-        }, ensure_ascii=False, default=str)
-
-        prompt_config = get_prompt_with_config(
-            "v2_generation.yaml", "engineering_dna",
-            code_analysis=code_data,
-            output_language=output_language,
-            kg_context=kg_context,
-        )
-
-        llm = CachedLLMService()
-        result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
-
-        if not isinstance(result, list):
-            return None
-
-        from app.services.match_config import sanitize_color
-
-        # 실제 코드 메트릭으로 note 검증/보강
-        actual_metrics = code_analysis.get("quality_metrics", {})
-        metric_map = {
-            "test": f"test_coverage: {actual_metrics.get('test_coverage', 0)}% (GitHub)",
-            "doc": f"documentation_score: {actual_metrics.get('documentation_score', 0)}% (GitHub)",
-            "iac": f"iac_score: {actual_metrics.get('iac_score', 0)}% (GitHub)",
-            "complex": f"complexity_score: {actual_metrics.get('complexity_score', 0)} (GitHub)",
-        }
-
-        items = []
-        for item in result[:6]:
-            if not isinstance(item, dict):
-                continue
-            color = sanitize_color(item.get("color", "slate"))
-            note = item.get("note")
-            # LLM note가 없거나 빈 경우, 실제 메트릭에서 보강
-            label_lower = item.get("label", "").lower()
-            if not note:
-                for key, metric_note in metric_map.items():
-                    if key in label_lower:
-                        note = metric_note
-                        break
-            items.append(EngineeringDNAItem(
-                label=item.get("label", ""),
-                value=max(0, min(100, int(item.get("value", 0)))),
-                display=item.get("display", ""),
-                color=color,
-                note=note,
-                tooltip=item.get("tooltip"),
-            ))
-
-        if items:
-            # === Post-processing 품질 검증 ===
-            no_note = sum(1 for i in items if not i.note or len(str(i.note).strip()) < 5)
-            no_tooltip = sum(1 for i in items if not i.tooltip or len(str(i.tooltip).strip()) < 10)
-            zero_value = sum(
-                1 for i in items
-                if i.value == 0 and i.note
-                and "not available" not in str(i.note).lower()
-                and "이용할 수 없" not in str(i.note)
-            )
-            if no_note > 0:
-                logger.warning(
-                    f"Engineering DNA: {no_note}/{len(items)} items have empty/short note — metric citation missing"
-                )
-            if no_tooltip > 0:
-                logger.warning(
-                    f"Engineering DNA: {no_tooltip}/{len(items)} items have empty/short tooltip — non-tech explanation missing"
-                )
-            if zero_value > 0:
-                logger.warning(
-                    f"Engineering DNA: {zero_value}/{len(items)} items have value=0 but note doesn't say 'not available'"
-                )
-            logger.info(f"LLM engineering DNA: {len(items)} items")
-            return items
-        return None
-
-    except Exception as e:
-        logger.warning(f"LLM engineering DNA failed, using fallback: {e}")
-        return None
-
-
 def _calculate_radar_scores(
     jd_analysis: dict,
     code_analysis: dict | None,
@@ -294,70 +186,6 @@ def _calculate_radar_scores(
         candidate_profile=candidate_profile,
     )
     return radar.candidate, radar.required, radar.sources, radar.confidence, radar.human_sources
-
-
-def _analyze_engineering_dna(code_analysis: dict | None, lang: str = "ko") -> list[EngineeringDNAItem]:
-    """Engineering DNA 분석"""
-    from app.services.i18n_labels import _t
-
-    items = []
-
-    if not code_analysis:
-        items.append(EngineeringDNAItem(
-            label=_t("code_analysis", lang),
-            value=0,
-            display=_t("unconfirmed", lang),
-            color="slate",
-            note=_t("no_github_data", lang),
-        ))
-        return items
-
-    quality = code_analysis.get("quality_metrics", {})
-
-    # 테스트 커버리지
-    test_coverage = quality.get("test_coverage", 0)
-    items.append(EngineeringDNAItem(
-        label=_t("test_coverage", lang),
-        value=test_coverage,
-        display=f"{test_coverage}%",
-        color="emerald" if test_coverage >= 70 else "amber" if test_coverage >= 40 else "red",
-        note=f"test_coverage: {test_coverage}% (GitHub)",
-    ))
-
-    # 문서화 품질
-    doc_score = quality.get("documentation_score", 0)
-    doc_display = _t("excellent", lang) if doc_score >= 80 else _t("moderate", lang) if doc_score >= 50 else _t("poor", lang)
-    items.append(EngineeringDNAItem(
-        label=_t("doc_quality", lang),
-        value=doc_score,
-        display=doc_display,
-        color="blue" if doc_score >= 80 else "amber" if doc_score >= 50 else "red",
-        note=f"documentation_score: {doc_score}% (GitHub)",
-    ))
-
-    # IaC 사용 여부
-    iac_score = quality.get("iac_score", 0)
-    items.append(EngineeringDNAItem(
-        label=_t("iac", lang),
-        value=iac_score,
-        display=_t("confirmed", lang) if iac_score >= 50 else _t("unconfirmed", lang),
-        color="emerald" if iac_score >= 50 else "red",
-        note=f"iac_score: {iac_score}% (GitHub)" if iac_score >= 50 else _t("iac_not_found", lang),
-        tooltip=_t("iac_tooltip", lang),
-    ))
-
-    # 코드 복잡도
-    complexity = quality.get("complexity_score", 50)
-    complexity_display = _t("low", lang) if complexity <= 30 else _t("moderate", lang) if complexity <= 70 else _t("high", lang)
-    items.append(EngineeringDNAItem(
-        label=_t("code_complexity", lang),
-        value=complexity,
-        display=complexity_display,
-        color="emerald" if complexity <= 30 else "amber" if complexity <= 70 else "red",
-        note=f"complexity_score: {complexity} (GitHub)",
-    ))
-
-    return items
 
 
 def _extract_risk_flags(

--- a/backend/app/workflows/activities/finalization.py
+++ b/backend/app/workflows/activities/finalization.py
@@ -340,17 +340,7 @@ async def finalize_output(
 
     activity.heartbeat("Generating candidate summary...")
 
-    # 1. 용어집 통합
-    all_terms = []
-    seen_terms = set()
-    for q in questions:
-        for term in q.get("terminology", []):
-            term_name = term.get("term", "") if isinstance(term, dict) else str(term)
-            if term_name and term_name not in seen_terms:
-                all_terms.append(term if isinstance(term, dict) else {"term": term_name})
-                seen_terms.add(term_name)
-
-    # 2. 후보자 요약 (LinkedIn 프로필 포함)
+    # 1. 후보자 요약 (LinkedIn 프로필 포함)
     linkedin_profile = enriched_input.get("linkedin_profile") or {}
     linkedin_summary = _format_linkedin_summary(linkedin_profile)
 
@@ -414,7 +404,6 @@ async def finalize_output(
         "candidate_summary": candidate_summary,
         "questions": questions,
         "interviewer_guide": interviewer_guide,
-        "full_glossary": all_terms,
         "linkedin_profile": {
             "name": linkedin_profile.get("full_name") or linkedin_profile.get("name"),
             "headline": linkedin_profile.get("headline"),
@@ -434,7 +423,7 @@ async def finalize_output(
         "metadata": {
             "total_questions": len(questions),
             "language": output_language,
-            "terminology_count": len(all_terms),
+            "terminology_count": 0,
             "experience_level": raw_input.get("experience_level", "미들"),
             "has_linkedin_data": bool(linkedin_profile),
             "has_code_analysis": bool(analysis.get("code_analysis")),

--- a/backend/app/workflows/activities/intel_generation.py
+++ b/backend/app/workflows/activities/intel_generation.py
@@ -1,192 +1,18 @@
 """
 backend/app/workflows/activities/intel_generation.py
-Intel Brief 생성 Activity (LLM 강화 + 규칙 기반 fallback)
+Intel Brief 생성 Activity
 """
-import json
 import logging
-from typing import Any
 
 from temporalio import activity
 
 from app.core.observability import observe_activity
 from app.models.intel import (
-    IntelBrief, JDSummary, CompetencyMatch, GitHubSummary,
+    IntelBrief, JDSummary, GitHubSummary,
     LinkedInPosition, RequirementMatch,
 )
 
 logger = logging.getLogger(__name__)
-
-
-async def _llm_match_competencies(
-    jd_analysis: dict,
-    document_analysis: dict,
-    code_analysis: dict | None,
-    output_language: str = "ko",
-    job_id: str | None = None,
-    linkedin_profile: dict | None = None,
-) -> list[CompetencyMatch] | None:
-    """LLM 기반 시맨틱 역량 매칭 (실패 시 None 반환)"""
-    try:
-        from app.services.cached_llm import CachedLLMService
-        from app.prompts import get_prompt_with_config
-        from app.workflows.utils import run_llm_with_prompt_config_heartbeat
-
-        jd_requirements = jd_analysis.get("requirements") or []
-        if not jd_requirements:
-            return None
-
-        candidate_skills = (document_analysis.get("profile") or {}).get("skills") or []
-        code_skills = (code_analysis.get("tech_stack") or []) if code_analysis else []
-
-        # LinkedIn 프로필에서 추가 스킬 통합
-        linkedin_skills = (linkedin_profile.get("skills") or []) if linkedin_profile else []
-        if linkedin_skills:
-            existing = {s.lower() for s in candidate_skills + code_skills}
-            for ls in linkedin_skills:
-                s = ls if isinstance(ls, str) else (ls.get("name", "") if isinstance(ls, dict) else "")
-                if s and s.lower() not in existing:
-                    candidate_skills.append(s)
-                    existing.add(s.lower())
-
-        # VectorStore 시맨틱 스킬 매칭
-        vector_context = ""
-        if job_id:
-            try:
-                from app.services.vector_store import get_vector_store
-                vs = get_vector_store(job_id)
-                # 필수 스킬 우선 정렬 (Issue #245)
-                sorted_reqs = sorted(
-                    jd_requirements,
-                    key=lambda r: 0 if r.get("category") in ("필수", "required", "must") else 1,
-                )
-                for req in sorted_reqs[:15]:
-                    skill = req.get("skill", "") if isinstance(req, dict) else str(req)
-                    if skill:
-                        matches = await vs.search_profile(skill, limit=2)
-                        for m in matches:
-                            if m["similarity"] >= 0.6:
-                                vector_context += f"- {skill}: {m['content_text'][:100]} (sim={m['similarity']:.2f})\n"
-            except Exception as e:
-                logger.debug(f"Vector skill enrichment failed: {e}")
-
-        kg_context = ""
-        if vector_context:
-            kg_context = f"Semantic skill matches from vector search:\n{vector_context}"
-
-        prompt_config = get_prompt_with_config(
-            "v2_generation.yaml", "competency_matching",
-            jd_requirements=json.dumps(sorted_reqs[:15], ensure_ascii=False, default=str),
-            candidate_skills=json.dumps(candidate_skills[:20], ensure_ascii=False, default=str),
-            code_skills=json.dumps(code_skills[:20], ensure_ascii=False, default=str),
-            output_language=output_language,
-            kg_context=kg_context,
-        )
-
-        llm = CachedLLMService()
-        result = await run_llm_with_prompt_config_heartbeat(llm, prompt_config, interval=30.0)
-
-        if not isinstance(result, list):
-            return None
-
-        from app.services.match_config import get_match_color_icon
-
-        # VectorStore에서 매칭된 스킬 이름 목록 (evidence_source 보강용)
-        vector_matched_skills = set()
-        if vector_context:
-            for line in vector_context.strip().split("\n"):
-                if line.startswith("- ") and ":" in line:
-                    skill_part = line[2:].split(":")[0].strip().lower()
-                    if skill_part:
-                        vector_matched_skills.add(skill_part)
-
-        VALID_SOURCES = {"resume", "github", "resume+github", "vector_store", "none", "llm"}
-
-        competencies = []
-        for item in result[:15]:
-            if not isinstance(item, dict):
-                continue
-            match_level = item.get("match", "none")
-            color, icon = get_match_color_icon(match_level)
-            # LLM이 evidence_source를 반환하면 유효값 검증 후 사용
-            ev_source = item.get("evidence_source", "")
-            if ev_source and ev_source not in VALID_SOURCES:
-                ev_source = ""  # 유효하지 않은 값은 무시
-            if not ev_source:
-                label = item.get("match_label", "").lower()
-                if "github" in label or "code" in label or "repo" in label:
-                    ev_source = "github"
-                elif "resume" in label or "이력서" in label or "경력" in label:
-                    ev_source = "resume"
-                elif match_level in ("strong", "match", "partial"):
-                    ev_source = "llm"
-
-            # VectorStore 시맨틱 매칭이 기여한 경우 소스 보강
-            comp_name_lower = item.get("name", "").lower()
-            if vector_matched_skills and comp_name_lower:
-                for vs_skill in vector_matched_skills:
-                    if vs_skill in comp_name_lower or comp_name_lower in vs_skill:
-                        if ev_source and ev_source not in ("none", "llm", "vector_store"):
-                            ev_source = f"{ev_source}+vector_store"
-                        elif ev_source in ("none", "llm", ""):
-                            ev_source = "vector_store"
-                        break
-            competencies.append(CompetencyMatch(
-                name=item.get("name", ""),
-                match=match_level,
-                match_label=item.get("match_label", ""),
-                desc=item.get("desc", ""),
-                why=item.get("why", ""),
-                color=color,
-                icon=icon,
-                evidence_source=ev_source,
-            ))
-
-        if competencies:
-            # === Post-processing 품질 검증 ===
-            VAGUE_PATTERNS = (
-                "다양한 경험", "풍부한 경력", "excellent skills", "strong background",
-                "good experience", "sufficient capability", "적절한 역량",
-                "관련 경험 있음", "해당 기술 보유",
-            )
-            vague_count = 0
-            no_why_count = 0
-            for c in competencies:
-                label_lower = (c.match_label or "").lower().strip()
-                if any(vp in label_lower for vp in VAGUE_PATTERNS) or (
-                    c.match in ("strong", "match") and len(label_lower) < 10
-                ):
-                    vague_count += 1
-                if not c.why or len(c.why.strip()) < 5:
-                    no_why_count += 1
-            if vague_count > 0:
-                logger.warning(
-                    f"Competency matching: {vague_count}/{len(competencies)} items have vague match_label"
-                )
-            if no_why_count > 0:
-                logger.warning(
-                    f"Competency matching: {no_why_count}/{len(competencies)} items have empty/short 'why' field"
-                )
-
-            # evidence_source 없는 strong/match → partial로 다운그레이드
-            downgraded = 0
-            for c in competencies:
-                if c.match in ("strong", "match") and c.evidence_source in ("", "llm", "none"):
-                    c.match = "partial"
-                    c.color, c.icon = get_match_color_icon("partial")
-                    downgraded += 1
-            if downgraded > 0:
-                logger.warning(
-                    f"Competency matching: {downgraded}/{len(competencies)} strong/match items "
-                    "downgraded to partial (no concrete evidence_source)"
-                )
-
-            logger.info(f"LLM competency matching: {len(competencies)} items")
-            return competencies
-        return None
-
-    except Exception as e:
-        logger.warning(f"LLM competency matching failed, using fallback: {e}")
-        return None
 
 
 def _extract_jd_summary(jd_analysis: dict, lang: str = "ko") -> JDSummary:
@@ -214,89 +40,6 @@ def _extract_jd_summary(jd_analysis: dict, lang: str = "ko") -> JDSummary:
         requirements=req_matches,
         success_metrics=jd_analysis.get("success_metrics", []),
     )
-
-
-def _match_competencies(
-    jd_analysis: dict,
-    document_analysis: dict,
-    code_analysis: dict | None,
-    lang: str = "ko",
-) -> list[CompetencyMatch]:
-    """JD 역량과 후보자 매칭 분석"""
-    competencies = []
-    jd_requirements = jd_analysis.get("requirements") or []
-    candidate_skills = (document_analysis.get("profile") or {}).get("skills") or []
-    code_skills = []
-    if code_analysis:
-        code_skills = code_analysis.get("tech_stack") or []
-
-    # 색상 및 아이콘 매핑
-    match_config = {
-        "strong": ("emerald", "✅"),
-        "match": ("emerald", "✅"),
-        "partial": ("amber", "⚠️"),
-        "unknown": ("amber", "⚠️"),
-        "none": ("red", "❌"),
-    }
-
-    # 필수 스킬 우선 정렬 + 최대 15개 (Issue #245)
-    sorted_reqs = sorted(
-        jd_requirements,
-        key=lambda r: 0 if r.get("category") in ("필수", "required", "must") else 1,
-    )
-    for req in sorted_reqs[:15]:
-        skill = req.get("skill", req.get("text", ""))
-        desc = req.get("description", req.get("desc", ""))
-        why = req.get("importance", req.get("why", ""))
-
-        # 매칭 레벨 결정
-        skill_lower = skill.lower()
-        candidate_skills_lower = [s.lower() for s in candidate_skills]
-        code_skills_lower = [s.lower() for s in code_skills]
-
-        from app.services.i18n_labels import _t
-
-        match_level = "none"
-        match_label = _t("candidate_no_evidence", lang)
-        evidence_source = ""
-
-        # 정확 매칭 확인 — 이력서 스킬 우선, 그다음 코드 스킬
-        resume_match = any(skill_lower in cs for cs in candidate_skills_lower)
-        code_match = any(skill_lower in cs for cs in code_skills_lower)
-        if resume_match or code_match:
-            match_level = "strong"
-            match_label = _t("candidate_strong_match", lang)
-            evidence_source = "resume" if resume_match else "github"
-        # 부분 매칭 확인
-        elif any(
-            any(word in cs for word in skill_lower.split())
-            for cs in candidate_skills_lower
-        ):
-            match_level = "partial"
-            match_label = _t("candidate_partial_match", lang)
-            evidence_source = "resume"
-        elif any(
-            any(word in cs for word in skill_lower.split())
-            for cs in code_skills_lower
-        ):
-            match_level = "partial"
-            match_label = _t("candidate_partial_match", lang)
-            evidence_source = "github"
-
-        color, icon = match_config.get(match_level, ("slate", "❓"))
-
-        competencies.append(CompetencyMatch(
-            name=skill,
-            match=match_level,
-            match_label=match_label,
-            desc=desc,
-            why=why,
-            color=color,
-            icon=icon,
-            evidence_source=evidence_source,
-        ))
-
-    return competencies
 
 
 def _extract_github_summary(code_analysis: dict | None, lang: str = "ko") -> GitHubSummary | None:
@@ -390,32 +133,9 @@ async def generate_intel_brief(
     jd_summary = _extract_jd_summary(jd_analysis, lang=output_language)
     activity.heartbeat()
 
-    # 2. 역량 매칭 분석 (규칙 기반 — JIT-16: LLM competency_matching 프롬프트 제거)
-    competencies = _match_competencies(jd_analysis, document_analysis, code_analysis, lang=output_language)
+    # 2. 역량 매칭 — JIT-17: competency_matching 함수 제거, 빈 리스트
+    competencies: list = []
     activity.heartbeat()
-
-    # 2b. candidate_profile 있으면 역량 매칭 보강 (정규화 스킬 + implied 관계)
-    if candidate_profile and competencies:
-        try:
-            from app.services.profile_scoring import extract_profile_skills, extract_profile_skill_sources
-            from app.services.match_config import get_match_color_icon
-            profile_skills = extract_profile_skills(candidate_profile)
-            sources_map = extract_profile_skill_sources(candidate_profile)
-
-            for comp in competencies:
-                comp_lower = comp.name.lower()
-                # none/partial인데 프로필에 canonical match가 있으면 업그레이드
-                if comp.match in ("none", "partial") and comp_lower in profile_skills:
-                    skill_sources = sources_map.get(comp_lower, [])
-                    comp.match = "strong"
-                    comp.color, comp.icon = get_match_color_icon("strong")
-                    source_str = "+".join(skill_sources) if skill_sources else "profile"
-                    comp.evidence_source = f"profile({source_str})"
-                    from app.services.i18n_labels import _t
-                    comp.match_label = _t("candidate_strong_match", output_language)
-                    logger.debug(f"Profile upgrade: {comp.name} none/partial → strong (canonical match)")
-        except Exception as e:
-            logger.debug(f"Profile competency enrichment failed (non-fatal): {e}")
 
     # 3. GitHub 기여도 데이터 포맷
     github_summary = _extract_github_summary(code_analysis, lang=output_language)

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -530,11 +530,6 @@ class InterviewGenerationWorkflow:
                 final_script["decision"] = decision_support
                 if candidate_profile:
                     final_script["candidate_profile"] = candidate_profile
-                # Category weights for scoring — 경험 레벨별 차등 배분
-                exp_level = input_data.get("experience_level", "미들")
-                final_script["category_weights"] = CATEGORY_WEIGHTS_BY_LEVEL.get(
-                    exp_level, CATEGORY_WEIGHTS_BY_LEVEL["미들"]
-                )
 
                 # 교차 일관성 검증 (Intel ↔ Deep Analysis ↔ Decision)
                 inconsistencies = []

--- a/backend/tests/test_workflow_v2.py
+++ b/backend/tests/test_workflow_v2.py
@@ -89,11 +89,13 @@ class TestV2ActivitySignatures:
 class TestV2LLMFallbackPattern:
     """v2 Activity들이 LLM + fallback 패턴을 따르는지 검증"""
 
-    def test_intel_generation_has_rule_based_competency_matching(self):
+    def test_intel_generation_has_essential_functions(self):
         from app.workflows.activities import intel_generation
         source = inspect.getsource(intel_generation)
-        # 규칙 기반 매칭 함수 존재 (JIT-16: LLM 제거, rules-only)
-        assert "_match_competencies" in source
+        # JIT-17: competency matching 제거, 핵심 함수만 확인
+        assert "_extract_jd_summary" in source
+        assert "_extract_github_summary" in source
+        assert "generate_intel_brief" in source
 
     def test_analysis_generation_has_llm_and_fallback(self):
         from app.workflows.activities import analysis_generation


### PR DESCRIPTION
## Summary
- engineering_dna 생성 함수 2개 삭제 (LLM + rules-based fallback)
- competency_matching 생성 함수 2개 삭제 (LLM + rules-based fallback)
- finalization.py full_glossary 수집/할당 제거
- interview_workflow.py category_weights 할당 제거 (상수는 내부 스코어링에서 유지)
- 총 478줄 삭감, jd_competency_map→skill_table 매핑은 이미 구현됨

## Test plan
- [x] backend pytest: v2 테스트 25개 전부 패스
- [x] 전체 스위트 452 passed (기존 실패 2개는 JIT-17 무관)

Closes JIT-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)