### PR TITLE
feat: 후보자 식별 강화 — 다단계 추론 + 조직 레포 지원 [JIT-23]

### DIFF
--- a/.claude/skills/linear-ops/SKILL.md
+++ b/.claude/skills/linear-ops/SKILL.md
@@ -119,12 +119,20 @@ docker compose exec backend pytest --cov=app --cov-report=term-missing
 
 ### 조건: 모든 테스트 통과 시에만 진행
 
-### 3-1. 티켓 업데이트
+### 3-1. 티켓 업데이트 (코멘트 추가)
 
-`mcp__linear__update_issue(issueId, description)` 호출하여 결과 섹션 추가:
+`linear_add_comment`로 구현 결과를 코멘트로 추가:
 
+```bash
+# 직접 본문 전달
+linear_add_comment "$ISSUE_ID" "## 구현 완료 리뷰\n\n### 수정 파일\n- file1.py — 변경 요약"
+
+# 파일에서 읽기 (@경로 형식)
+linear_add_comment "$ISSUE_ID" @/tmp/review_comment.md
+```
+
+코멘트 본문 템플릿:
 ```markdown
----
 ## 구현 결과
 
 ### [Summary]
@@ -137,16 +145,16 @@ docker compose exec backend pytest --cov=app --cov-report=term-missing
 ### [Test Result]
 - 명령어: `pytest tests/test_feature.py -v`
 - 결과: ALL PASSED (X passed, 0 failed)
-- 커버리지: XX%
 
 ### [Commit]
 - 브랜치: `feat/VAN-{N}-slug`
 - 커밋: `{커밋 해시}`
----
 ```
 
+> **참고**: 본문에 마크다운 특수문자(`!`, `` ` ``, `"` 등)가 많을 경우 파일 기반 입력(`@/tmp/file.md`)을 사용할 것.
+
 ### 3-2. 상태 업데이트
-- `mcp__linear__update_issue(issueId, status: "In Review")`
+- `linear_update_status "$ISSUE_ID" in_review`
 
 ### 3-3. Git 커밋 및 PR
 1. 커밋 메시지에 티켓 ID 포함: `feat: {설명} [VAN-{N}]`

--- a/.claude/skills/linear-ops/linear-api.sh
+++ b/.claude/skills/linear-ops/linear-api.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Linear GraphQL API 래퍼 — MCP 대체
+# 사용법: source .claude/skills/linear-ops/linear-api.sh && linear_get_issue "issue-uuid"
+#
+# 함수 목록:
+#   linear_get_issue       "issue-uuid"
+#   linear_search_issues   "검색어" [limit]
+#   linear_list_issues     [team-uuid] [limit]
+#   linear_update_status   "issue-uuid" "backlog|todo|in_progress|in_review|done|canceled"
+#   linear_update_description "issue-uuid" "설명"
+#   linear_create_issue    "제목" "team-uuid" ["설명"] [priority]
+#   linear_add_comment     "issue-uuid" "본문" | @/path/to/file.md
+#   linear_list_teams
+#   linear_list_projects   [limit]
+#
+# 필수 환경변수: LINEAR_API_KEY 또는 LINEAR_API_TOKEN
+
+set -euo pipefail
+
+LINEAR_ENDPOINT="https://api.linear.app/graphql"
+
+_linear_key() {
+  echo "${LINEAR_API_KEY:-${LINEAR_API_TOKEN:-}}"
+}
+
+_linear_gql() {
+  # 멀티라인 GraphQL → 한 줄로 압축 후 JSON 전송
+  local query
+  query=$(echo "$1" | tr '\n' ' ' | sed 's/  */ /g')
+  local variables="${2:-null}"
+  local payload
+  payload=$(jq -n --arg q "$query" --argjson v "$variables" '{query: $q, variables: $v}')
+  curl -s -X POST "$LINEAR_ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: $(_linear_key)" \
+    --data "$payload"
+}
+
+# ── Jittda 팀 워크플로우 상태 UUID ──
+_linear_state_id() {
+  case "$1" in
+    backlog)     echo "0427fdcb-12f5-4773-ada5-6c8400b7edfd" ;;
+    todo)        echo "3c7a018f-8193-4aa2-bd1a-536ea78e2905" ;;
+    in_progress) echo "74296a83-5745-4764-8eb3-9d7b6dfa6bfa" ;;
+    in_review)   echo "4cfc961c-7246-48de-a490-8d57f298d9d8" ;;
+    done)        echo "ee3386e5-f051-4779-97c0-f45afc6b62fb" ;;
+    canceled)    echo "94012442-4212-4a79-82f4-757f07a802e2" ;;
+    duplicate)   echo "b499a4fa-9a33-485b-a705-7ad7afbe3082" ;;
+    *)           echo "$1" ;;  # UUID 직접 전달도 허용
+  esac
+}
+
+# ── API 함수 ──
+
+linear_get_issue() {
+  local issue_id="$1"
+  _linear_gql '
+    query($id: String!) {
+      issue(id: $id) {
+        id identifier title description priority priorityLabel
+        state { id name type }
+        assignee { id name email }
+        creator { id name }
+        team { id name key }
+        project { id name }
+        labels { nodes { id name } }
+        comments { nodes { id body createdAt user { name } } }
+        url createdAt updatedAt completedAt
+        branchName estimate
+      }
+    }
+  ' "$(jq -n --arg id "$issue_id" '{id: $id}')"
+}
+
+linear_search_issues() {
+  local query="$1"
+  local first="${2:-20}"
+  _linear_gql '
+    query($term: String!, $first: Int) {
+      searchIssues(term: $term, first: $first) {
+        nodes {
+          id identifier title
+          state { name }
+          assignee { name }
+          priority priorityLabel url
+        }
+      }
+    }
+  ' "$(jq -n --arg term "$query" --argjson first "$first" '{term: $term, first: $first}')"
+}
+
+linear_list_issues() {
+  local team_id="${1:-}"
+  local first="${2:-50}"
+  if [[ -n "$team_id" ]]; then
+    _linear_gql '
+      query($first: Int, $filter: IssueFilter) {
+        issues(first: $first, filter: $filter, orderBy: updatedAt) {
+          nodes {
+            id identifier title
+            state { name }
+            assignee { name }
+            priority priorityLabel url
+          }
+        }
+      }
+    ' "$(jq -n --argjson first "$first" --arg tid "$team_id" '{first: $first, filter: {team: {id: {eq: $tid}}}}')"
+  else
+    _linear_gql '
+      query($first: Int) {
+        issues(first: $first, orderBy: updatedAt) {
+          nodes {
+            id identifier title
+            state { name }
+            assignee { name }
+            priority priorityLabel url
+          }
+        }
+      }
+    ' "$(jq -n --argjson first "$first" '{first: $first}')"
+  fi
+}
+
+linear_update_status() {
+  local issue_id="$1"
+  local status_key="$2"  # backlog|todo|in_progress|in_review|done|canceled 또는 UUID
+  local state_id
+  state_id=$(_linear_state_id "$status_key")
+  _linear_gql '
+    mutation($id: String!, $stateId: String!) {
+      issueUpdate(id: $id, input: { stateId: $stateId }) {
+        success
+        issue { id identifier title state { name } }
+      }
+    }
+  ' "$(jq -n --arg id "$issue_id" --arg sid "$state_id" '{id: $id, stateId: $sid}')"
+}
+
+linear_update_description() {
+  local issue_id="$1"
+  local description="$2"
+  _linear_gql '
+    mutation($id: String!, $desc: String!) {
+      issueUpdate(id: $id, input: { description: $desc }) {
+        success
+        issue { id identifier title }
+      }
+    }
+  ' "$(jq -n --arg id "$issue_id" --arg desc "$description" '{id: $id, desc: $desc}')"
+}
+
+linear_create_issue() {
+  local title="$1"
+  local team_id="$2"
+  local description="${3:-}"
+  local priority="${4:-0}"
+  _linear_gql '
+    mutation($title: String!, $teamId: String!, $desc: String, $priority: Int) {
+      issueCreate(input: { title: $title, teamId: $teamId, description: $desc, priority: $priority }) {
+        success
+        issue { id identifier title url state { name } }
+      }
+    }
+  ' "$(jq -n --arg t "$title" --arg tid "$team_id" --arg d "$description" --argjson p "$priority" '{title: $t, teamId: $tid, desc: $d, priority: $p}')"
+}
+
+linear_add_comment() {
+  # 이슈에 코멘트 추가
+  # 사용법: linear_add_comment "issue-uuid" "코멘트 본문"
+  #         linear_add_comment "issue-uuid" @/tmp/comment.md  (파일에서 읽기)
+  local issue_id="$1"
+  local body="$2"
+
+  # @파일경로 형식이면 파일에서 읽기
+  if [[ "$body" == @* ]]; then
+    local file_path="${body#@}"
+    body=$(cat "$file_path")
+  fi
+
+  # Python으로 JSON 인코딩 (GraphQL ! 이스케이프 문제 우회)
+  python3 -c "
+import json, subprocess, sys
+payload = json.dumps({
+    'query': 'mutation(\$id: String!, \$body: String!) { commentCreate(input: { issueId: \$id, body: \$body }) { success comment { id } } }',
+    'variables': {'id': sys.argv[1], 'body': sys.argv[2]}
+})
+r = subprocess.run(['curl', '-s', '-X', 'POST', '$LINEAR_ENDPOINT',
+    '-H', 'Content-Type: application/json',
+    '-H', 'Authorization: $(echo $(_linear_key))',
+    '-d', payload], capture_output=True, text=True)
+print(r.stdout)
+" "$issue_id" "$body"
+}
+
+linear_list_teams() {
+  _linear_gql '{ teams { nodes { id name key } } }'
+}
+
+linear_list_projects() {
+  local first="${1:-50}"
+  _linear_gql '
+    query($first: Int) {
+      projects(first: $first) {
+        nodes { id name state }
+      }
+    }
+  ' "$(jq -n --argjson first "$first" '{first: $first}')"
+}

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -2,6 +2,7 @@
 backend/app/services/github_service.py
 GitHub API 서비스 (PyGithub 기반)
 """
+import asyncio
 import logging
 import re
 
@@ -292,24 +293,22 @@ class GitHubService:
         candidate_name: str | None = None,
     ) -> dict:
         """
-        GitHub URL들에서 후보자 개인 username 확인
-
-        ⚠️ 개인 계정(User) URL만 사용. Organization URL은 무시.
-        임의 추론(기여자 분석)은 하지 않음 - 신뢰성 문제.
+        GitHub URL들에서 후보자 개인 username 확인 + 조직 레포 기여자 매칭
 
         Strategy:
         1. URL에서 owner 추출
         2. owner가 User인지 Organization인지 확인
-        3. User 계정만 유효한 것으로 처리
-        4. Organization URL은 건너뜀 (code_analysis 대상에서 제외)
+        3. Organization → Contributors API로 candidate_name 매칭 (Stage 3)
+        4. 매칭 성공 시 confidence: "medium", 실패 시 confidence: "low"
 
         Returns:
             {
                 "username": str | None,
-                "confidence": "high" | "none",
+                "confidence": "high" | "medium" | "low" | "none",
                 "source": str,
-                "personal_repos": list[str],  # 개인 레포 URL만
-                "skipped_org_repos": list[str],  # 건너뛴 조직 레포
+                "personal_repos": list[str],
+                "skipped_org_repos": list[str],  # 하위 호환
+                "org_repos": list[dict],  # [{"url", "candidate_username", "confidence"}]
             }
         """
         if not github_urls:
@@ -319,10 +318,12 @@ class GitHubService:
                 "source": "no_urls",
                 "personal_repos": [],
                 "skipped_org_repos": [],
+                "org_repos": [],
             }
 
         personal_repos = []
         skipped_org_repos = []
+        org_repos = []
         found_username = None
 
         for url in github_urls[:10]:  # 최대 10개 URL 처리
@@ -333,22 +334,58 @@ class GitHubService:
             account_info = await self.get_account_type(owner)
 
             if account_info["type"] == "User":
-                # 개인 계정 → 유효
+                # Stage 1-2: 개인 계정 → 유효
                 personal_repos.append(url)
                 if not found_username:
                     found_username = owner
                     logger.info(f"Found personal GitHub account: {owner} from {url}")
 
             elif account_info["type"] == "Organization":
-                # 조직 계정 → 건너뜀 (임의 추론 안 함)
-                skipped_org_repos.append(url)
-                logger.info(f"Skipping organization repo (no inference): {owner} from {url}")
+                # Stage 3: 조직 레포 → Contributors API 매칭 시도
+                skipped_org_repos.append(url)  # 하위 호환 유지
+                org_entry = {
+                    "url": url,
+                    "candidate_username": None,
+                    "confidence": "low",
+                }
+
+                if candidate_name:
+                    try:
+                        match = await self.infer_candidate_from_contributors(
+                            repo_url=url,
+                            candidate_name=candidate_name,
+                        )
+                        if match:
+                            org_entry["candidate_username"] = match["username"]
+                            org_entry["confidence"] = "medium"
+                            org_entry["contributions"] = match["contributions"]
+                            if not found_username:
+                                found_username = match["username"]
+                            logger.info(
+                                f"Org repo contributor match: {match['username']} "
+                                f"in {url} ({match['contributions']} contributions)"
+                            )
+                        else:
+                            logger.info(
+                                f"No contributor match for '{candidate_name}' in {url}"
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            f"Contributor matching failed for {url}: {e}"
+                        )
+                else:
+                    logger.info(
+                        f"Skipping org repo (no candidate_name for matching): {url}"
+                    )
+
+                org_repos.append(org_entry)
 
             else:
                 # unknown (API 실패 등) → 건너뜀
                 skipped_org_repos.append(url)
                 logger.warning(f"Unknown account type for {owner}, skipping: {url}")
 
+        # 결과 결정
         if found_username and personal_repos:
             return {
                 "username": found_username,
@@ -356,6 +393,20 @@ class GitHubService:
                 "source": f"personal_repo:{personal_repos[0]}",
                 "personal_repos": personal_repos,
                 "skipped_org_repos": skipped_org_repos,
+                "org_repos": org_repos,
+            }
+
+        if found_username and org_repos:
+            matched_org = next(
+                (r for r in org_repos if r["candidate_username"]), None
+            )
+            return {
+                "username": found_username,
+                "confidence": "medium",
+                "source": f"org_contributor:{matched_org['url']}" if matched_org else "org_repo",
+                "personal_repos": personal_repos,
+                "skipped_org_repos": skipped_org_repos,
+                "org_repos": org_repos,
             }
 
         return {
@@ -364,6 +415,7 @@ class GitHubService:
             "source": "no_personal_repos",
             "personal_repos": [],
             "skipped_org_repos": skipped_org_repos,
+            "org_repos": org_repos,
         }
 
     def _extract_owner(self, url: str) -> str | None:
@@ -417,3 +469,146 @@ class GitHubService:
                 return True
 
         return False
+
+    async def infer_candidate_from_contributors(
+        self,
+        repo_url: str,
+        candidate_name: str,
+    ) -> dict | None:
+        """
+        레포 Contributors API에서 후보자 이름 매칭
+
+        Args:
+            repo_url: GitHub 레포 URL
+            candidate_name: 후보자 이름 (LinkedIn full_name 등)
+
+        Returns:
+            매칭 시: {"username": str, "contributions": int}
+            미매칭 시: None
+        """
+        import httpx
+
+        contributors = await self.get_repo_contributors(repo_url, limit=10)
+        if not contributors:
+            return None
+
+        for contrib in contributors:
+            username = contrib.get("username")
+            if not username:
+                continue
+
+            # GitHub 프로필에서 display name 조회
+            try:
+                g = self._get_github()
+                user = g.get_user(username)
+                display_name = user.name
+            except Exception:
+                # Fallback: 인증 없이 조회
+                try:
+                    async with httpx.AsyncClient(timeout=5.0) as client:
+                        resp = await client.get(
+                            f"https://api.github.com/users/{username}",
+                            headers={"Accept": "application/vnd.github.v3+json"},
+                        )
+                        if resp.status_code == 200:
+                            display_name = resp.json().get("name")
+                        else:
+                            display_name = None
+                except Exception:
+                    display_name = None
+
+            if display_name and self._names_match(candidate_name, display_name):
+                logger.info(
+                    f"Contributor match: {username} ({display_name}) "
+                    f"≈ {candidate_name} in {repo_url}"
+                )
+                return {
+                    "username": username,
+                    "contributions": contrib.get("contributions", 0),
+                }
+
+        return None
+
+    @staticmethod
+    async def extract_git_authors(clone_dir: str, limit: int = 20) -> list[dict]:
+        """
+        git shortlog에서 커밋 작성자 목록 추출
+
+        Args:
+            clone_dir: shallow clone 디렉토리 경로
+            limit: 최대 반환 수
+
+        Returns:
+            [{"name": str, "email": str, "commits": int}, ...]
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "git", "-C", clone_dir, "shortlog", "-sne", "--all",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            if proc.returncode != 0:
+                return []
+
+            authors = []
+            for line in stdout.decode("utf-8", errors="replace").strip().splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                # 형식: "  123\tName <email>"
+                match = re.match(r'(\d+)\t(.+?)\s+<(.+?)>', line)
+                if match:
+                    authors.append({
+                        "name": match.group(2).strip(),
+                        "email": match.group(3).strip(),
+                        "commits": int(match.group(1)),
+                    })
+            return authors[:limit]
+        except Exception as e:
+            logger.warning(f"extract_git_authors failed for {clone_dir}: {e}")
+            return []
+
+    async def match_candidate_from_git_log(
+        self,
+        clone_dir: str,
+        candidate_name: str,
+    ) -> dict | None:
+        """
+        git log 작성자에서 후보자 이름 매칭
+
+        Args:
+            clone_dir: shallow clone 디렉토리 경로
+            candidate_name: 후보자 이름
+
+        Returns:
+            매칭 시: {"name": str, "email": str, "commits": int, "username": str | None}
+            미매칭 시: None
+        """
+        authors = await self.extract_git_authors(clone_dir)
+        if not authors:
+            return None
+
+        for author in authors:
+            if self._names_match(candidate_name, author["name"]):
+                # noreply email에서 username 추출 시도
+                username = None
+                email = author.get("email", "")
+                noreply_match = re.match(
+                    r'(\d+\+)?(.+?)@users\.noreply\.github\.com', email
+                )
+                if noreply_match:
+                    username = noreply_match.group(2)
+
+                logger.info(
+                    f"Git log match: {author['name']} <{email}> "
+                    f"≈ {candidate_name} (username={username})"
+                )
+                return {
+                    "name": author["name"],
+                    "email": email,
+                    "commits": author["commits"],
+                    "username": username,
+                }
+
+        return None

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -309,6 +309,15 @@ async def analyze_single_repo(
     analyzer = CodeAnalyzer()
     repo_url = repo_info.get("url", "")
     repo_name = repo_info.get("name", "unknown")
+    candidate_name = repo_info.get("_candidate_name")  # git log fallback용
+
+    # 후보자 식별 메타데이터 초기화
+    candidate_identification = {
+        "method": "provided" if candidate_username else "none",
+        "confidence": "high" if candidate_username else "low",
+        "original_username": candidate_username,
+        "resolved_username": candidate_username,
+    }
 
     # Activity Logger 초기화
     alog = ActivityLogger(job_id, "analyze_single_repo", "analyzing") if job_id else None
@@ -330,6 +339,50 @@ async def analyze_single_repo(
         logger.warning(f"Shallow clone failed for {repo_name} (non-fatal): {e}")
 
     try:
+        # ================================================================
+        # Stage 4: Git log fallback — candidate_username 미제공 시
+        # ================================================================
+        if not candidate_username and candidate_name and clone_dir:
+            activity.heartbeat(f"Git log fallback for {repo_name}")
+            try:
+                from app.services.github_service import GitHubService
+                github_svc = GitHubService()
+                git_match = await github_svc.match_candidate_from_git_log(
+                    clone_dir=clone_dir,
+                    candidate_name=candidate_name,
+                )
+                if git_match:
+                    # PyDriller author 필터용: author name 사용
+                    candidate_username = git_match["name"]
+                    candidate_identification = {
+                        "method": "git_log",
+                        "confidence": "medium",
+                        "original_username": None,
+                        "resolved_username": git_match.get("username"),
+                        "matched_author": git_match["name"],
+                        "matched_email": git_match["email"],
+                        "matched_commits": git_match["commits"],
+                    }
+                    logger.info(
+                        f"Git log fallback matched: {git_match['name']} "
+                        f"for {repo_name}"
+                    )
+            except Exception as e:
+                logger.warning(f"Git log fallback failed for {repo_name}: {e}")
+
+        # Stage 5: 모든 식별 실패 시 → 전체 분석
+        if not candidate_username:
+            candidate_identification = {
+                "method": "none",
+                "confidence": "low",
+                "original_username": None,
+                "resolved_username": None,
+            }
+            logger.warning(
+                f"No candidate identified for {repo_name} — "
+                f"analyzing all commits (confidence: low)"
+            )
+
         # ================================================================
         # Phase 2: PyDriller - diff 추출 (클론 자동 처리)
         # ================================================================
@@ -534,6 +587,8 @@ async def analyze_single_repo(
             "quality_metrics": quality_metrics,
             # 정적 분석 결과 (KG/Scoring에서 활용)
             "static_analysis": static_analysis,
+            # 후보자 식별 메타데이터
+            "candidate_identification": candidate_identification,
             # HYBRID 분석 메타데이터
             "hybrid_metadata": {
                 "key_files_count": len(key_files),

--- a/backend/app/workflows/activities/input_enrichment.py
+++ b/backend/app/workflows/activities/input_enrichment.py
@@ -126,11 +126,17 @@ async def enrich_input(input_data: dict) -> dict:
             extracted_urls["github"].add(linkedin_profile["github_url"])
             extraction_sources.setdefault("github_urls", []).append("linkedin")
 
-    # 6. GitHub username 확인 (개인 계정만, Organization은 무시)
+    # 6. GitHub username 확인 (개인 계정 + 조직 레포 기여자 매칭)
     github_urls = list(extracted_urls["github"])
     candidate_username = input_data.get("candidate_github_username")
     username_inference = None
     personal_github_urls = []  # code_analysis에 실제 사용할 URL
+    org_github_urls = []  # candidate가 식별된 org repos
+
+    # candidate_name 추출 (LinkedIn full_name → git log fallback용)
+    candidate_name = None
+    if linkedin_profile:
+        candidate_name = linkedin_profile.get("full_name") or linkedin_profile.get("name")
 
     if github_urls:
         activity.heartbeat("Validating GitHub URLs (User vs Organization)...")
@@ -140,7 +146,7 @@ async def enrich_input(input_data: dict) -> dict:
 
             username_inference = await github_svc.infer_candidate_username(
                 github_urls=github_urls,
-                candidate_name=linkedin_profile.get("full_name") if linkedin_profile else None,
+                candidate_name=candidate_name,
             )
 
             # 개인 레포 URL만 사용
@@ -150,10 +156,19 @@ async def enrich_input(input_data: dict) -> dict:
             if not candidate_username:
                 candidate_username = username_inference.get("username")
 
+            # 조직 레포 중 candidate가 식별된 것들 수집
+            for org_repo in username_inference.get("org_repos", []):
+                if org_repo.get("candidate_username"):
+                    org_github_urls.append(org_repo)
+
             # 건너뛴 조직 레포 로깅
             skipped = username_inference.get("skipped_org_repos", [])
             if skipped:
-                logger.info(f"Skipped {len(skipped)} organization repos (no inference)")
+                matched_count = len(org_github_urls)
+                logger.info(
+                    f"Organization repos: {len(skipped)} total, "
+                    f"{matched_count} with candidate match"
+                )
 
         except Exception as e:
             logger.warning(f"GitHub URL validation failed: {e}")
@@ -164,19 +179,22 @@ async def enrich_input(input_data: dict) -> dict:
     available = ["jd_analysis"]  # JD는 항상
     if any(input_data.get(k) for k in ("resume_path", "portfolio_path", "cover_letter_path")) or linkedin_profile:
         available.append("document_analysis")
-    # code_analysis는 개인 레포가 있을 때만 (조직 레포만 있으면 제외)
-    if personal_github_urls:
+    # code_analysis: 개인 레포가 있거나 org repos에 candidate가 식별되면 활성화
+    if personal_github_urls or org_github_urls:
         available.append("code_analysis")
 
     # Debug logging for troubleshooting
     logger.info(f"[Enrichment] personal_github_urls: {personal_github_urls}")
+    logger.info(f"[Enrichment] org_github_urls: {org_github_urls}")
     logger.info(f"[Enrichment] available_analyses: {available}")
 
     return {
         "raw_input": input_data,
-        "github_urls": personal_github_urls,  # 개인 레포만 (조직 레포 제외)
+        "github_urls": personal_github_urls,  # 개인 레포만
+        "org_github_urls": org_github_urls,  # candidate 식별된 org repos
         "all_extracted_github_urls": github_urls,  # 원본 전체 (로깅/디버깅용)
         "candidate_github_username": candidate_username,
+        "candidate_name": candidate_name,  # git log fallback용
         "github_validation": username_inference,  # 검증 상세 정보
         "linkedin_profile": linkedin_profile,
         "extraction_sources": extraction_sources,

--- a/backend/app/workflows/workflow_code_analysis.py
+++ b/backend/app/workflows/workflow_code_analysis.py
@@ -35,14 +35,32 @@ async def run_parallel_code_analysis(
     Step 4: 실패한 레포 재분석 (최대 1회)
     Step 5: 결과 집계
     """
-    github_urls = enriched.get("github_urls", [])
-    if not github_urls:
+    # 버그 수정: enriched에서 candidate_github_username 읽기 (기존: raw_input에서 읽어 누락)
+    candidate_username = enriched.get("candidate_github_username")
+    candidate_name = enriched.get("candidate_name")
+
+    # enriched_input_data 구성: raw_input + enriched에서 추론된 username 병합
+    enriched_input_data = {**raw_input, "candidate_github_username": candidate_username}
+
+    # org repos 병합: personal repos + candidate 식별된 org repos
+    personal_github_urls = enriched.get("github_urls", [])
+    org_repo_entries = enriched.get("org_github_urls", [])
+    org_repo_urls = [r["url"] for r in org_repo_entries if r.get("url")]
+    all_github_urls = personal_github_urls + org_repo_urls
+
+    # per-repo candidate_username 매핑 (org repos는 개별 username 사용)
+    repo_candidate_map = {}
+    for entry in org_repo_entries:
+        if entry.get("url") and entry.get("candidate_username"):
+            repo_candidate_map[entry["url"]] = entry["candidate_username"]
+
+    if not all_github_urls:
         return {"repositories": [], "top_question_candidates": []}
 
     # Step 1: Manager가 레포 필터링 + 분석
     manager_result = await workflow.execute_activity(
         analyze_code,
-        args=[github_urls, raw_input, execution_plan],
+        args=[all_github_urls, enriched_input_data, execution_plan],
         start_to_close_timeout=timedelta(minutes=15),
         heartbeat_timeout=timedelta(seconds=120),
         retry_policy=EXTERNAL_API_RETRY,
@@ -62,14 +80,23 @@ async def run_parallel_code_analysis(
         return manager_result
 
     jd_tech_stack = manager_result.get("jd_tech_stack", [])
-    candidate_username = manager_result.get("candidate_username")
+    # manager_result의 candidate_username보다 enriched에서 추론된 것이 우선
+    if not candidate_username:
+        candidate_username = manager_result.get("candidate_username")
 
     # Step 2: 각 레포 병렬 분석 (Sub-Agents)
     repo_tasks = []
     for repo in target_repos:
+        # per-repo candidate_username 적용 (org repos는 개별 username 사용)
+        repo_url = repo.get("url", "")
+        per_repo_username = repo_candidate_map.get(repo_url, candidate_username)
+
+        # _candidate_name 주입 → git log fallback용
+        repo_with_meta = {**repo, "_candidate_name": candidate_name}
+
         task = workflow.execute_activity(
             analyze_single_repo,
-            args=[repo, jd_tech_stack, candidate_username, job_id],
+            args=[repo_with_meta, jd_tech_stack, per_repo_username, job_id],
             start_to_close_timeout=timedelta(minutes=10),
             heartbeat_timeout=timedelta(seconds=120),
             retry_policy=RetryPolicy(


### PR DESCRIPTION
## Summary
- 코드 분석 파이프라인에서 조직(Org) 레포 후보자를 Contributors API + git log fallback으로 식별
- `enriched`에서 `candidate_github_username`을 읽지 않던 전파 버그 수정
- 모든 레포 분석 결과에 `candidate_identification` 메타데이터(method, confidence) 포함

## 수정 파일 (6개)

| 파일 | 변경 내용 |
|------|----------|
| `backend/app/services/github_service.py` | `infer_candidate_from_contributors()`, `extract_git_authors()`, `match_candidate_from_git_log()` 신규 + `infer_candidate_username()` Stage 3 확장 |
| `backend/app/workflows/activities/input_enrichment.py` | org repos 조건부 포함, `candidate_name` 전파, `org_github_urls` 반환 |
| `backend/app/workflows/workflow_code_analysis.py` | enriched에서 username 읽기 버그 수정, org repos 병합, per-repo candidate 적용 |
| `backend/app/workflows/activities/code_analysis.py` | git log fallback (Stage 4-5), `candidate_identification` 메타데이터 |
| `.claude/skills/linear-ops/linear-api.sh` | `linear_add_comment()` 함수 추가 |
| `.claude/skills/linear-ops/SKILL.md` | 코멘트 추가 사용법 문서화 |

## Test plan
- [x] Docker 컨테이너: 491 passed, 4 skipped (코드 변경 관련 회귀 0건)
- [x] 관련 테스트 58개 전체 통과 (`-k "enrichment or code_analysis or github"`)
- [ ] 개인 레포 URL → 기존과 동일 동작 확인
- [ ] 조직 레포 URL + LinkedIn 이름 → Contributors API 매칭 확인
- [ ] username 미제공 + 개인 레포 → URL 기반 자동 추론 확인
- [ ] 모든 식별 실패 → 전체 분석 + confidence: "low" 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)