### PR TITLE
refactor: Pydantic 모델 deprecated 표시 — 미사용 클래스 주석 정리

### DIFF
--- a/backend/app/models/decision.py
+++ b/backend/app/models/decision.py
@@ -41,7 +41,7 @@ class InterviewerGuideTips(BaseModel):
 
 
 class JDCompetencyWeight(BaseModel):
-    """JD 역량 가중치"""
+    """JD 역량 가중치 (Deprecated: JIT-17에서 related_questions를 skill_table로 이전, 기존 데이터 역직렬화용 유지)"""
     competency: str
     weight: float
     related_questions: list[int] = Field(default_factory=list)

--- a/backend/app/models/deep_analysis.py
+++ b/backend/app/models/deep_analysis.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 
 class EngineeringDNAItem(BaseModel):
-    """Engineering DNA 항목"""
+    """Engineering DNA 항목 (Deprecated: JIT-12/17에서 프론트엔드·백엔드 모두 제거, 기존 데이터 역직렬화용 유지)"""
     label: str  # 예: "테스트 커버리지"
     value: int  # 퍼센트 (0-100)
     display: str  # 표시 텍스트 (예: "82%", "우수", "미확인")

--- a/backend/app/models/intel.py
+++ b/backend/app/models/intel.py
@@ -23,7 +23,7 @@ class JDSummary(BaseModel):
 
 
 class CompetencyMatch(BaseModel):
-    """JD 역량 vs 후보자 매칭"""
+    """JD 역량 vs 후보자 매칭 (Deprecated: JIT-17에서 생성 로직 제거, 기존 데이터 역직렬화용 유지)"""
     name: str
     match: Literal["strong", "match", "partial", "unknown", "none"]
     match_label: str


### PR DESCRIPTION
## Summary
- EngineeringDNAItem, CompetencyMatch, JDCompetencyWeight에 deprecated 주석 추가
- 기존 저장된 데이터의 역직렬화 호환성 유지 (필드 삭제 X, 기본값 유지)
- SkillMatchRow.related_questions, InterviewerGuideTips 정리 등은 이전 이슈에서 이미 완료

## Test plan
- [x] backend pytest 정상 (변경은 docstring만)
- [x] 기존 데이터 역직렬화에 영향 없음

Closes JIT-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)