### PR TITLE
feat: 코드 분석 파이프라인 통합 — Phase 재설계 + LLM 입력 정제

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -46,6 +46,7 @@ class Settings(BaseSettings):
     # GitHub
     GITHUB_TOKEN: str | None = None
     GITHUB_ANALYSIS_YEARS: int = 1  # 분석 기간 (기본 1년, 최대 3년 권장)
+    USE_AST_PIPELINE: bool = True  # JIT-24: AST+JD 파이프라인 (False면 기존 diff 기반)
 
     # LLM
     OPENAI_API_KEY: str | None = None

--- a/backend/app/models/analysis.py
+++ b/backend/app/models/analysis.py
@@ -328,6 +328,20 @@ class HybridAnalysisMetadata(BaseModel):
     analysis_duration_ms: int | None = Field(default=None, description="분석 소요 시간 (밀리초)")
 
 
+class ChunkRelevanceScore(BaseModel):
+    """JD-Aware 청크 관련성 점수 (JIT-22)"""
+    chunk_name: str = Field(description="청크 이름 (함수/클래스명)")
+    chunk_type: str = Field(default="function", description="청크 타입 (function/class)")
+    file_path: str = Field(default="", description="파일 경로")
+    jd_keyword_score: float = Field(ge=0.0, le=1.0, description="JD 키워드 매칭 점수")
+    complexity_score: float = Field(ge=0.0, le=1.0, description="구조적 복잡도 점수")
+    interview_potential: float = Field(ge=0.0, le=1.0, description="면접 잠재력 점수")
+    contributor_score: float = Field(ge=0.0, le=1.0, description="후보자 기여 점수")
+    total_score: float = Field(ge=0.0, le=1.0, description="가중 합산 총점")
+    char_count: int = Field(default=0, description="소스 코드 문자 수")
+    evidence: list[str] = Field(default_factory=list, description="점수 근거")
+
+
 class CodeAnalysisValidation(BaseModel):
     """코드 분석 결과 품질 검증"""
     valid: bool = Field(description="검증 통과 여부")

--- a/backend/app/services/ast_analyzer.py
+++ b/backend/app/services/ast_analyzer.py
@@ -3,10 +3,29 @@ backend/app/services/ast_analyzer.py
 AST 구조 분석 (Python: ast, JS/TS: tree-sitter, fallback)
 
 Extracted from code_analyzer.py for SRP compliance.
+
+JIT-21/24: analyze_directory() — clone_dir에서 직접 AST 파싱 + 청크 메타데이터 추출
 """
 import logging
+import os
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# analyze_directory 지원 확장자
+_SUPPORTED_EXTENSIONS: dict[str, str] = {
+    ".py": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".java": "java",
+    ".go": "go",
+    ".rs": "rust",
+}
+
+# 제외 디렉토리
+_EXCLUDE_DIRS = {".git", "__pycache__", "node_modules", ".venv", "venv", ".tox", "dist", "build"}
 
 
 async def analyze_ast(
@@ -199,3 +218,327 @@ def _walk_ts_node(
 
     for child in node.children:
         _walk_ts_node(child, functions, classes, imports, file_info)
+
+
+# =========================================================================
+# analyze_directory — clone_dir에서 직접 AST 파싱 + 청크 메타데이터 추출 (JIT-21/24)
+# =========================================================================
+
+
+def analyze_directory(
+    clone_dir: str,
+    file_types: list[str] | None = None,
+    max_files: int = 50,
+    max_chunk_chars: int = 10_000,
+) -> list[dict]:
+    """clone_dir에서 소스 파일을 읽어 함수/클래스 단위 청크를 추출
+
+    chunk_scorer.rank_chunks_by_relevance()의 입력 포맷:
+    {name, type, file_path, source_code, identifiers, imports, decorators, char_count}
+
+    Args:
+        clone_dir: shallow clone 디렉토리 경로
+        file_types: 분석 대상 확장자 (예: [".py", ".ts"]). None이면 전체 지원 언어.
+        max_files: 최대 분석 파일 수
+        max_chunk_chars: 청크별 최대 문자 수
+
+    Returns:
+        청크 dict 리스트
+    """
+    ext_set = set(file_types) if file_types else set(_SUPPORTED_EXTENSIONS.keys())
+    # 지원 언어만 필터
+    ext_set = ext_set & set(_SUPPORTED_EXTENSIONS.keys())
+    if not ext_set:
+        ext_set = {".py"}
+
+    # 파일 수집 (크기 역순 = 큰 파일 우선)
+    candidates: list[tuple[int, str, str]] = []
+    for root, dirs, filenames in os.walk(clone_dir):
+        dirs[:] = [d for d in dirs if d not in _EXCLUDE_DIRS]
+        for fname in filenames:
+            ext = Path(fname).suffix.lower()
+            if ext not in ext_set:
+                continue
+            abs_path = os.path.join(root, fname)
+            try:
+                fsize = os.path.getsize(abs_path)
+            except OSError:
+                continue
+            if fsize == 0 or fsize > 200_000:
+                continue
+            rel_path = os.path.relpath(abs_path, clone_dir)
+            candidates.append((fsize, rel_path, abs_path))
+
+    candidates.sort(key=lambda x: x[0], reverse=True)
+
+    chunks: list[dict] = []
+    files_processed = 0
+
+    for _, rel_path, abs_path in candidates:
+        if files_processed >= max_files:
+            break
+        try:
+            with open(abs_path, "r", encoding="utf-8", errors="ignore") as fh:
+                source = fh.read()
+        except OSError:
+            continue
+
+        ext = Path(rel_path).suffix.lower()
+        lang = _SUPPORTED_EXTENSIONS.get(ext, "")
+        file_chunks = _extract_chunks(source, rel_path, lang, max_chunk_chars)
+        chunks.extend(file_chunks)
+        files_processed += 1
+
+    logger.info(f"analyze_directory: {files_processed} files → {len(chunks)} chunks from {clone_dir}")
+    return chunks
+
+
+def _extract_chunks(
+    source: str,
+    file_path: str,
+    lang: str,
+    max_chars: int,
+) -> list[dict]:
+    """소스 코드에서 함수/클래스 단위 청크 추출"""
+    if lang == "python":
+        return _extract_python_chunks(source, file_path, max_chars)
+    # JS/TS: tree-sitter 사용 시도, 실패 시 전체 파일을 하나의 청크로
+    if lang in ("javascript", "typescript"):
+        ts_chunks = _extract_ts_chunks(source, file_path, lang, max_chars)
+        if ts_chunks:
+            return ts_chunks
+    # 기타 언어 또는 파서 실패: 파일 전체를 하나의 청크로
+    return _file_level_chunk(source, file_path, max_chars)
+
+
+def _extract_python_chunks(
+    source: str,
+    file_path: str,
+    max_chars: int,
+) -> list[dict]:
+    """Python AST로 함수/클래스 청크 추출"""
+    import ast as ast_mod
+
+    chunks: list[dict] = []
+    lines = source.splitlines(keepends=True)
+
+    # 파일 레벨 imports 수집
+    file_imports: list[str] = []
+    try:
+        tree = ast_mod.parse(source)
+    except SyntaxError:
+        return _file_level_chunk(source, file_path, max_chars)
+
+    for node in ast_mod.iter_child_nodes(tree):
+        if isinstance(node, ast_mod.Import):
+            for alias in node.names:
+                file_imports.append(f"import {alias.name}")
+        elif isinstance(node, ast_mod.ImportFrom):
+            file_imports.append(f"from {node.module or ''} import ...")
+
+    for node in ast_mod.iter_child_nodes(tree):
+        if isinstance(node, (ast_mod.FunctionDef, ast_mod.AsyncFunctionDef)):
+            chunk_source = ast_mod.get_source_segment(source, node) or ""
+            if not chunk_source:
+                # fallback: 줄 번호 기반
+                start = node.lineno - 1
+                end = node.end_lineno or (start + 1)
+                chunk_source = "".join(lines[start:end])
+            chunk_source = chunk_source[:max_chars]
+
+            decorators = []
+            for d in node.decorator_list:
+                if isinstance(d, ast_mod.Name):
+                    decorators.append(d.id)
+                elif isinstance(d, ast_mod.Attribute):
+                    decorators.append(ast_mod.unparse(d))
+                else:
+                    decorators.append(ast_mod.unparse(d))
+
+            identifiers = _extract_python_identifiers(node)
+
+            chunks.append({
+                "name": node.name,
+                "type": "function",
+                "file_path": file_path,
+                "source_code": chunk_source,
+                "identifiers": identifiers,
+                "imports": file_imports,
+                "decorators": decorators,
+                "char_count": len(chunk_source),
+            })
+
+        elif isinstance(node, ast_mod.ClassDef):
+            chunk_source = ast_mod.get_source_segment(source, node) or ""
+            if not chunk_source:
+                start = node.lineno - 1
+                end = node.end_lineno or (start + 1)
+                chunk_source = "".join(lines[start:end])
+            chunk_source = chunk_source[:max_chars]
+
+            decorators = []
+            for d in node.decorator_list:
+                if isinstance(d, ast_mod.Name):
+                    decorators.append(d.id)
+                elif isinstance(d, ast_mod.Attribute):
+                    decorators.append(ast_mod.unparse(d))
+                else:
+                    decorators.append(ast_mod.unparse(d))
+
+            identifiers = _extract_python_identifiers(node)
+
+            chunks.append({
+                "name": node.name,
+                "type": "class",
+                "file_path": file_path,
+                "source_code": chunk_source,
+                "identifiers": identifiers,
+                "imports": file_imports,
+                "decorators": decorators,
+                "char_count": len(chunk_source),
+            })
+
+    if not chunks:
+        return _file_level_chunk(source, file_path, max_chars)
+
+    return chunks
+
+
+def _extract_python_identifiers(node) -> list[str]:
+    """Python AST 노드에서 식별자(변수명, 호출명) 추출"""
+    import ast as ast_mod
+    identifiers: set[str] = set()
+    for child in ast_mod.walk(node):
+        if isinstance(child, ast_mod.Name):
+            identifiers.add(child.id)
+        elif isinstance(child, ast_mod.Attribute):
+            identifiers.add(child.attr)
+        elif isinstance(child, ast_mod.FunctionDef):
+            identifiers.add(child.name)
+        elif isinstance(child, ast_mod.AsyncFunctionDef):
+            identifiers.add(child.name)
+    return list(identifiers)[:50]
+
+
+def _extract_ts_chunks(
+    source: str,
+    file_path: str,
+    lang: str,
+    max_chars: int,
+) -> list[dict]:
+    """tree-sitter로 JS/TS 청크 추출. 실패 시 빈 리스트."""
+    try:
+        if lang == "typescript":
+            import tree_sitter_typescript as ts_ts
+            from tree_sitter import Language, Parser
+            language = Language(ts_ts.language_typescript())
+        else:
+            import tree_sitter_javascript as ts_js
+            from tree_sitter import Language, Parser
+            language = Language(ts_js.language())
+
+        parser = Parser(language)
+        tree = parser.parse(source.encode("utf-8"))
+    except (ImportError, Exception):
+        return []
+
+    file_imports: list[str] = []
+    chunks: list[dict] = []
+    _walk_ts_for_chunks(tree.root_node, source, file_path, file_imports, chunks, max_chars)
+    return chunks
+
+
+def _walk_ts_for_chunks(
+    node,
+    source: str,
+    file_path: str,
+    file_imports: list[str],
+    chunks: list[dict],
+    max_chars: int,
+) -> None:
+    """tree-sitter 노드에서 청크 추출"""
+    ntype = node.type
+
+    if ntype == "import_statement":
+        src_node = node.child_by_field_name("source")
+        if src_node:
+            file_imports.append(src_node.text.decode("utf-8").strip("'\""))
+
+    if ntype in ("function_declaration", "method_definition", "arrow_function"):
+        chunk_text = source[node.start_byte:node.end_byte][:max_chars]
+        name_node = node.child_by_field_name("name")
+        name = name_node.text.decode("utf-8") if name_node else "<anonymous>"
+
+        if ntype == "arrow_function" and node.parent and node.parent.type == "variable_declarator":
+            pname = node.parent.child_by_field_name("name")
+            if pname:
+                name = pname.text.decode("utf-8")
+
+        identifiers = _extract_ts_identifiers(node)
+        chunks.append({
+            "name": name,
+            "type": "function",
+            "file_path": file_path,
+            "source_code": chunk_text,
+            "identifiers": identifiers,
+            "imports": list(file_imports),
+            "decorators": [],
+            "char_count": len(chunk_text),
+        })
+        return  # 중첩 함수는 별도 추출하지 않음
+
+    if ntype == "class_declaration":
+        chunk_text = source[node.start_byte:node.end_byte][:max_chars]
+        name_node = node.child_by_field_name("name")
+        name = name_node.text.decode("utf-8") if name_node else "<anonymous>"
+        identifiers = _extract_ts_identifiers(node)
+        chunks.append({
+            "name": name,
+            "type": "class",
+            "file_path": file_path,
+            "source_code": chunk_text,
+            "identifiers": identifiers,
+            "imports": list(file_imports),
+            "decorators": [],
+            "char_count": len(chunk_text),
+        })
+        return
+
+    for child in node.children:
+        _walk_ts_for_chunks(child, source, file_path, file_imports, chunks, max_chars)
+
+
+def _extract_ts_identifiers(node) -> list[str]:
+    """tree-sitter 노드에서 식별자 추출"""
+    identifiers: set[str] = set()
+
+    def _walk(n):
+        if n.type == "identifier":
+            identifiers.add(n.text.decode("utf-8"))
+        for child in n.children:
+            _walk(child)
+
+    _walk(node)
+    return list(identifiers)[:50]
+
+
+def _file_level_chunk(
+    source: str,
+    file_path: str,
+    max_chars: int,
+) -> list[dict]:
+    """파일 전체를 단일 청크로 반환 (파서 실패 / 비지원 언어 fallback)"""
+    if not source.strip():
+        return []
+    truncated = source[:max_chars]
+    name = Path(file_path).stem
+    return [{
+        "name": f"file:{name}",
+        "type": "module",
+        "file_path": file_path,
+        "source_code": truncated,
+        "identifiers": [],
+        "imports": [],
+        "decorators": [],
+        "char_count": len(truncated),
+    }]

--- a/backend/app/services/chunk_scorer.py
+++ b/backend/app/services/chunk_scorer.py
@@ -1,0 +1,324 @@
+"""
+backend/app/services/chunk_scorer.py
+JD-Aware Chunk Relevance Scoring Engine [JIT-22]
+
+청크(함수/클래스) 수준의 JD 관련성 스코어링.
+analyze_directory() (JIT-21)가 추출한 청크 메타데이터를 활용.
+
+Score = JD키워드매칭(40%) + 구조적복잡도(25%) + 면접잠재력(20%) + 후보자기여(15%)
+"""
+from __future__ import annotations
+
+import logging
+import math
+
+from app.services.scoring_formulas import _fuzzy_skill_match
+
+logger = logging.getLogger(__name__)
+
+# 스코어 가중치
+WEIGHT_JD_KEYWORD = 0.40
+WEIGHT_COMPLEXITY = 0.25
+WEIGHT_INTERVIEW = 0.20
+WEIGHT_CONTRIBUTOR = 0.15
+
+# 면접 잠재력 감지 패턴 (키워드 → 점수 기여)
+_INTERVIEW_PATTERNS: dict[str, float] = {
+    # 에러 핸들링
+    "try": 0.15,
+    "except": 0.15,
+    "catch": 0.15,
+    "finally": 0.10,
+    # 비동기
+    "async": 0.20,
+    "await": 0.15,
+    # API 데코레이터
+    "app.get": 0.20,
+    "app.post": 0.20,
+    "app.put": 0.15,
+    "app.delete": 0.15,
+    "router.get": 0.20,
+    "router.post": 0.20,
+    # 디자인 패턴 키워드
+    "singleton": 0.25,
+    "factory": 0.20,
+    "observer": 0.20,
+    "strategy": 0.20,
+    "decorator": 0.15,
+    "repository": 0.15,
+    # 제어 흐름 복잡성
+    "yield": 0.15,
+    "generator": 0.15,
+    "recursion": 0.15,
+    # 테스트 관련
+    "pytest": 0.10,
+    "unittest": 0.10,
+    "mock": 0.10,
+}
+
+# CC 정규화 범위
+_CC_MIN = 1.0
+_CC_MAX = 30.0
+
+
+def _calculate_jd_keyword_score(
+    chunk: dict,
+    jd_tech_stack: list[str],
+) -> tuple[float, list[str]]:
+    """JD 키워드 매칭 점수 (0.0-1.0)
+
+    chunk의 identifiers, imports, decorators를 jd_tech_stack과 퍼지 매칭.
+
+    Returns:
+        (score, evidence_list)
+    """
+    if not jd_tech_stack:
+        return 0.0, []
+
+    identifiers = set(chunk.get("identifiers", []))
+    imports = set(chunk.get("imports", []))
+    decorators = set(chunk.get("decorators", []))
+
+    # 모든 청크 토큰을 하나의 집합으로 합침
+    all_tokens: set[str] = set()
+    for ident in identifiers:
+        all_tokens.add(ident.lower())
+    for imp in imports:
+        # import 문에서 모듈명 추출 (예: "from fastapi import ..." → "fastapi")
+        for part in imp.lower().replace("from ", "").replace("import ", "").split():
+            all_tokens.add(part.strip(",").strip())
+    for dec in decorators:
+        for part in dec.lower().split("."):
+            all_tokens.add(part.strip())
+
+    matched_count = 0
+    evidence: list[str] = []
+
+    for jd_skill in jd_tech_stack:
+        best_score = 0.0
+        best_token = ""
+
+        for token in all_tokens:
+            score = _fuzzy_skill_match(jd_skill, token)
+            if score > best_score:
+                best_score = score
+                best_token = token
+                if score >= 1.0:
+                    break
+
+        if best_score >= 0.6:
+            matched_count += 1
+            evidence.append(f"JD '{jd_skill}' ↔ '{best_token}' ({best_score:.1f})")
+
+    score = matched_count / max(len(jd_tech_stack), 1)
+    return min(1.0, score), evidence
+
+
+def _calculate_complexity_score(
+    chunk: dict,
+) -> tuple[float, list[str]]:
+    """구조적 복잡도 점수 (0.0-1.0)
+
+    Lizard CC 사용 가능 시 정규화, 아니면 라인수 휴리스틱.
+
+    Returns:
+        (score, evidence_list)
+    """
+    source_code = chunk.get("source_code", "")
+    evidence: list[str] = []
+
+    # Lizard CC 계산 시도
+    cc_value = _get_lizard_cc(source_code)
+    if cc_value is not None and cc_value > 0:
+        # CC 1~30 → 0.0~1.0 정규화
+        normalized = min(1.0, max(0.0, (cc_value - _CC_MIN) / (_CC_MAX - _CC_MIN)))
+        evidence.append(f"Lizard CC={cc_value:.1f} → {normalized:.2f}")
+        return normalized, evidence
+
+    # Fallback: 라인수 휴리스틱
+    line_count = len(source_code.splitlines()) if source_code else 0
+    if line_count <= 0:
+        return 0.0, ["source 없음"]
+
+    # 5~100줄 → 0.0~1.0 (log scale)
+    normalized = min(1.0, max(0.0, math.log10(max(line_count, 1)) / math.log10(100)))
+    evidence.append(f"라인수 휴리스틱: {line_count}줄 → {normalized:.2f}")
+    return normalized, evidence
+
+
+def _get_lizard_cc(source_code: str) -> float | None:
+    """Lizard로 소스 코드의 평균 CC를 계산. 실패 시 None."""
+    if not source_code or len(source_code) < 10:
+        return None
+
+    try:
+        import lizard
+        analysis = lizard.analyze_file.analyze_source_code("chunk.py", source_code)
+        if analysis.function_list:
+            avg_cc = sum(f.cyclomatic_complexity for f in analysis.function_list) / len(analysis.function_list)
+            return avg_cc
+    except Exception:
+        pass
+
+    return None
+
+
+def _calculate_interview_potential(
+    chunk: dict,
+) -> tuple[float, list[str]]:
+    """면접 잠재력 점수 (0.0-1.0)
+
+    패턴 감지: try/except, async, API decorator, 디자인 패턴 키워드 등.
+
+    Returns:
+        (score, evidence_list)
+    """
+    source_code = (chunk.get("source_code", "") or "").lower()
+    decorators = [d.lower() for d in chunk.get("decorators", [])]
+    identifiers = [i.lower() for i in chunk.get("identifiers", [])]
+    evidence: list[str] = []
+
+    raw_score = 0.0
+
+    # 소스 코드 기반 패턴 검색
+    for pattern, weight in _INTERVIEW_PATTERNS.items():
+        if pattern in source_code:
+            raw_score += weight
+            evidence.append(f"패턴 '{pattern}' 감지 (+{weight:.2f})")
+
+    # 데코레이터 기반 추가 점수
+    for dec in decorators:
+        for pattern, weight in _INTERVIEW_PATTERNS.items():
+            if pattern in dec:
+                raw_score += weight * 0.5  # 데코레이터 중복 방지용 0.5배
+                break
+
+    # 중첩 제어 흐름 (들여쓰기 깊이 휴리스틱)
+    lines = (chunk.get("source_code", "") or "").splitlines()
+    max_indent = 0
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped:
+            indent = len(line) - len(stripped)
+            max_indent = max(max_indent, indent)
+    if max_indent >= 16:  # 4단계 이상 중첩 (4스페이스 기준)
+        raw_score += 0.15
+        evidence.append(f"깊은 중첩 (indent={max_indent})")
+
+    # 0.0~1.0 클램핑 (raw가 1.0 초과 가능)
+    score = min(1.0, max(0.0, raw_score))
+    return score, evidence
+
+
+def calculate_chunk_score(
+    chunk: dict,
+    jd_tech_stack: list[str],
+    contributor_ratio: float | None = None,
+) -> ChunkRelevanceScore:
+    """단일 청크의 JD-Aware 관련성 점수 계산
+
+    Args:
+        chunk: analyze_directory() 반환 청크 dict
+            keys: name, type, identifiers, imports, decorators, source_code, char_count, file_path
+        jd_tech_stack: JD에서 추출한 기술 스택 키워드
+        contributor_ratio: 후보자 기여 비율 (0.0-1.0). None이면 기본값 0.5
+
+    Returns:
+        ChunkRelevanceScore
+    """
+    # 1. JD 키워드 매칭 (40%)
+    jd_score, jd_evidence = _calculate_jd_keyword_score(chunk, jd_tech_stack)
+
+    # 2. 구조적 복잡도 (25%)
+    cx_score, cx_evidence = _calculate_complexity_score(chunk)
+
+    # 3. 면접 잠재력 (20%)
+    ip_score, ip_evidence = _calculate_interview_potential(chunk)
+
+    # 4. 후보자 기여 (15%)
+    ct_score = contributor_ratio if contributor_ratio is not None else 0.5
+    ct_score = min(1.0, max(0.0, ct_score))
+    ct_evidence = [f"기여율: {ct_score:.2f}" + (" (기본값)" if contributor_ratio is None else "")]
+
+    # 가중 합산
+    total = (
+        jd_score * WEIGHT_JD_KEYWORD
+        + cx_score * WEIGHT_COMPLEXITY
+        + ip_score * WEIGHT_INTERVIEW
+        + ct_score * WEIGHT_CONTRIBUTOR
+    )
+    total = min(1.0, max(0.0, total))
+
+    all_evidence = jd_evidence + cx_evidence + ip_evidence + ct_evidence
+
+    from app.models.analysis import ChunkRelevanceScore
+    return ChunkRelevanceScore(
+        chunk_name=chunk.get("name", ""),
+        chunk_type=chunk.get("type", "function"),
+        file_path=chunk.get("file_path", ""),
+        jd_keyword_score=round(jd_score, 4),
+        complexity_score=round(cx_score, 4),
+        interview_potential=round(ip_score, 4),
+        contributor_score=round(ct_score, 4),
+        total_score=round(total, 4),
+        char_count=chunk.get("char_count", 0),
+        evidence=all_evidence,
+    )
+
+
+def rank_chunks_by_relevance(
+    chunks: list[dict],
+    jd_tech_stack: list[str],
+    token_budget: int = 50_000,
+    contributor_ratio: float | None = None,
+) -> list[dict]:
+    """청크를 JD 관련성 기준으로 랭킹 + 토큰 예산 내 선택
+
+    Knapsack 방식: 큰 청크 스킵 후에도 작은 고점수 청크 포함 가능.
+
+    Args:
+        chunks: analyze_directory() 반환 청크 리스트
+        jd_tech_stack: JD 기술 스택
+        token_budget: 토큰 예산 (char_count // 4 ≈ tokens)
+        contributor_ratio: 후보자 기여 비율
+
+    Returns:
+        원본 chunk dict + "relevance_score" 키 추가된 리스트 (점수 내림차순)
+    """
+    if not chunks:
+        return []
+
+    # 1. 모든 청크에 점수 계산
+    scored: list[tuple[ChunkRelevanceScore, dict]] = []
+    for chunk in chunks:
+        score = calculate_chunk_score(chunk, jd_tech_stack, contributor_ratio)
+        scored.append((score, chunk))
+
+    # 2. 점수 내림차순 정렬
+    scored.sort(key=lambda x: x[0].total_score, reverse=True)
+
+    # 3. 토큰 예산 내 선택 (Knapsack: 큰 청크 스킵 후 작은 것 계속 시도)
+    selected: list[dict] = []
+    used_tokens = 0
+
+    for score, chunk in scored:
+        est_tokens = chunk.get("char_count", 0) // 4
+        if est_tokens <= 0:
+            continue
+
+        if used_tokens + est_tokens > token_budget:
+            # 예산 초과하지만 계속 순회 (작은 청크가 뒤에 있을 수 있음)
+            continue
+
+        enriched = {
+            **chunk,
+            "relevance_score": score.model_dump(),
+        }
+        selected.append(enriched)
+        used_tokens += est_tokens
+
+    logger.info(
+        f"rank_chunks: {len(selected)}/{len(chunks)} chunks selected "
+        f"({used_tokens} est tokens, budget={token_budget})"
+    )
+    return selected

--- a/backend/app/services/code_analysis_prompts.py
+++ b/backend/app/services/code_analysis_prompts.py
@@ -3,6 +3,8 @@ backend/app/services/code_analysis_prompts.py
 HYBRID 3-Stage Multi-Agent 분석용 프롬프트 빌더
 
 Extracted from code_analyzer.py for SRP compliance.
+
+JIT-24: AST 청크 메타데이터 + 완전한 소스코드 입력 지원
 """
 
 
@@ -11,8 +13,17 @@ def build_overview_prompt(
     commit_diffs: list[dict],
     ast_summary: dict,
     jd_tech_stack: list[str],
+    ranked_chunks: list[dict] | None = None,
 ) -> str:
-    """Stage 1: Overview Agent 프롬프트 생성"""
+    """Stage 1: Overview Agent 프롬프트 생성
+
+    Args:
+        files: PyDriller로 추출한 파일 목록
+        commit_diffs: 커밋별 diff 데이터
+        ast_summary: AST 분석 결과
+        jd_tech_stack: JD에서 추출한 기술 스택
+        ranked_chunks: JD-Aware 랭킹된 청크 리스트 (JIT-24, optional)
+    """
     file_summary = "\n".join([
         f"- {f.get('filename', 'unknown')}: {f.get('added', 0)} additions, complexity={f.get('complexity', 0)}"
         for f in files[:30]
@@ -30,6 +41,32 @@ def build_overview_prompt(
         f"Parser: {ast_summary.get('parser_used', 'N/A')}"
     )
 
+    # JIT-24: 청크 메타데이터 섹션 (AST 파이프라인 활성 시)
+    chunk_section = ""
+    if ranked_chunks:
+        chunk_lines = []
+        for c in ranked_chunks[:15]:
+            score_info = c.get("relevance_score", {})
+            total = score_info.get("total_score", 0) if isinstance(score_info, dict) else 0
+            jd_score = score_info.get("jd_keyword_score", 0) if isinstance(score_info, dict) else 0
+            chunk_lines.append(
+                f"- **{c.get('name', '?')}** ({c.get('type', '?')}) "
+                f"in `{c.get('file_path', '?')}` — "
+                f"JD={jd_score:.2f}, Total={total:.2f}, "
+                f"{c.get('char_count', 0)} chars"
+            )
+            # 식별자/import 힌트
+            idents = c.get("identifiers", [])[:5]
+            imps = c.get("imports", [])[:3]
+            if idents:
+                chunk_lines.append(f"  identifiers: {', '.join(idents)}")
+            if imps:
+                chunk_lines.append(f"  imports: {', '.join(imps)}")
+        chunk_section = f"""
+## JD-Ranked Code Chunks ({len(ranked_chunks)} selected)
+{chr(10).join(chunk_lines)}
+"""
+
     return f"""Analyze this repository to identify key files for technical interview preparation.
 
 ## Target Tech Stack (from Job Description)
@@ -43,7 +80,7 @@ def build_overview_prompt(
 
 ## AST Summary
 {ast_info}
-
+{chunk_section}
 ## Your Task
 1. Select 5-10 key files that best demonstrate the candidate's technical skills matching the JD tech stack
 2. Provide a technical overview of the repository
@@ -67,14 +104,52 @@ def build_deep_analysis_prompt(
     commit_history: list[dict],
     jd_tech_stack: list[str],
 ) -> str:
-    """Stage 2: Deep Analysis Agent 프롬프트 생성"""
+    """Stage 2: Deep Analysis Agent 프롬프트 생성
+
+    JIT-24: source_code 필드 우선 사용 (완전한 함수/클래스 코드).
+    fallback: diff → diff_preview (기존 호환).
+    """
     file_path = file_info.get("path", file_info.get("filename", "unknown"))
-    diff_content = file_info.get("diff", file_info.get("diff_preview", ""))[:2000]
+
+    # JIT-24: 완전한 소스코드 우선, diff fallback
+    source_code = file_info.get("source_code", "")
+    if not source_code:
+        source_code = file_info.get("diff", file_info.get("diff_preview", ""))
+    # 소스코드는 최대 8000자 (기존 2000자에서 확대)
+    source_code = source_code[:8000] if source_code else ""
 
     commit_info = "\n".join([
         f"- {c.get('commit_hash', '')} ({c.get('date', '')}): {c.get('message', '')[:100]}"
         for c in commit_history[:5]
     ])
+
+    # JIT-24: 청크 메타데이터 (identifiers, imports, decorators)
+    metadata_section = ""
+    identifiers = file_info.get("identifiers", [])
+    imports = file_info.get("imports", [])
+    decorators = file_info.get("decorators", [])
+    relevance_score = file_info.get("relevance_score", {})
+
+    if identifiers or imports or decorators:
+        parts = []
+        if identifiers:
+            parts.append(f"Identifiers: {', '.join(identifiers[:20])}")
+        if imports:
+            parts.append(f"Imports: {', '.join(imports[:10])}")
+        if decorators:
+            parts.append(f"Decorators: {', '.join(decorators[:5])}")
+        if isinstance(relevance_score, dict) and relevance_score:
+            parts.append(
+                f"JD Relevance: {relevance_score.get('jd_keyword_score', 0):.2f}, "
+                f"Interview Potential: {relevance_score.get('interview_potential', 0):.2f}"
+            )
+        metadata_section = f"""
+## Code Metadata (AST-extracted)
+{chr(10).join(parts)}
+"""
+
+    # 코드 블록 라벨
+    code_label = "Source Code" if file_info.get("source_code") else "Code/Diff Content"
 
     return f"""Perform deep analysis on this file for technical interview preparation.
 
@@ -82,10 +157,10 @@ def build_deep_analysis_prompt(
 
 ## Target Tech Stack
 {', '.join(jd_tech_stack) if jd_tech_stack else 'Not specified'}
-
-## Code/Diff Content
+{metadata_section}
+## {code_label}
 ```
-{diff_content}
+{source_code}
 ```
 
 ## Commit History
@@ -95,7 +170,7 @@ def build_deep_analysis_prompt(
 1. Identify design patterns used
 2. Identify algorithms implemented
 3. Assess code quality (0.0-1.0 scale)
-4. Generate potential interview questions
+4. Generate potential interview questions based on this specific code
 5. Note any remarkable implementation aspects
 
 Respond in JSON format:

--- a/backend/app/services/code_analyzer.py
+++ b/backend/app/services/code_analyzer.py
@@ -21,6 +21,8 @@ from app.models.analysis import (
 )
 from app.services.llm_config import KIMI_CODER_MODEL
 from app.services.ast_analyzer import analyze_ast as _analyze_ast_standalone
+from app.services.ast_analyzer import analyze_directory as _analyze_directory
+from app.services.chunk_scorer import rank_chunks_by_relevance
 from app.services.code_analysis_prompts import (
     build_overview_prompt,
     build_deep_analysis_prompt,
@@ -315,7 +317,7 @@ class CodeAnalyzer:
         jd_tech_stack: list[str],
         token_budget: int = 30_000,
     ) -> list[dict]:
-        """토큰 예산 내 파일 랭킹"""
+        """토큰 예산 내 파일 랭킹 (레거시 — USE_AST_PIPELINE=False 시 사용)"""
         top = self.select_top_files(files, jd_tech_stack, max_files=50)
         selected = []
         total_tokens = 0
@@ -327,6 +329,40 @@ class CodeAnalyzer:
             selected.append(f)
             total_tokens += est_tokens
         return selected
+
+    def select_top_chunks(
+        self,
+        chunks: list[dict],
+        jd_tech_stack: list[str],
+        token_budget: int = 50_000,
+        contributor_ratio: float | None = None,
+    ) -> list[dict]:
+        """JD-Aware 청크 선별 (JIT-22 rank_chunks_by_relevance 위임)"""
+        return rank_chunks_by_relevance(
+            chunks=chunks,
+            jd_tech_stack=jd_tech_stack,
+            token_budget=token_budget,
+            contributor_ratio=contributor_ratio,
+        )
+
+    def analyze_directory(
+        self,
+        clone_dir: str,
+        file_types: list[str] | None = None,
+        max_files: int = 50,
+    ) -> list[dict]:
+        """clone_dir에서 AST 파싱 + 청크 메타데이터 추출 (JIT-21)"""
+        return _analyze_directory(
+            clone_dir=clone_dir,
+            file_types=file_types,
+            max_files=max_files,
+        )
+
+    @staticmethod
+    def calculate_dynamic_token_budget(total_nloc: int) -> int:
+        """레포 크기에 비례한 동적 토큰 예산 (20K~50K)"""
+        budget = max(20_000, min(50_000, total_nloc * 5))
+        return budget
 
     async def llm_analyze_code(
         self,
@@ -458,6 +494,7 @@ Based on the code above, respond ONLY with a valid JSON object (no markdown, no 
         ast_summary: dict,
         jd_tech_stack: list[str],
         model: str | None = None,
+        ranked_chunks: list[dict] | None = None,
     ) -> dict:
         """Stage 1: Overview Agent - 전체 diff 분석, 핵심 파일 선별
 
@@ -467,12 +504,13 @@ Based on the code above, respond ONLY with a valid JSON object (no markdown, no 
             ast_summary: AST 분석 결과
             jd_tech_stack: JD에서 추출한 기술 스택
             model: 사용할 LLM 모델 (기본: GLM)
+            ranked_chunks: JD-Aware 랭킹된 청크 리스트 (JIT-24, optional)
 
         Returns:
             OverviewAnalysisResult 형식의 딕셔너리
         """
         model = model or KIMI_CODER_MODEL
-        prompt = build_overview_prompt(files, commit_diffs, ast_summary, jd_tech_stack)
+        prompt = build_overview_prompt(files, commit_diffs, ast_summary, jd_tech_stack, ranked_chunks)
 
         from app.services.cached_llm import CachedLLMService
         llm = CachedLLMService()

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -449,26 +449,61 @@ async def analyze_single_repo(
                 logger.warning(f"Static analysis failed for {repo_name} (non-fatal): {e}")
 
         # ================================================================
-        # Phase 3: AST 분석
+        # Phase 3: AST 분석 + JD Scoring (JIT-24: feature flag 분기)
         # ================================================================
-        activity.heartbeat(f"Phase 3: AST for {repo_name}")
-        if alog:
-            await alog.progress(f"Phase 3: AST for {repo_name}", {
-                "phase": 3,
-                "files_count": len(driller_result.get("files", [])),
-            })
-
         primary_lang = max(
             repo_info.get("languages", {}),
             key=repo_info.get("languages", {}).get,
             default=None
         )
+        use_ast_pipeline = settings.USE_AST_PIPELINE
+
+        # 공통: AST 분석 (기존 호환용)
+        activity.heartbeat(f"Phase 3: AST for {repo_name}")
+        if alog:
+            await alog.progress(f"Phase 3: AST for {repo_name}", {
+                "phase": 3,
+                "files_count": len(driller_result.get("files", [])),
+                "use_ast_pipeline": use_ast_pipeline,
+            })
+
         top_files = analyzer.select_top_files(
             files=driller_result["files"],
             jd_tech_stack=jd_tech_stack,
             max_files=20,
         )
         ast_result = await analyzer.analyze_ast(files=top_files, primary_language=primary_lang)
+
+        # JIT-24: AST 파이프라인 — clone_dir에서 직접 청크 추출 + JD 스코어링
+        ranked_chunks: list[dict] = []
+        if use_ast_pipeline and clone_dir:
+            activity.heartbeat(f"Phase 3.5: AST chunk extraction + JD scoring for {repo_name}")
+            if alog:
+                await alog.progress(f"Phase 3.5: JD-Aware chunk scoring for {repo_name}", {
+                    "phase": 3.5,
+                })
+
+            file_types = _jd_to_file_types(jd_tech_stack)
+            all_chunks = analyzer.analyze_directory(
+                clone_dir=clone_dir,
+                file_types=file_types,
+                max_files=50,
+            )
+
+            # 동적 토큰 예산 (레포 크기 비례)
+            total_nloc = driller_result["stats"].get("total_additions", 0)
+            token_budget = analyzer.calculate_dynamic_token_budget(total_nloc)
+
+            ranked_chunks = analyzer.select_top_chunks(
+                chunks=all_chunks,
+                jd_tech_stack=jd_tech_stack,
+                token_budget=token_budget,
+            )
+
+            logger.info(
+                f"JIT-24 AST pipeline: {len(all_chunks)} chunks → "
+                f"{len(ranked_chunks)} selected (budget={token_budget}) for {repo_name}"
+            )
 
         # ================================================================
         # Phase 4: HYBRID 3-Stage LLM 분석 (Kimi Coder 모델 사용)
@@ -488,6 +523,7 @@ async def analyze_single_repo(
             ast_summary=ast_result,
             jd_tech_stack=jd_tech_stack,
             model=KIMI_CODER_MODEL,
+            ranked_chunks=ranked_chunks if use_ast_pipeline else None,
         )
 
         # 핵심 파일 추출 (최대 10개)
@@ -505,22 +541,44 @@ async def analyze_single_repo(
             await alog.progress(f"Stage 2: Deep Analysis for {repo_name}", {
                 "stage": 2,
                 "key_files_count": len(key_files),
+                "use_ast_pipeline": use_ast_pipeline,
             })
+
+        # JIT-24: 청크 기반 소스코드 매핑 (AST 파이프라인)
+        chunk_by_file: dict[str, dict] = {}
+        if use_ast_pipeline and ranked_chunks:
+            for chunk in ranked_chunks:
+                fp = chunk.get("file_path", "")
+                # 파일별 가장 큰(고점수) 청크를 우선 매핑
+                if fp not in chunk_by_file:
+                    chunk_by_file[fp] = chunk
 
         deep_analysis_tasks = []
         for file_info in key_files:
             file_path = file_info.get("path", file_info.get("filename", ""))
             commit_history = _get_file_commits(driller_result, file_path)
 
-            # 파일 소스/diff 정보 추가
-            enriched_file_info = {
-                **file_info,
-                "diff": next(
-                    (f.get("diff", "") or f.get("source", "") for f in driller_result["files"]
-                     if f.get("filename") == file_path),
-                    ""
-                ),
-            }
+            # JIT-24: AST 청크에서 완전한 소스코드 + 메타데이터 가져오기
+            if use_ast_pipeline and file_path in chunk_by_file:
+                chunk = chunk_by_file[file_path]
+                enriched_file_info = {
+                    **file_info,
+                    "source_code": chunk.get("source_code", ""),
+                    "identifiers": chunk.get("identifiers", []),
+                    "imports": chunk.get("imports", []),
+                    "decorators": chunk.get("decorators", []),
+                    "relevance_score": chunk.get("relevance_score", {}),
+                }
+            else:
+                # 레거시 경로: diff 기반
+                enriched_file_info = {
+                    **file_info,
+                    "diff": next(
+                        (f.get("diff", "") or f.get("source", "") for f in driller_result["files"]
+                         if f.get("filename") == file_path),
+                        ""
+                    ),
+                }
 
             task = analyzer.llm_deep_file_analysis(
                 file_info=enriched_file_info,
@@ -597,6 +655,8 @@ async def analyze_single_repo(
                 "model_used": KIMI_CODER_MODEL,
                 "has_static_analysis": static_analysis is not None,
                 "used_clone_fallback": used_clone_fallback,
+                "use_ast_pipeline": use_ast_pipeline,
+                "ranked_chunks_count": len(ranked_chunks),
             },
         }
 
@@ -607,6 +667,8 @@ async def analyze_single_repo(
                 "key_files": len(key_files),
                 "quality_score": synthesis_result.get("quality_score", 0),
                 "used_clone_fallback": used_clone_fallback,
+                "use_ast_pipeline": use_ast_pipeline,
+                "ranked_chunks_count": len(ranked_chunks),
             })
 
         return result

--- a/backend/tests/test_chunk_scorer.py
+++ b/backend/tests/test_chunk_scorer.py
@@ -1,0 +1,522 @@
+"""
+backend/tests/test_chunk_scorer.py
+JD-Aware Chunk Relevance Scoring Engine 단위 테스트 [JIT-22]
+
+테스트 항목:
+- CS-01: JD 키워드 매칭 (FastAPI import → JD "FastAPI" 고점수)
+- CS-02: 구조적 복잡도 (Lizard CC + fallback)
+- CS-03: 면접 잠재력 (try/except, async, API decorator)
+- CS-04: 후보자 기여 (명시적 비율 vs 기본값)
+- CS-05: 가중 합산 총점 (0.4*jd + 0.25*cx + 0.20*ip + 0.15*ct)
+- CS-06: rank_chunks 정렬 + 토큰 예산 제한
+- CS-07: 엣지 케이스 (빈 입력, 빈 JD, 소스 없음)
+- CS-08: select_top_files 하위 호환
+"""
+import sys
+from unittest.mock import MagicMock
+
+# pgvector가 설치되지 않은 환경에서도 테스트 가능하도록 mock
+if "pgvector" not in sys.modules:
+    sys.modules["pgvector"] = MagicMock()
+    sys.modules["pgvector.sqlalchemy"] = MagicMock()
+
+import pytest
+
+
+# ============================================================
+# Helper: 테스트용 청크 팩토리
+# ============================================================
+
+def _make_chunk(
+    name: str = "test_func",
+    chunk_type: str = "function",
+    file_path: str = "main.py",
+    source_code: str = "",
+    identifiers: list[str] | None = None,
+    imports: list[str] | None = None,
+    decorators: list[str] | None = None,
+    char_count: int | None = None,
+) -> dict:
+    """테스트용 청크 dict 생성"""
+    src = source_code if source_code is not None else "def test_func():\n    pass"
+    return {
+        "name": name,
+        "type": chunk_type,
+        "file_path": file_path,
+        "source_code": src,
+        "identifiers": identifiers or [],
+        "imports": imports or [],
+        "decorators": decorators or [],
+        "char_count": char_count if char_count is not None else len(src),
+    }
+
+
+# ============================================================
+# CS-01: JD 키워드 매칭
+# ============================================================
+
+class TestJDKeywordMatching:
+    """JD 키워드 매칭 점수 테스트"""
+
+    def test_exact_import_match(self):
+        """FastAPI import가 있으면 JD 'FastAPI'에 고점수"""
+        from app.services.chunk_scorer import _calculate_jd_keyword_score
+
+        chunk = _make_chunk(
+            imports=["from fastapi import APIRouter"],
+            identifiers=["APIRouter", "router"],
+        )
+        score, evidence = _calculate_jd_keyword_score(chunk, ["FastAPI"])
+        assert score > 0.0
+        assert any("FastAPI" in e or "fastapi" in e for e in evidence)
+
+    def test_multiple_jd_skills(self):
+        """여러 JD 스킬 중 일부 매칭 → 비례 점수"""
+        from app.services.chunk_scorer import _calculate_jd_keyword_score
+
+        chunk = _make_chunk(
+            imports=["from fastapi import APIRouter", "import sqlalchemy"],
+            identifiers=["APIRouter", "Session", "sqlalchemy"],
+        )
+        score, evidence = _calculate_jd_keyword_score(chunk, ["FastAPI", "PostgreSQL", "Redis"])
+        # FastAPI, sqlalchemy 매칭 → 2/3 이상은 아닐 수 있지만 0보다 큼
+        assert score > 0.0
+        assert score <= 1.0
+
+    def test_no_match(self):
+        """JD 스킬과 전혀 무관한 청크 → 0점"""
+        from app.services.chunk_scorer import _calculate_jd_keyword_score
+
+        chunk = _make_chunk(
+            imports=["import os"],
+            identifiers=["path", "join"],
+        )
+        score, evidence = _calculate_jd_keyword_score(chunk, ["React", "TypeScript"])
+        assert score == 0.0
+
+    def test_empty_jd(self):
+        """빈 JD → 0점"""
+        from app.services.chunk_scorer import _calculate_jd_keyword_score
+
+        chunk = _make_chunk(imports=["import fastapi"])
+        score, evidence = _calculate_jd_keyword_score(chunk, [])
+        assert score == 0.0
+
+    def test_decorator_matching(self):
+        """데코레이터에 JD 키워드가 포함되면 매칭"""
+        from app.services.chunk_scorer import _calculate_jd_keyword_score
+
+        chunk = _make_chunk(
+            decorators=["app.get", "pytest.fixture"],
+            identifiers=[],
+        )
+        score, evidence = _calculate_jd_keyword_score(chunk, ["pytest"])
+        assert score > 0.0
+
+
+# ============================================================
+# CS-02: 구조적 복잡도
+# ============================================================
+
+class TestComplexityScore:
+    """구조적 복잡도 점수 테스트"""
+
+    def test_simple_function_low_complexity(self):
+        """단순 함수 → 낮은 복잡도 점수"""
+        from app.services.chunk_scorer import _calculate_complexity_score
+
+        chunk = _make_chunk(source_code="def hello():\n    return 'world'")
+        score, evidence = _calculate_complexity_score(chunk)
+        assert 0.0 <= score <= 1.0
+
+    def test_complex_function(self):
+        """분기가 많은 함수 → 높은 복잡도 점수"""
+        from app.services.chunk_scorer import _calculate_complexity_score
+
+        complex_source = """def process(data):
+    if data is None:
+        return None
+    result = []
+    for item in data:
+        if item > 0:
+            if item % 2 == 0:
+                result.append(item * 2)
+            else:
+                result.append(item * 3)
+        elif item == 0:
+            continue
+        else:
+            for sub in range(abs(item)):
+                if sub % 3 == 0:
+                    result.append(sub)
+                elif sub % 5 == 0:
+                    result.append(-sub)
+    return result
+"""
+        chunk = _make_chunk(source_code=complex_source)
+        score, evidence = _calculate_complexity_score(chunk)
+        assert score > 0.0
+
+    def test_empty_source_fallback(self):
+        """소스 없음 → 0점"""
+        from app.services.chunk_scorer import _calculate_complexity_score
+
+        chunk = _make_chunk(source_code="")
+        score, evidence = _calculate_complexity_score(chunk)
+        assert score == 0.0
+
+    def test_line_count_fallback(self):
+        """Lizard 실패 시 라인수 기반 휴리스틱"""
+        from app.services.chunk_scorer import _calculate_complexity_score
+
+        # 일부러 파싱 불가 소스 (Lizard가 함수를 못 찾음)
+        chunk = _make_chunk(source_code="x = 1\n" * 50)
+        score, evidence = _calculate_complexity_score(chunk)
+        assert 0.0 <= score <= 1.0
+        assert any("라인수" in e or "source" in e for e in evidence)
+
+
+# ============================================================
+# CS-03: 면접 잠재력
+# ============================================================
+
+class TestInterviewPotential:
+    """면접 잠재력 점수 테스트"""
+
+    def test_try_except_pattern(self):
+        """try/except 패턴 감지"""
+        from app.services.chunk_scorer import _calculate_interview_potential
+
+        source = """def safe_divide(a, b):
+    try:
+        return a / b
+    except ZeroDivisionError:
+        return 0
+"""
+        chunk = _make_chunk(source_code=source)
+        score, evidence = _calculate_interview_potential(chunk)
+        assert score > 0.0
+        assert any("try" in e or "except" in e for e in evidence)
+
+    def test_async_pattern(self):
+        """async/await 패턴 감지"""
+        from app.services.chunk_scorer import _calculate_interview_potential
+
+        source = """async def fetch_data(url):
+    async with aiohttp.ClientSession() as session:
+        resp = await session.get(url)
+        return await resp.json()
+"""
+        chunk = _make_chunk(source_code=source)
+        score, evidence = _calculate_interview_potential(chunk)
+        assert score > 0.0
+        assert any("async" in e or "await" in e for e in evidence)
+
+    def test_api_decorator_pattern(self):
+        """API 데코레이터 패턴 감지"""
+        from app.services.chunk_scorer import _calculate_interview_potential
+
+        source = """@app.get("/users/{user_id}")
+async def get_user(user_id: int):
+    return {"user_id": user_id}
+"""
+        chunk = _make_chunk(
+            source_code=source,
+            decorators=["app.get"],
+        )
+        score, evidence = _calculate_interview_potential(chunk)
+        assert score > 0.0
+
+    def test_plain_function_low_potential(self):
+        """단순 함수 → 낮은 면접 잠재력"""
+        from app.services.chunk_scorer import _calculate_interview_potential
+
+        chunk = _make_chunk(source_code="def add(a, b):\n    return a + b")
+        score, evidence = _calculate_interview_potential(chunk)
+        # 단순 함수여도 0 이상일 수 있지만 낮아야 함
+        assert score < 0.5
+
+    def test_deep_nesting(self):
+        """깊은 중첩 → 추가 점수"""
+        from app.services.chunk_scorer import _calculate_interview_potential
+
+        source = "def deep():\n" + "    " * 1 + "if True:\n"
+        source += "    " * 2 + "for i in range(10):\n"
+        source += "    " * 3 + "if i > 0:\n"
+        source += "    " * 4 + "while i > 0:\n"
+        source += "    " * 5 + "i -= 1\n"
+        chunk = _make_chunk(source_code=source)
+        score, evidence = _calculate_interview_potential(chunk)
+        assert 0.0 <= score <= 1.0
+
+
+# ============================================================
+# CS-04: 후보자 기여
+# ============================================================
+
+class TestContributorScore:
+    """후보자 기여 점수 테스트"""
+
+    def test_explicit_ratio(self):
+        """명시적 기여 비율 전달"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        chunk = _make_chunk()
+        result = calculate_chunk_score(chunk, ["Python"], contributor_ratio=0.8)
+        assert result.contributor_score == 0.8
+
+    def test_default_ratio(self):
+        """기여 비율 미지정 → 기본값 0.5"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        chunk = _make_chunk()
+        result = calculate_chunk_score(chunk, ["Python"], contributor_ratio=None)
+        assert result.contributor_score == 0.5
+
+    def test_ratio_clamped(self):
+        """기여 비율 0.0~1.0 클램핑"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        chunk = _make_chunk()
+        result_high = calculate_chunk_score(chunk, ["Python"], contributor_ratio=1.5)
+        assert result_high.contributor_score == 1.0
+
+        result_low = calculate_chunk_score(chunk, ["Python"], contributor_ratio=-0.3)
+        assert result_low.contributor_score == 0.0
+
+
+# ============================================================
+# CS-05: 가중 합산 총점
+# ============================================================
+
+class TestWeightedTotal:
+    """가중 합산 총점 검증"""
+
+    def test_weight_formula(self):
+        """총점 = 0.4*jd + 0.25*cx + 0.20*ip + 0.15*ct"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        chunk = _make_chunk(
+            imports=["from fastapi import FastAPI"],
+            identifiers=["FastAPI"],
+            source_code="async def handler():\n    try:\n        await do()\n    except Exception:\n        pass\n",
+        )
+        result = calculate_chunk_score(chunk, ["FastAPI"], contributor_ratio=1.0)
+
+        expected = (
+            result.jd_keyword_score * 0.40
+            + result.complexity_score * 0.25
+            + result.interview_potential * 0.20
+            + result.contributor_score * 0.15
+        )
+        assert abs(result.total_score - round(expected, 4)) < 0.01
+
+    def test_total_bounded(self):
+        """총점은 항상 0.0~1.0"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        chunk = _make_chunk()
+        result = calculate_chunk_score(chunk, ["Python", "FastAPI", "Redis"])
+        assert 0.0 <= result.total_score <= 1.0
+
+    def test_all_zeros(self):
+        """모든 입력이 빈 경우에도 안전"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        chunk = _make_chunk(
+            source_code="",
+            identifiers=[],
+            imports=[],
+            decorators=[],
+            char_count=0,
+        )
+        result = calculate_chunk_score(chunk, [], contributor_ratio=0.0)
+        assert result.total_score == 0.0
+
+
+# ============================================================
+# CS-06: rank_chunks 정렬 + 토큰 예산 제한
+# ============================================================
+
+class TestRankChunks:
+    """rank_chunks_by_relevance 테스트"""
+
+    def test_sorted_by_score_desc(self):
+        """결과가 점수 내림차순으로 정렬됨"""
+        from app.services.chunk_scorer import rank_chunks_by_relevance
+
+        chunks = [
+            _make_chunk(name="low", source_code="x = 1", char_count=10, identifiers=["x"]),
+            _make_chunk(
+                name="high",
+                source_code="async def handler():\n    try:\n        await do()\n    except Exception:\n        pass\n",
+                char_count=100,
+                imports=["from fastapi import FastAPI"],
+                identifiers=["FastAPI"],
+            ),
+        ]
+        result = rank_chunks_by_relevance(chunks, ["FastAPI"], token_budget=100_000)
+        assert len(result) == 2
+        scores = [r["relevance_score"]["total_score"] for r in result]
+        assert scores[0] >= scores[1]
+
+    def test_token_budget_limit(self):
+        """토큰 예산 초과 시 자르기"""
+        from app.services.chunk_scorer import rank_chunks_by_relevance
+
+        # 각 1000자 청크 3개 = 3000자 ≈ 750 토큰
+        chunks = [
+            _make_chunk(name=f"func_{i}", source_code="x = 1\n" * 150, char_count=1000)
+            for i in range(3)
+        ]
+        # 예산 500 토큰 = 2000자 → 2개만 선택
+        result = rank_chunks_by_relevance(chunks, ["Python"], token_budget=500)
+        assert len(result) <= 2
+
+    def test_knapsack_small_after_big(self):
+        """큰 청크 스킵 후 작은 고점수 청크 포함 (Knapsack)"""
+        from app.services.chunk_scorer import rank_chunks_by_relevance
+
+        chunks = [
+            _make_chunk(
+                name="big_low",
+                source_code="x = 1\n" * 500,
+                char_count=3000,  # 750 tokens
+                identifiers=["x"],
+            ),
+            _make_chunk(
+                name="small_high",
+                source_code="async def handler():\n    await do()\n",
+                char_count=100,  # 25 tokens
+                imports=["from fastapi import FastAPI"],
+                identifiers=["FastAPI"],
+            ),
+        ]
+        # 예산 100 토큰 = 400자 → 큰 청크는 스킵, 작은 청크는 포함
+        result = rank_chunks_by_relevance(chunks, ["FastAPI"], token_budget=100)
+        names = [r["name"] for r in result]
+        assert "small_high" in names
+        assert "big_low" not in names
+
+    def test_empty_chunks(self):
+        """빈 입력 → 빈 결과"""
+        from app.services.chunk_scorer import rank_chunks_by_relevance
+
+        result = rank_chunks_by_relevance([], ["Python"])
+        assert result == []
+
+
+# ============================================================
+# CS-07: 엣지 케이스
+# ============================================================
+
+class TestEdgeCases:
+    """엣지 케이스 테스트"""
+
+    def test_empty_source(self):
+        """source_code 없는 청크"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        chunk = _make_chunk(source_code="", char_count=0)
+        result = calculate_chunk_score(chunk, ["Python"])
+        assert result.total_score >= 0.0
+
+    def test_empty_jd_tech_stack(self):
+        """빈 JD 기술 스택"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        chunk = _make_chunk(
+            imports=["from fastapi import FastAPI"],
+            source_code="async def handler():\n    pass\n",
+        )
+        result = calculate_chunk_score(chunk, [])
+        assert result.jd_keyword_score == 0.0
+        # 다른 점수는 여전히 계산됨
+        assert result.total_score >= 0.0
+
+    def test_chunk_relevance_score_model(self):
+        """ChunkRelevanceScore 모델 필드 검증"""
+        from app.models.analysis import ChunkRelevanceScore
+
+        score = ChunkRelevanceScore(
+            chunk_name="test",
+            chunk_type="function",
+            file_path="test.py",
+            jd_keyword_score=0.5,
+            complexity_score=0.3,
+            interview_potential=0.4,
+            contributor_score=0.5,
+            total_score=0.42,
+            char_count=100,
+            evidence=["test evidence"],
+        )
+        assert score.chunk_name == "test"
+        assert score.total_score == 0.42
+
+    def test_very_large_source(self):
+        """매우 큰 소스 코드 처리"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        large_source = "x = 1\n" * 5000
+        chunk = _make_chunk(source_code=large_source, char_count=len(large_source))
+        result = calculate_chunk_score(chunk, ["Python"])
+        assert 0.0 <= result.total_score <= 1.0
+
+    def test_unicode_in_source(self):
+        """한글/유니코드 소스 처리"""
+        from app.services.chunk_scorer import calculate_chunk_score
+
+        source = "def 인사(이름: str) -> str:\n    return f'안녕하세요, {이름}'\n"
+        chunk = _make_chunk(
+            name="인사",
+            source_code=source,
+            identifiers=["이름", "str"],
+            char_count=len(source),
+        )
+        result = calculate_chunk_score(chunk, ["Python"])
+        assert 0.0 <= result.total_score <= 1.0
+
+
+# ============================================================
+# CS-08: select_top_files 하위 호환
+# ============================================================
+
+class TestSelectTopFilesCompat:
+    """기존 select_top_files가 변경 없이 동작하는지 검증"""
+
+    def test_select_top_files_unchanged(self):
+        """select_top_files는 기존과 동일하게 복잡도 기반 정렬"""
+        from app.services.code_analyzer import CodeAnalyzer
+
+        analyzer = CodeAnalyzer()
+        files = [
+            {"filename": "simple.py", "complexity": 2, "methods": 1},
+            {"filename": "complex.py", "complexity": 15, "methods": 5},
+            {"filename": "medium.py", "complexity": 8, "methods": 3},
+        ]
+        result = analyzer.select_top_files(files, ["Python"], max_files=3)
+        assert len(result) == 3
+        # 복잡도 순 정렬 확인
+        assert result[0]["filename"] == "complex.py"
+
+    def test_select_top_files_max_limit(self):
+        """max_files 제한 동작"""
+        from app.services.code_analyzer import CodeAnalyzer
+
+        analyzer = CodeAnalyzer()
+        files = [
+            {"filename": f"file_{i}.py", "complexity": i, "methods": 1}
+            for i in range(10)
+        ]
+        result = analyzer.select_top_files(files, ["Python"], max_files=3)
+        assert len(result) == 3
+
+    def test_select_top_chunks_exists(self):
+        """select_top_chunks 메서드가 존재하고 호출 가능"""
+        from app.services.code_analyzer import CodeAnalyzer
+
+        analyzer = CodeAnalyzer()
+        assert hasattr(analyzer, "select_top_chunks")
+        # 빈 입력으로 호출
+        result = analyzer.select_top_chunks([], ["Python"])
+        assert result == []


### PR DESCRIPTION
## Summary
- **JIT-24**: AST 파이프라인 + JD-Aware Scoring을 코드 분석 파이프라인에 통합
- JIT-20(shallow clone), JIT-21(AST 파서), JIT-22(JD Scoring), JIT-23(후보자 식별) 결과물을 `analyze_single_repo()`에 통합
- `USE_AST_PIPELINE` feature flag로 기존/신규 파이프라인 전환 가능 (롤백 안전)

## 주요 변경
- `analyze_directory()`: clone_dir에서 직접 AST 파싱 → 함수/클래스 단위 청크 추출 (Python ast + tree-sitter JS/TS)
- `ChunkRelevanceScore` 모델 + `rank_chunks_by_relevance()`: JD 관련성 기반 청크 선별
- Stage 2 Deep Analysis: `diff[:2000]` → 완전한 함수/클래스 소스코드 (최대 8000자)
- `build_overview_prompt`: AST 청크 메타데이터 (identifiers, imports, decorators) 섹션 추가
- `build_deep_analysis_prompt`: source_code 우선 사용 + 청크 메타데이터 주입
- 동적 토큰 예산: 레포 크기 비례 20K~50K (기존 고정 30K)

## 수정 파일
- `backend/app/core/config.py` — `USE_AST_PIPELINE` feature flag
- `backend/app/models/analysis.py` — `ChunkRelevanceScore` 모델
- `backend/app/services/ast_analyzer.py` — `analyze_directory()` + 청크 추출
- `backend/app/services/chunk_scorer.py` — JD-Aware 스코어링 엔진 (신규)
- `backend/app/services/code_analysis_prompts.py` — Overview/Deep 프롬프트 개선
- `backend/app/services/code_analyzer.py` — `select_top_chunks()`, `calculate_dynamic_token_budget()`
- `backend/app/workflows/activities/code_analysis.py` — Phase 3~4 파이프라인 재설계

## Test plan
- [x] chunk_scorer 단위 테스트 32개 통과
- [x] 전체 backend 테스트 481 passed (기존 실패 3개는 무관)
- [ ] Docker 환경에서 E2E 검증 (실제 레포 분석)
- [ ] `USE_AST_PIPELINE=false`로 기존 파이프라인 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)