### PR TITLE
feat: AST 파서 확장 — clone 디렉토리 직접 파싱 + 청크 메타데이터 [JIT-21]

### DIFF
--- a/backend/app/services/ast_analyzer.py
+++ b/backend/app/services/ast_analyzer.py
@@ -5,9 +5,21 @@ AST 구조 분석 (Python: ast, JS/TS: tree-sitter, fallback)
 Extracted from code_analyzer.py for SRP compliance.
 """
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
+# 디렉토리 순회 시 건너뛸 디렉토리명
+_SKIP_DIRS = {".git", "__pycache__", "node_modules", ".venv", "venv", ".tox", ".mypy_cache"}
+
+# 확장자 → 언어 매핑
+_EXT_TO_LANG: dict[str, str] = {
+    ".py": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+}
 
 async def analyze_ast(
     files: list[dict],
@@ -199,3 +211,294 @@ def _walk_ts_node(
 
     for child in node.children:
         _walk_ts_node(child, functions, classes, imports, file_info)
+
+
+# ============================================================
+# analyze_directory — clone 디렉토리에서 직접 파싱 [JIT-21]
+# ============================================================
+
+async def analyze_directory(
+    clone_dir: str,
+    file_types: list[str],
+) -> dict:
+    """clone 디렉토리의 소스 파일을 직접 파싱하여 함수/클래스 청크 + 메타데이터 추출.
+
+    Args:
+        clone_dir: clone된 레포 디렉토리 경로
+        file_types: 파싱할 파일 확장자 목록 (예: [".py", ".js", ".ts"])
+
+    Returns:
+        {"chunks": [ChunkDict, ...]}
+        ChunkDict keys: name, type, identifiers, imports, decorators,
+                        source_code, char_count, file_path
+    """
+    chunks: list[dict] = []
+
+    for root, dirs, filenames in os.walk(clone_dir):
+        # 숨김 디렉토리 및 불필요한 디렉토리 제외
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS and not d.startswith(".")]
+
+        for filename in filenames:
+            ext = os.path.splitext(filename)[1]
+            if ext not in file_types:
+                continue
+
+            filepath = os.path.join(root, filename)
+            rel_path = os.path.relpath(filepath, clone_dir)
+
+            try:
+                with open(filepath, encoding="utf-8", errors="replace") as fh:
+                    source = fh.read()
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            if not source.strip():
+                continue
+
+            lang = _EXT_TO_LANG.get(ext)
+            if lang == "python":
+                _parse_python_chunks(source, rel_path, chunks)
+            elif lang in ("javascript", "typescript"):
+                _parse_ts_chunks(source, rel_path, lang, chunks)
+
+    return {"chunks": chunks}
+
+
+def _parse_python_chunks(
+    source: str,
+    file_path: str,
+    chunks: list[dict],
+) -> None:
+    """Python 소스에서 함수/클래스 청크를 추출하여 chunks 리스트에 추가."""
+    import ast as ast_mod
+
+    # 파일 전체의 import 문 추출
+    file_imports: list[str] = []
+    try:
+        tree = ast_mod.parse(source)
+    except SyntaxError:
+        return
+
+    for node in ast_mod.walk(tree):
+        if isinstance(node, ast_mod.Import):
+            for alias in node.names:
+                file_imports.append(f"import {alias.name}")
+        elif isinstance(node, ast_mod.ImportFrom):
+            module = node.module or ""
+            names = ", ".join(a.name for a in node.names)
+            file_imports.append(f"from {module} import {names}")
+
+    source_lines = source.splitlines()
+
+    for node in ast_mod.iter_child_nodes(tree):
+        if isinstance(node, ast_mod.FunctionDef) or isinstance(node, ast_mod.AsyncFunctionDef):
+            chunk_source = ast_mod.get_source_segment(source, node) or _get_lines(source_lines, node)
+            identifiers = _extract_python_identifiers(node)
+            decorators = _extract_python_decorators(node)
+
+            chunks.append({
+                "name": node.name,
+                "type": "function",
+                "identifiers": identifiers,
+                "imports": list(file_imports),
+                "decorators": decorators,
+                "source_code": chunk_source,
+                "char_count": len(chunk_source),
+                "file_path": file_path,
+            })
+
+        elif isinstance(node, ast_mod.ClassDef):
+            chunk_source = ast_mod.get_source_segment(source, node) or _get_lines(source_lines, node)
+            identifiers = _extract_python_identifiers(node)
+            decorators = _extract_python_decorators(node)
+
+            chunks.append({
+                "name": node.name,
+                "type": "class",
+                "identifiers": identifiers,
+                "imports": list(file_imports),
+                "decorators": decorators,
+                "source_code": chunk_source,
+                "char_count": len(chunk_source),
+                "file_path": file_path,
+            })
+
+
+def _extract_python_identifiers(node) -> list[str]:
+    """AST 노드에서 사용된 변수/함수명(Name 노드)을 추출."""
+    import ast as ast_mod
+
+    identifiers: set[str] = set()
+    for child in ast_mod.walk(node):
+        if isinstance(child, ast_mod.Name):
+            identifiers.add(child.id)
+        elif isinstance(child, ast_mod.arg):
+            identifiers.add(child.arg)
+    return sorted(identifiers)
+
+
+def _extract_python_decorators(node) -> list[str]:
+    """AST 노드의 데코레이터 리스트를 문자열로 추출."""
+    import ast as ast_mod
+
+    decorators: list[str] = []
+    for d in getattr(node, "decorator_list", []):
+        if isinstance(d, ast_mod.Name):
+            decorators.append(d.id)
+        elif isinstance(d, ast_mod.Attribute):
+            # @pytest.fixture → "pytest.fixture"
+            parts = []
+            current = d
+            while isinstance(current, ast_mod.Attribute):
+                parts.append(current.attr)
+                current = current.value
+            if isinstance(current, ast_mod.Name):
+                parts.append(current.id)
+            decorators.append(".".join(reversed(parts)))
+        elif isinstance(d, ast_mod.Call):
+            # @app.get("/path") → 함수 부분만 추출
+            func = d.func
+            if isinstance(func, ast_mod.Name):
+                decorators.append(func.id)
+            elif isinstance(func, ast_mod.Attribute):
+                parts = []
+                current = func
+                while isinstance(current, ast_mod.Attribute):
+                    parts.append(current.attr)
+                    current = current.value
+                if isinstance(current, ast_mod.Name):
+                    parts.append(current.id)
+                decorators.append(".".join(reversed(parts)))
+    return decorators
+
+
+def _get_lines(source_lines: list[str], node) -> str:
+    """ast 노드의 소스 코드를 줄 번호로 추출 (get_source_segment fallback)."""
+    start = getattr(node, "lineno", 1) - 1
+    end = getattr(node, "end_lineno", start + 1)
+    return "\n".join(source_lines[start:end])
+
+
+def _parse_ts_chunks(
+    source: str,
+    file_path: str,
+    lang: str,
+    chunks: list[dict],
+) -> None:
+    """JS/TS 소스에서 함수/클래스 청크를 추출하여 chunks 리스트에 추가."""
+    try:
+        import tree_sitter_javascript as ts_js
+        import tree_sitter_typescript as ts_ts
+        from tree_sitter import Language, Parser
+    except ImportError:
+        raise ImportError("tree-sitter JS/TS bindings not installed")
+
+    if lang == "typescript":
+        language = Language(ts_ts.language_typescript())
+    else:
+        language = Language(ts_js.language())
+
+    ts_parser = Parser(language)
+
+    try:
+        tree = ts_parser.parse(source.encode("utf-8"))
+    except Exception:
+        return
+
+    # 파일 전체의 import 추출
+    file_imports: list[str] = []
+    _collect_ts_imports(tree.root_node, file_imports)
+
+    # 최상위 함수/클래스 추출
+    _collect_ts_chunks(tree.root_node, file_path, file_imports, source, chunks)
+
+
+def _collect_ts_imports(node, file_imports: list[str]) -> None:
+    """tree-sitter 루트 노드에서 import 문을 수집."""
+    for child in node.children:
+        if child.type == "import_statement":
+            file_imports.append(child.text.decode("utf-8"))
+        elif child.type == "import_declaration":
+            file_imports.append(child.text.decode("utf-8"))
+
+
+def _collect_ts_chunks(
+    node,
+    file_path: str,
+    file_imports: list[str],
+    source: str,
+    chunks: list[dict],
+) -> None:
+    """tree-sitter 노드를 순회하며 함수/클래스 청크를 수집."""
+    for child in node.children:
+        ntype = child.type
+
+        if ntype in ("function_declaration", "method_definition"):
+            name_node = child.child_by_field_name("name")
+            chunk_source = child.text.decode("utf-8")
+            identifiers = _collect_ts_identifiers(child)
+
+            chunks.append({
+                "name": name_node.text.decode("utf-8") if name_node else "<anonymous>",
+                "type": "function",
+                "identifiers": sorted(identifiers),
+                "imports": list(file_imports),
+                "decorators": [],
+                "source_code": chunk_source,
+                "char_count": len(chunk_source),
+                "file_path": file_path,
+            })
+
+        elif ntype == "lexical_declaration":
+            # const foo = () => {} 패턴
+            for decl in child.children:
+                if decl.type == "variable_declarator":
+                    value = decl.child_by_field_name("value")
+                    if value and value.type == "arrow_function":
+                        name_node = decl.child_by_field_name("name")
+                        chunk_source = child.text.decode("utf-8")
+                        identifiers = _collect_ts_identifiers(value)
+
+                        chunks.append({
+                            "name": name_node.text.decode("utf-8") if name_node else "<arrow>",
+                            "type": "function",
+                            "identifiers": sorted(identifiers),
+                            "imports": list(file_imports),
+                            "decorators": [],
+                            "source_code": chunk_source,
+                            "char_count": len(chunk_source),
+                            "file_path": file_path,
+                        })
+
+        elif ntype == "class_declaration":
+            name_node = child.child_by_field_name("name")
+            chunk_source = child.text.decode("utf-8")
+            identifiers = _collect_ts_identifiers(child)
+
+            chunks.append({
+                "name": name_node.text.decode("utf-8") if name_node else "<anonymous>",
+                "type": "class",
+                "identifiers": sorted(identifiers),
+                "imports": list(file_imports),
+                "decorators": [],
+                "source_code": chunk_source,
+                "char_count": len(chunk_source),
+                "file_path": file_path,
+            })
+
+        elif ntype == "export_statement":
+            # export function / export class 패턴
+            _collect_ts_chunks(child, file_path, file_imports, source, chunks)
+
+
+def _collect_ts_identifiers(node) -> set[str]:
+    """tree-sitter 노드에서 identifier를 재귀적으로 수집."""
+    identifiers: set[str] = set()
+
+    if node.type == "identifier":
+        identifiers.add(node.text.decode("utf-8"))
+
+    for child in node.children:
+        identifiers.update(_collect_ts_identifiers(child))
+
+    return identifiers

--- a/backend/tests/test_ast_analyzer.py
+++ b/backend/tests/test_ast_analyzer.py
@@ -1,0 +1,323 @@
+"""
+backend/tests/test_ast_analyzer.py
+AST 파서 확장 — analyze_directory() 단위 테스트 [JIT-21]
+
+테스트 항목:
+- AD-01: Python 소스 파일에서 함수/클래스 청크 + 메타데이터 추출
+- AD-02: JS/TS 소스 파일에서 함수/클래스 청크 + 메타데이터 추출
+- AD-03: 빈 디렉토리 / 비매칭 확장자 → 빈 결과
+- AD-04: 기존 analyze_ast() 함수 동작 유지 (하위 호환)
+- AD-05: 메타데이터 필드 완전성 검증
+"""
+import pytest
+import textwrap
+
+
+# ============================================================
+# AD-01: Python 소스 파일에서 함수/클래스 청크 + 메타데이터 추출
+# ============================================================
+
+class TestAnalyzeDirectoryPython:
+    """Python 소스 파일 파싱 및 메타데이터 추출"""
+
+    @pytest.mark.asyncio
+    async def test_python_function_chunk(self, tmp_path):
+        """Python 함수를 청크 단위로 추출하고 메타데이터 포함"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "main.py").write_text(textwrap.dedent("""\
+            import os
+            from pathlib import Path
+
+            def hello(name: str) -> str:
+                greeting = f"Hello, {name}"
+                return greeting
+        """))
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        assert len(result["chunks"]) >= 1
+        func_chunk = next(c for c in result["chunks"] if c["name"] == "hello")
+        assert func_chunk["type"] == "function"
+        assert "name" in func_chunk["identifiers"]
+        assert "greeting" in func_chunk["identifiers"]
+        assert func_chunk["file_path"].endswith("main.py")
+        assert func_chunk["char_count"] > 0
+        assert "def hello" in func_chunk["source_code"]
+
+    @pytest.mark.asyncio
+    async def test_python_class_chunk(self, tmp_path):
+        """Python 클래스를 청크 단위로 추출하고 데코레이터/메서드 포함"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "service.py").write_text(textwrap.dedent("""\
+            from dataclasses import dataclass
+
+            @dataclass
+            class UserService:
+                name: str
+
+                def get_user(self, user_id: int):
+                    return {"id": user_id, "name": self.name}
+        """))
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        class_chunk = next(c for c in result["chunks"] if c["name"] == "UserService")
+        assert class_chunk["type"] == "class"
+        assert "dataclass" in class_chunk["decorators"]
+        assert class_chunk["char_count"] > 0
+
+    @pytest.mark.asyncio
+    async def test_python_imports_extracted(self, tmp_path):
+        """Python import 문이 파일별로 추출됨"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "app.py").write_text(textwrap.dedent("""\
+            import os
+            from pathlib import Path
+            from typing import Optional
+
+            def run():
+                pass
+        """))
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        func_chunk = next(c for c in result["chunks"] if c["name"] == "run")
+        assert any("os" in imp for imp in func_chunk["imports"])
+        assert any("pathlib" in imp or "Path" in imp for imp in func_chunk["imports"])
+
+
+# ============================================================
+# AD-02: JS/TS 소스 파일에서 함수/클래스 청크 + 메타데이터 추출
+# ============================================================
+
+class TestAnalyzeDirectoryJsTs:
+    """JS/TS 소스 파일 파싱 및 메타데이터 추출"""
+
+    @pytest.mark.asyncio
+    async def test_js_function_chunk(self, tmp_path):
+        """JavaScript 함수를 청크 단위로 추출"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "index.js").write_text(textwrap.dedent("""\
+            import express from 'express';
+
+            function createApp(port) {
+                const app = express();
+                app.listen(port);
+                return app;
+            }
+        """))
+
+        try:
+            result = await analyze_directory(str(tmp_path), [".js"])
+        except ImportError:
+            pytest.skip("tree-sitter JS bindings not installed")
+
+        assert len(result["chunks"]) >= 1
+        func_chunk = next(c for c in result["chunks"] if c["name"] == "createApp")
+        assert func_chunk["type"] == "function"
+        assert func_chunk["file_path"].endswith("index.js")
+        assert func_chunk["char_count"] > 0
+
+    @pytest.mark.asyncio
+    async def test_ts_class_chunk(self, tmp_path):
+        """TypeScript 클래스를 청크 단위로 추출"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "user.ts").write_text(textwrap.dedent("""\
+            import { Injectable } from '@nestjs/common';
+
+            class UserService {
+                constructor(private readonly db: Database) {}
+
+                async findById(id: number) {
+                    return this.db.find(id);
+                }
+            }
+        """))
+
+        try:
+            result = await analyze_directory(str(tmp_path), [".ts"])
+        except ImportError:
+            pytest.skip("tree-sitter TS bindings not installed")
+
+        assert len(result["chunks"]) >= 1
+        class_chunk = next(c for c in result["chunks"] if c["name"] == "UserService")
+        assert class_chunk["type"] == "class"
+        assert class_chunk["char_count"] > 0
+
+
+# ============================================================
+# AD-03: 빈 디렉토리 / 비매칭 확장자 → 빈 결과
+# ============================================================
+
+class TestAnalyzeDirectoryEdgeCases:
+    """엣지 케이스 처리"""
+
+    @pytest.mark.asyncio
+    async def test_empty_directory(self, tmp_path):
+        """빈 디렉토리 → 빈 결과"""
+        from app.services.ast_analyzer import analyze_directory
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        assert result["chunks"] == []
+
+    @pytest.mark.asyncio
+    async def test_no_matching_extensions(self, tmp_path):
+        """매칭되는 확장자 없음 → 빈 결과"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "README.md").write_text("# Hello")
+        (tmp_path / "data.json").write_text("{}")
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        assert result["chunks"] == []
+
+    @pytest.mark.asyncio
+    async def test_syntax_error_file_skipped(self, tmp_path):
+        """문법 오류 파일은 건너뛰고 나머지 파싱"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "good.py").write_text("def good():\n    return 1\n")
+        (tmp_path / "bad.py").write_text("def bad(\n")  # SyntaxError
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        names = [c["name"] for c in result["chunks"]]
+        assert "good" in names
+
+    @pytest.mark.asyncio
+    async def test_git_and_hidden_dirs_excluded(self, tmp_path):
+        """.git, __pycache__, node_modules 등 제외"""
+        from app.services.ast_analyzer import analyze_directory
+
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "config.py").write_text("def git_internal(): pass\n")
+
+        cache_dir = tmp_path / "__pycache__"
+        cache_dir.mkdir()
+        (cache_dir / "cached.py").write_text("def cached(): pass\n")
+
+        (tmp_path / "real.py").write_text("def real_func(): pass\n")
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        names = [c["name"] for c in result["chunks"]]
+        assert "real_func" in names
+        assert "git_internal" not in names
+        assert "cached" not in names
+
+
+# ============================================================
+# AD-04: 기존 analyze_ast() 함수 동작 유지 (하위 호환)
+# ============================================================
+
+class TestAnalyzeAstBackwardCompat:
+    """기존 analyze_ast() 하위 호환성"""
+
+    @pytest.mark.asyncio
+    async def test_analyze_ast_still_works(self):
+        """기존 analyze_ast() 함수가 동일하게 동작"""
+        from app.services.ast_analyzer import analyze_ast
+
+        files = [
+            {
+                "source": "def hello():\n    pass\n\nclass Foo:\n    def bar(self):\n        pass\n",
+            }
+        ]
+
+        result = await analyze_ast(files, primary_language="python")
+
+        assert "functions" in result
+        assert "classes" in result
+        assert "imports" in result
+        assert "parser_used" in result
+        assert any(f["name"] == "hello" for f in result["functions"])
+        assert any(c["name"] == "Foo" for c in result["classes"])
+
+
+# ============================================================
+# AD-05: 메타데이터 필드 완전성 검증
+# ============================================================
+
+class TestChunkMetadataCompleteness:
+    """각 청크에 필수 메타데이터 필드가 모두 존재"""
+
+    @pytest.mark.asyncio
+    async def test_all_metadata_fields_present(self, tmp_path):
+        """모든 필수 메타데이터 필드 존재 확인"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "sample.py").write_text(textwrap.dedent("""\
+            import json
+            from os.path import join
+
+            @staticmethod
+            def process_data(items: list) -> dict:
+                result = {}
+                for item in items:
+                    result[item] = True
+                return result
+        """))
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        required_fields = {
+            "name", "type", "identifiers", "imports",
+            "decorators", "source_code", "char_count", "file_path",
+        }
+
+        assert len(result["chunks"]) >= 1
+        for chunk in result["chunks"]:
+            missing = required_fields - set(chunk.keys())
+            assert not missing, f"Missing fields: {missing}"
+
+    @pytest.mark.asyncio
+    async def test_identifiers_are_sets_of_strings(self, tmp_path):
+        """identifiers는 문자열 set (또는 list)"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "calc.py").write_text(textwrap.dedent("""\
+            def add(a, b):
+                total = a + b
+                return total
+        """))
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        chunk = result["chunks"][0]
+        assert isinstance(chunk["identifiers"], (set, list))
+        assert all(isinstance(i, str) for i in chunk["identifiers"])
+
+    @pytest.mark.asyncio
+    async def test_decorators_extracted_correctly(self, tmp_path):
+        """데코레이터가 문자열 리스트로 추출"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "api.py").write_text(textwrap.dedent("""\
+            import pytest
+
+            @pytest.fixture
+            def client():
+                return "test_client"
+
+            @staticmethod
+            def helper():
+                pass
+        """))
+
+        result = await analyze_directory(str(tmp_path), [".py"])
+
+        client_chunk = next(c for c in result["chunks"] if c["name"] == "client")
+        assert isinstance(client_chunk["decorators"], list)
+        # pytest.fixture 또는 Attribute 형태로 추출
+        assert len(client_chunk["decorators"]) >= 1
+
+        helper_chunk = next(c for c in result["chunks"] if c["name"] == "helper")
+        assert "staticmethod" in helper_chunk["decorators"]


### PR DESCRIPTION
## Summary

- `analyze_directory(clone_dir, file_types)` 함수 추가 — clone 디렉토리의 소스 파일을 직접 파싱
- Python(ast)/JS/TS(tree-sitter) 함수/클래스 청크별 메타데이터 추출: `identifiers`, `imports`, `decorators`, `source_code`, `char_count`, `file_path`
- 기존 `analyze_ast()` 함수 완전 유지 (하위 호환)

## 수정 파일

| 파일 | 변경 |
|------|------|
| `backend/app/services/ast_analyzer.py` | `analyze_directory()` 및 헬퍼 함수 추가 |
| `backend/tests/test_ast_analyzer.py` | 단위 테스트 13개 신규 |

## Test plan

- [x] Python 함수/클래스 청크 추출 + 메타데이터 검증
- [x] JS/TS 함수/클래스 청크 추출 + 메타데이터 검증
- [x] 빈 디렉토리, 비매칭 확장자, 문법 오류 엣지 케이스
- [x] .git/__pycache__/node_modules 디렉토리 제외
- [x] 기존 `analyze_ast()` 하위 호환성
- [x] 메타데이터 필드 완전성 (8개 필드 모두 존재)
- [x] 기존 `test_code_analysis.py` 14개 테스트 통과 (회귀 없음)

**Linear**: https://linear.app/jittda/issue/JIT-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)