### PR TITLE
test: 코드 분석 파이프라인 테스트 38개 추가 (JIT-26)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -125,6 +125,44 @@ def mock_enriched_input(sample_input_data, sample_linkedin_profile):
 
 
 # ============================================================
+# JIT-26: Code Analysis Pipeline Fixtures
+# ============================================================
+
+@pytest.fixture
+def sample_jd_tech_stack():
+    """JD 기술 스택 샘플"""
+    return ["Python", "FastAPI", "PostgreSQL"]
+
+
+@pytest.fixture
+def valid_repo_result():
+    """정상 레포 분석 결과 (validate_code_analysis 통과용)"""
+    return {
+        "repo_name": "test-repo",
+        "candidate_commits": 50,
+        "ast_analysis": {
+            "functions": [{"name": "main"}, {"name": "helper"}],
+            "classes": [{"name": "UserService"}],
+            "parser_used": "ast",
+        },
+        "analysis": {
+            "patterns": ["Repository", "Factory"],
+            "quality_score": 0.7,
+            "notable_implementations": [
+                {"title": "Async workflow engine", "question_potential": 0.9},
+            ],
+        },
+        "notable_implementations": [
+            {"title": "Async workflow engine", "question_potential": 0.9},
+        ],
+        "hybrid_metadata": {
+            "key_files_count": 3,
+            "deep_analyses_count": 3,
+        },
+    }
+
+
+# ============================================================
 # Mock Services
 # ============================================================
 

--- a/backend/tests/test_ast_analyzer.py
+++ b/backend/tests/test_ast_analyzer.py
@@ -1,0 +1,253 @@
+"""
+backend/tests/test_ast_analyzer.py
+AST 디렉토리 분석기 단위 테스트 (JIT-26)
+
+테스트 항목:
+- analyze_directory(): 파일 탐색, 필터링, 청크 추출
+- _extract_python_chunks(): Python AST 파싱
+- _extract_ts_chunks(): tree-sitter fallback
+"""
+import pytest
+
+
+# ============================================================
+# TestAnalyzeDirectory: analyze_directory() 테스트
+# ============================================================
+
+class TestAnalyzeDirectory:
+    """analyze_directory() — clone_dir에서 AST 파싱 + 청크 추출"""
+
+    def test_python_files_extract_chunks(self, tmp_path):
+        """Python 파일에서 함수/클래스 청크 추출 + 스키마 키 검증"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "main.py").write_text(
+            "def hello():\n    return 'world'\n\n"
+            "class Greeter:\n    def greet(self):\n        pass\n"
+        )
+
+        chunks = analyze_directory(str(tmp_path))
+
+        assert len(chunks) >= 2  # hello 함수 + Greeter 클래스
+        required_keys = {"name", "type", "file_path", "source_code", "identifiers", "imports", "decorators", "char_count"}
+        for chunk in chunks:
+            assert required_keys.issubset(chunk.keys()), f"누락 키: {required_keys - chunk.keys()}"
+            assert chunk["type"] in ("function", "class", "module")
+            assert chunk["char_count"] > 0
+
+        names = {c["name"] for c in chunks}
+        assert "hello" in names
+        assert "Greeter" in names
+
+    def test_excludes_directories(self, tmp_path):
+        """.git, __pycache__, node_modules 디렉토리 스킵"""
+        from app.services.ast_analyzer import analyze_directory
+
+        # 제외 대상 디렉토리에 파일 생성
+        for excluded in [".git", "__pycache__", "node_modules"]:
+            d = tmp_path / excluded
+            d.mkdir()
+            (d / "hidden.py").write_text("def secret(): pass\n")
+
+        # 정상 파일
+        (tmp_path / "visible.py").write_text("def public(): pass\n")
+
+        chunks = analyze_directory(str(tmp_path))
+
+        file_paths = {c["file_path"] for c in chunks}
+        assert all(excluded not in fp for fp in file_paths for excluded in [".git", "__pycache__", "node_modules"])
+        assert any("visible.py" in fp for fp in file_paths)
+
+    def test_max_files_limit(self, tmp_path):
+        """60개 파일 → max_files=50 적용 확인"""
+        from app.services.ast_analyzer import analyze_directory
+
+        for i in range(60):
+            (tmp_path / f"file_{i:03d}.py").write_text(f"def func_{i}(): pass\n")
+
+        chunks = analyze_directory(str(tmp_path), max_files=50)
+
+        # 50개 파일 이하에서 추출된 청크만 존재
+        unique_files = {c["file_path"] for c in chunks}
+        assert len(unique_files) <= 50
+
+    def test_file_types_filter(self, tmp_path):
+        """file_types=['.py']로 .ts/.go 필터링"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "app.py").write_text("def main(): pass\n")
+        (tmp_path / "app.ts").write_text("function main() {}\n")
+        (tmp_path / "app.go").write_text("package main\nfunc main() {}\n")
+
+        chunks = analyze_directory(str(tmp_path), file_types=[".py"])
+
+        file_paths = {c["file_path"] for c in chunks}
+        assert any(".py" in fp for fp in file_paths)
+        assert not any(".ts" in fp for fp in file_paths)
+        assert not any(".go" in fp for fp in file_paths)
+
+    def test_empty_directory(self, tmp_path):
+        """빈 디렉토리 → 빈 리스트"""
+        from app.services.ast_analyzer import analyze_directory
+
+        chunks = analyze_directory(str(tmp_path))
+        assert chunks == []
+
+    def test_large_files_excluded(self, tmp_path):
+        """300KB 파일 스킵 (>200KB 제한)"""
+        from app.services.ast_analyzer import analyze_directory
+
+        # 300KB 초과 파일
+        large_content = "x = 1\n" * 60_000  # ~360KB
+        (tmp_path / "large.py").write_text(large_content)
+
+        # 정상 크기 파일
+        (tmp_path / "small.py").write_text("def ok(): pass\n")
+
+        chunks = analyze_directory(str(tmp_path))
+
+        file_paths = {c["file_path"] for c in chunks}
+        assert not any("large.py" in fp for fp in file_paths)
+        assert any("small.py" in fp for fp in file_paths)
+
+    def test_empty_files_excluded(self, tmp_path):
+        """0바이트 파일 스킵"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "blank.py").write_text("")
+        (tmp_path / "valid.py").write_text("x = 1\n")
+
+        chunks = analyze_directory(str(tmp_path))
+
+        file_paths = {c["file_path"] for c in chunks}
+        assert not any("blank.py" in fp for fp in file_paths)
+        assert any("valid.py" in fp for fp in file_paths)
+
+
+# ============================================================
+# TestExtractPythonChunks: Python AST 파싱 테스트
+# ============================================================
+
+class TestExtractPythonChunks:
+    """_extract_python_chunks — Python AST 파싱"""
+
+    def test_extracts_functions_and_classes(self, tmp_path):
+        """함수 2개 + 클래스 1개 파싱, name/type/identifiers/imports/decorators 검증"""
+        from app.services.ast_analyzer import analyze_directory
+
+        source = (
+            "import os\n"
+            "from pathlib import Path\n\n"
+            "def func_a(x, y):\n    return x + y\n\n"
+            "def func_b():\n    os.getcwd()\n\n"
+            "class MyClass:\n    def method(self):\n        pass\n"
+        )
+        (tmp_path / "module.py").write_text(source)
+
+        chunks = analyze_directory(str(tmp_path))
+
+        names = {c["name"] for c in chunks}
+        assert "func_a" in names
+        assert "func_b" in names
+        assert "MyClass" in names
+
+        func_a = next(c for c in chunks if c["name"] == "func_a")
+        assert func_a["type"] == "function"
+        assert isinstance(func_a["identifiers"], list)
+        assert isinstance(func_a["imports"], list)
+        assert len(func_a["imports"]) >= 1  # import os, from pathlib import Path
+
+        my_class = next(c for c in chunks if c["name"] == "MyClass")
+        assert my_class["type"] == "class"
+
+    def test_syntax_error_fallback(self, tmp_path):
+        """잘못된 Python → _file_level_chunk fallback (type='module')"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "bad.py").write_text("def broken(:\n    pass\n")
+
+        chunks = analyze_directory(str(tmp_path))
+
+        assert len(chunks) == 1
+        assert chunks[0]["type"] == "module"
+        assert chunks[0]["name"].startswith("file:")
+
+    def test_async_function_extraction(self, tmp_path):
+        """AsyncFunctionDef 캡처"""
+        from app.services.ast_analyzer import analyze_directory
+
+        source = "async def fetch_data(url):\n    return await get(url)\n"
+        (tmp_path / "async_mod.py").write_text(source)
+
+        chunks = analyze_directory(str(tmp_path))
+
+        assert any(c["name"] == "fetch_data" and c["type"] == "function" for c in chunks)
+
+    def test_decorator_extraction(self, tmp_path):
+        """@staticmethod, @app.get 데코레이터 추출"""
+        from app.services.ast_analyzer import analyze_directory
+
+        source = (
+            "class Api:\n"
+            "    @staticmethod\n"
+            "    def helper():\n        pass\n"
+        )
+        (tmp_path / "deco.py").write_text(source)
+
+        chunks = analyze_directory(str(tmp_path))
+
+        api_class = next((c for c in chunks if c["name"] == "Api"), None)
+        assert api_class is not None
+        # 데코레이터는 클래스 내부 함수에 있으므로, 클래스 레벨 청크에서는 빈 리스트일 수 있음
+        # 하지만 데코레이터 필드는 리스트로 존재해야 함
+        assert isinstance(api_class["decorators"], list)
+
+    def test_max_chunk_chars_truncation(self, tmp_path):
+        """10K 초과 소스 → 절삭 확인"""
+        from app.services.ast_analyzer import analyze_directory
+
+        # 12K 글자 함수
+        body = "    x = 1\n" * 1500  # ~15K chars
+        source = f"def big_func():\n{body}"
+        (tmp_path / "big.py").write_text(source)
+
+        chunks = analyze_directory(str(tmp_path), max_chunk_chars=10_000)
+
+        big = next((c for c in chunks if c["name"] == "big_func"), None)
+        assert big is not None
+        assert big["char_count"] <= 10_000
+
+
+# ============================================================
+# TestExtractTsChunks: tree-sitter JS/TS fallback 테스트
+# ============================================================
+
+class TestExtractTsChunks:
+    """_extract_ts_chunks — tree-sitter fallback"""
+
+    def test_returns_empty_without_tree_sitter(self, tmp_path):
+        """tree-sitter ImportError → file-level fallback 청크"""
+        from unittest.mock import patch
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "app.ts").write_text("function hello() { return 'world'; }\n")
+
+        # tree-sitter를 import할 수 없는 환경 시뮬레이션
+        with patch("app.services.ast_analyzer._extract_ts_chunks", return_value=[]):
+            chunks = analyze_directory(str(tmp_path), file_types=[".ts"])
+
+        # tree-sitter 없으면 file-level chunk fallback
+        assert len(chunks) >= 1
+        assert chunks[0]["type"] == "module"
+
+    def test_file_level_chunk_fallback(self, tmp_path):
+        """미지원 언어 (.rs) → 파일 레벨 청크"""
+        from app.services.ast_analyzer import analyze_directory
+
+        (tmp_path / "main.rs").write_text("fn main() { println!(\"hello\"); }\n")
+
+        chunks = analyze_directory(str(tmp_path), file_types=[".rs"])
+
+        assert len(chunks) == 1
+        assert chunks[0]["type"] == "module"
+        assert "main" in chunks[0]["name"]

--- a/backend/tests/test_code_analysis.py
+++ b/backend/tests/test_code_analysis.py
@@ -283,3 +283,238 @@ class TestCodeAnalysisIntegration:
 
             assert "repositories" in result
             assert "top_question_candidates" in result
+
+
+# ============================================================
+# P2C-07: validate_code_analysis 테스트 (JIT-26)
+# ============================================================
+
+@patch("app.core.observability.is_langfuse_enabled", return_value=False)
+class TestValidateCodeAnalysis:
+    """validate_code_analysis Activity 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_valid_result(self, _mock_langfuse):
+        """정상 결과 → valid=True"""
+        from app.workflows.activities.code_analysis import validate_code_analysis
+
+        repo_result = {
+            "repo_name": "test-repo",
+            "candidate_commits": 50,
+            "ast_analysis": {
+                "functions": [{"name": "func1"}],
+                "classes": [{"name": "Class1"}],
+                "parser_used": "ast",
+            },
+            "analysis": {
+                "patterns": ["Repository"],
+                "quality_score": 0.7,
+            },
+            "notable_implementations": [{"title": "Async engine"}],
+            "hybrid_metadata": {
+                "key_files_count": 3,
+                "deep_analyses_count": 3,
+            },
+        }
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+            result = await validate_code_analysis(repo_result)
+
+        assert result["valid"] is True
+        assert result["issues"] == []
+        assert result["repo_name"] == "test-repo"
+
+    @pytest.mark.asyncio
+    async def test_low_commits(self, _mock_langfuse):
+        """커밋 0개 → valid=False"""
+        from app.workflows.activities.code_analysis import validate_code_analysis
+
+        repo_result = {
+            "repo_name": "empty-repo",
+            "candidate_commits": 0,
+            "ast_analysis": {"functions": [{"name": "f"}], "classes": []},
+            "analysis": {"patterns": ["Singleton"], "quality_score": 0.5},
+            "notable_implementations": [],
+            "hybrid_metadata": {},
+        }
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+            result = await validate_code_analysis(repo_result, min_commits=1)
+
+        assert result["valid"] is False
+        assert any("커밋 수 부족" in issue for issue in result["issues"])
+
+    @pytest.mark.asyncio
+    async def test_no_ast_findings(self, _mock_langfuse):
+        """함수/클래스 없음 → 이슈"""
+        from app.workflows.activities.code_analysis import validate_code_analysis
+
+        repo_result = {
+            "repo_name": "no-ast",
+            "candidate_commits": 10,
+            "ast_analysis": {"functions": [], "classes": []},
+            "analysis": {"patterns": [], "quality_score": 0.5},
+            "notable_implementations": [],
+            "hybrid_metadata": {},
+        }
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+            result = await validate_code_analysis(repo_result)
+
+        assert result["valid"] is False
+        assert any("AST" in issue for issue in result["issues"])
+
+    @pytest.mark.asyncio
+    async def test_low_notables(self, _mock_langfuse):
+        """notable=0, min_notables=1 → 이슈"""
+        from app.workflows.activities.code_analysis import validate_code_analysis
+
+        repo_result = {
+            "repo_name": "low-notables",
+            "candidate_commits": 20,
+            "ast_analysis": {"functions": [{"name": "f"}], "classes": []},
+            "analysis": {"patterns": ["Factory"], "quality_score": 0.6},
+            "notable_implementations": [],
+            "hybrid_metadata": {},
+        }
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+            result = await validate_code_analysis(repo_result, min_notables=1)
+
+        assert result["valid"] is False
+        assert any("notable" in issue for issue in result["issues"])
+
+    @pytest.mark.asyncio
+    async def test_deep_analysis_failure(self, _mock_langfuse):
+        """deep_analyses=0, key_files>0 → 이슈"""
+        from app.workflows.activities.code_analysis import validate_code_analysis
+
+        repo_result = {
+            "repo_name": "deep-fail",
+            "candidate_commits": 30,
+            "ast_analysis": {"functions": [{"name": "f"}], "classes": []},
+            "analysis": {"patterns": ["Singleton"], "quality_score": 0.5},
+            "notable_implementations": [],
+            "hybrid_metadata": {
+                "key_files_count": 5,
+                "deep_analyses_count": 0,
+            },
+        }
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+            result = await validate_code_analysis(repo_result)
+
+        assert result["valid"] is False
+        assert any("Deep Analysis" in issue for issue in result["issues"])
+
+    @pytest.mark.asyncio
+    async def test_low_quality_with_many_commits(self, _mock_langfuse):
+        """quality=0.2, commits=50 → 이슈"""
+        from app.workflows.activities.code_analysis import validate_code_analysis
+
+        repo_result = {
+            "repo_name": "low-quality",
+            "candidate_commits": 50,
+            "ast_analysis": {"functions": [{"name": "f"}], "classes": []},
+            "analysis": {"patterns": ["Factory"], "quality_score": 0.2},
+            "notable_implementations": [{"title": "Something"}],
+            "hybrid_metadata": {},
+        }
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+            result = await validate_code_analysis(repo_result)
+
+        assert result["valid"] is False
+        assert any("품질 점수" in issue for issue in result["issues"])
+
+    @pytest.mark.asyncio
+    async def test_all_issues_combined(self, _mock_langfuse):
+        """복합 실패 → 복수 이슈"""
+        from app.workflows.activities.code_analysis import validate_code_analysis
+
+        repo_result = {
+            "repo_name": "many-issues",
+            "candidate_commits": 0,
+            "ast_analysis": {"functions": [], "classes": []},
+            "analysis": {"patterns": [], "quality_score": 0.0},
+            "notable_implementations": [],
+            "hybrid_metadata": {
+                "key_files_count": 3,
+                "deep_analyses_count": 0,
+            },
+        }
+
+        with patch("app.workflows.activities.code_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+            result = await validate_code_analysis(repo_result, min_commits=1, min_notables=1)
+
+        assert result["valid"] is False
+        assert len(result["issues"]) >= 3
+
+
+# ============================================================
+# P2C-08: _get_file_commits 테스트 (JIT-26)
+# ============================================================
+
+class TestGetFileCommits:
+    """_get_file_commits — 특정 파일의 커밋 이력 추출"""
+
+    def test_extracts_matching_commits(self):
+        """file_path 매칭 커밋 필터"""
+        from app.workflows.activities.code_analysis import _get_file_commits
+
+        driller_result = {
+            "commit_diffs": [
+                {"file_path": "main.py", "commit_hash": "aaa", "message": "feat", "date": "2025-01", "additions": 10, "deletions": 2},
+                {"file_path": "utils.py", "commit_hash": "bbb", "message": "fix", "date": "2025-02", "additions": 5, "deletions": 1},
+                {"file_path": "main.py", "commit_hash": "ccc", "message": "refactor", "date": "2025-03", "additions": 20, "deletions": 5},
+            ]
+        }
+
+        commits = _get_file_commits(driller_result, "main.py")
+
+        assert len(commits) == 2
+        assert all(c["commit_hash"] in ("aaa", "ccc") for c in commits)
+
+    def test_limits_to_10(self):
+        """15개 커밋 → max 10 반환"""
+        from app.workflows.activities.code_analysis import _get_file_commits
+
+        driller_result = {
+            "commit_diffs": [
+                {"file_path": "app.py", "commit_hash": f"h{i}", "message": f"commit {i}", "date": f"2025-{i:02d}", "additions": i, "deletions": 0}
+                for i in range(15)
+            ]
+        }
+
+        commits = _get_file_commits(driller_result, "app.py")
+
+        assert len(commits) == 10
+
+
+# ============================================================
+# P2C-09: calculate_dynamic_token_budget 테스트 (JIT-26)
+# ============================================================
+
+class TestCalculateDynamicTokenBudget:
+    """CodeAnalyzer.calculate_dynamic_token_budget — 동적 토큰 예산"""
+
+    def test_minimum_20k(self):
+        """nloc=100 → 20,000 (최소값)"""
+        from app.services.code_analyzer import CodeAnalyzer
+
+        budget = CodeAnalyzer.calculate_dynamic_token_budget(100)
+        assert budget == 20_000
+
+    def test_maximum_50k(self):
+        """nloc=100,000 → 50,000 (최대값)"""
+        from app.services.code_analyzer import CodeAnalyzer
+
+        budget = CodeAnalyzer.calculate_dynamic_token_budget(100_000)
+        assert budget == 50_000

--- a/backend/tests/test_code_analysis_prompts.py
+++ b/backend/tests/test_code_analysis_prompts.py
@@ -1,0 +1,209 @@
+"""
+backend/tests/test_code_analysis_prompts.py
+프롬프트 빌더 함수 단위 테스트 (JIT-26)
+
+테스트 항목:
+- build_overview_prompt(): Overview Agent 프롬프트
+- build_deep_analysis_prompt(): Deep Analysis Agent 프롬프트
+- build_synthesis_prompt(): Synthesis Agent 프롬프트
+"""
+import pytest
+
+from app.services.code_analysis_prompts import (
+    build_overview_prompt,
+    build_deep_analysis_prompt,
+    build_synthesis_prompt,
+)
+
+
+# ============================================================
+# TestBuildOverviewPrompt
+# ============================================================
+
+class TestBuildOverviewPrompt:
+    """build_overview_prompt — Stage 1 프롬프트 생성"""
+
+    def test_basic_structure(self):
+        """프롬프트에 'Tech Stack', 'File Summary' 섹션 포함"""
+        prompt = build_overview_prompt(
+            files=[{"filename": "main.py", "added": 100, "complexity": 5}],
+            commit_diffs=[{"file_path": "main.py", "commit_hash": "abc123", "diff": "+print('hi')"}],
+            ast_summary={"functions": [{"name": "main"}], "classes": [], "parser_used": "ast"},
+            jd_tech_stack=["Python", "FastAPI"],
+        )
+
+        assert "Tech Stack" in prompt
+        assert "File Summary" in prompt
+        assert "Python" in prompt
+        assert "FastAPI" in prompt
+        assert "main.py" in prompt
+
+    def test_with_ranked_chunks(self):
+        """ranked_chunks 전달 시 청크 메타데이터 포함"""
+        ranked_chunks = [
+            {
+                "name": "handle_request",
+                "type": "function",
+                "file_path": "api/routes.py",
+                "char_count": 500,
+                "identifiers": ["request", "response"],
+                "imports": ["from fastapi import Request"],
+                "relevance_score": {
+                    "total_score": 0.85,
+                    "jd_keyword_score": 0.7,
+                },
+            }
+        ]
+
+        prompt = build_overview_prompt(
+            files=[],
+            commit_diffs=[],
+            ast_summary={"functions": [], "classes": [], "parser_used": "ast"},
+            jd_tech_stack=["Python"],
+            ranked_chunks=ranked_chunks,
+        )
+
+        assert "JD-Ranked Code Chunks" in prompt
+        assert "handle_request" in prompt
+        assert "api/routes.py" in prompt
+
+    def test_without_ranked_chunks(self):
+        """ranked_chunks=None → 청크 섹션 생략"""
+        prompt = build_overview_prompt(
+            files=[],
+            commit_diffs=[],
+            ast_summary={"functions": [], "classes": [], "parser_used": "ast"},
+            jd_tech_stack=["Python"],
+            ranked_chunks=None,
+        )
+
+        assert "JD-Ranked Code Chunks" not in prompt
+
+    def test_empty_inputs(self):
+        """모든 빈 입력 → 에러 없이 유효한 프롬프트"""
+        prompt = build_overview_prompt(
+            files=[],
+            commit_diffs=[],
+            ast_summary={},
+            jd_tech_stack=[],
+        )
+
+        assert isinstance(prompt, str)
+        assert len(prompt) > 50  # 프롬프트 프레임워크 최소 길이
+        assert "Your Task" in prompt
+
+
+# ============================================================
+# TestBuildDeepAnalysisPrompt
+# ============================================================
+
+class TestBuildDeepAnalysisPrompt:
+    """build_deep_analysis_prompt — Stage 2 프롬프트 생성"""
+
+    def test_source_code_priority(self):
+        """source_code 있으면 diff 대신 사용"""
+        prompt = build_deep_analysis_prompt(
+            file_info={
+                "path": "service.py",
+                "source_code": "def create_user(name):\n    return User(name=name)\n",
+                "diff": "should not appear",
+            },
+            commit_history=[],
+            jd_tech_stack=["Python"],
+        )
+
+        assert "create_user" in prompt
+        assert "should not appear" not in prompt
+        assert "Source Code" in prompt
+
+    def test_diff_fallback(self):
+        """source_code 없으면 diff 사용"""
+        prompt = build_deep_analysis_prompt(
+            file_info={
+                "path": "service.py",
+                "diff": "+def old_func():\n+    pass",
+            },
+            commit_history=[],
+            jd_tech_stack=["Python"],
+        )
+
+        assert "old_func" in prompt
+        assert "Code/Diff Content" in prompt
+
+    def test_metadata_section(self):
+        """identifiers/imports/decorators → 'Code Metadata' 섹션"""
+        prompt = build_deep_analysis_prompt(
+            file_info={
+                "path": "handler.py",
+                "source_code": "pass",
+                "identifiers": ["Request", "Response", "JSONResponse"],
+                "imports": ["from fastapi import Request"],
+                "decorators": ["app.get"],
+                "relevance_score": {
+                    "jd_keyword_score": 0.8,
+                    "interview_potential": 0.6,
+                },
+            },
+            commit_history=[],
+            jd_tech_stack=["FastAPI"],
+        )
+
+        assert "Code Metadata" in prompt
+        assert "Request" in prompt
+        assert "fastapi" in prompt
+        assert "app.get" in prompt
+        assert "JD Relevance" in prompt
+
+    def test_source_truncation(self):
+        """8000자 초과 소스 절삭"""
+        long_source = "x = 1\n" * 2000  # ~12K chars
+        prompt = build_deep_analysis_prompt(
+            file_info={
+                "path": "big.py",
+                "source_code": long_source,
+            },
+            commit_history=[],
+            jd_tech_stack=[],
+        )
+
+        # 프롬프트 내 소스코드가 8000자 이하로 잘림
+        # (프롬프트 전체 길이가 아닌, 소스코드 부분만)
+        assert len(prompt) < len(long_source) + 2000  # 프롬프트 오버헤드 감안
+
+
+# ============================================================
+# TestBuildSynthesisPrompt
+# ============================================================
+
+class TestBuildSynthesisPrompt:
+    """build_synthesis_prompt — Stage 3 프롬프트 생성"""
+
+    def test_basic_structure(self):
+        """'Overview Analysis', 'Deep Analysis Results' 섹션 포함"""
+        prompt = build_synthesis_prompt(
+            overview={
+                "tech_overview": "FastAPI backend service",
+                "primary_languages": ["Python"],
+                "frameworks_detected": ["FastAPI"],
+                "key_files": [{"path": "main.py"}],
+            },
+            deep_analyses=[
+                {
+                    "file_path": "main.py",
+                    "patterns_found": ["Repository"],
+                    "algorithms_used": [],
+                    "code_quality_score": 0.8,
+                    "notable_aspects": ["Clean architecture"],
+                    "question_candidates": ["How did you design the API?"],
+                }
+            ],
+            repo_info={"name": "test-repo"},
+            jd_tech_stack=["Python", "FastAPI"],
+        )
+
+        assert "Overview Analysis" in prompt
+        assert "Deep Analysis Results" in prompt
+        assert "test-repo" in prompt
+        assert "FastAPI backend service" in prompt
+        assert "Repository" in prompt
+        assert "main.py" in prompt

--- a/backend/tests/test_pipeline_integration.py
+++ b/backend/tests/test_pipeline_integration.py
@@ -1,0 +1,136 @@
+"""
+backend/tests/test_pipeline_integration.py
+코드 분석 파이프라인 통합 테스트 (JIT-26)
+
+합성 레포로 전체 파이프라인 E2E 검증.
+외부 API/Docker 불필요 — tmp_path 합성 레포만 사용.
+"""
+import pytest
+
+
+class TestPipelineIntegration:
+    """코드 분석 파이프라인 E2E 통합 테스트"""
+
+    def _create_fastapi_repo(self, tmp_path):
+        """합성 FastAPI 프로젝트 레포 생성"""
+        (tmp_path / "main.py").write_text(
+            "from fastapi import FastAPI\n\n"
+            "app = FastAPI()\n\n"
+            "@app.get('/health')\n"
+            "async def health_check():\n"
+            "    return {'status': 'ok'}\n\n"
+            "@app.post('/users')\n"
+            "async def create_user(name: str):\n"
+            "    return {'name': name}\n"
+        )
+        (tmp_path / "models.py").write_text(
+            "from pydantic import BaseModel\n\n"
+            "class User(BaseModel):\n"
+            "    name: str\n"
+            "    email: str\n\n"
+            "class UserCreate(BaseModel):\n"
+            "    name: str\n"
+        )
+        (tmp_path / "utils.py").write_text(
+            "import os\n\n"
+            "def get_env(key: str) -> str:\n"
+            "    return os.getenv(key, '')\n"
+        )
+
+    def test_directory_to_chunks_to_scoring(self, tmp_path):
+        """analyze_directory → rank_chunks: FastAPI 관련 청크가 유틸리티보다 높은 점수"""
+        from app.services.ast_analyzer import analyze_directory
+        from app.services.chunk_scorer import rank_chunks_by_relevance
+
+        self._create_fastapi_repo(tmp_path)
+
+        # Step 1: analyze_directory
+        chunks = analyze_directory(str(tmp_path))
+        assert len(chunks) >= 3  # 최소 3개 이상의 함수/클래스 청크
+
+        # Step 2: rank_chunks_by_relevance
+        jd_tech_stack = ["Python", "FastAPI", "PostgreSQL"]
+        ranked = rank_chunks_by_relevance(
+            chunks=chunks,
+            jd_tech_stack=jd_tech_stack,
+            token_budget=50_000,
+        )
+
+        assert len(ranked) >= 1
+
+        # FastAPI 엔드포인트 함수가 유틸리티 함수보다 JD 관련성이 높아야 함
+        fastapi_chunks = [c for c in ranked if "fastapi" in " ".join(c.get("imports", [])).lower() or "app" in c.get("source_code", "").lower()]
+        util_chunks = [c for c in ranked if c.get("file_path", "").endswith("utils.py")]
+
+        if fastapi_chunks and util_chunks:
+            best_fastapi_score = max(
+                c.get("relevance_score", {}).get("total_score", 0) for c in fastapi_chunks
+            )
+            best_util_score = max(
+                c.get("relevance_score", {}).get("total_score", 0) for c in util_chunks
+            )
+            assert best_fastapi_score >= best_util_score
+
+    def test_chunks_to_overview_prompt(self, tmp_path):
+        """청크 → build_overview_prompt: 프롬프트에 합성 레포 파일명 포함"""
+        from app.services.ast_analyzer import analyze_directory
+        from app.services.chunk_scorer import rank_chunks_by_relevance
+        from app.services.code_analysis_prompts import build_overview_prompt
+
+        self._create_fastapi_repo(tmp_path)
+
+        chunks = analyze_directory(str(tmp_path))
+        ranked = rank_chunks_by_relevance(
+            chunks=chunks,
+            jd_tech_stack=["Python", "FastAPI"],
+            token_budget=50_000,
+        )
+
+        prompt = build_overview_prompt(
+            files=[{"filename": "main.py", "added": 50, "complexity": 3}],
+            commit_diffs=[],
+            ast_summary={"functions": [{"name": "health_check"}], "classes": [], "parser_used": "ast"},
+            jd_tech_stack=["Python", "FastAPI"],
+            ranked_chunks=ranked,
+        )
+
+        assert "main.py" in prompt
+        assert "JD-Ranked Code Chunks" in prompt
+        # 랭킹된 청크 중 하나의 이름이 프롬프트에 포함
+        any_chunk_name_in_prompt = any(c["name"] in prompt for c in ranked)
+        assert any_chunk_name_in_prompt
+
+    def test_token_budget_respected(self, tmp_path):
+        """token_budget=500 → 선택된 청크 총 char_count < budget*4"""
+        from app.services.ast_analyzer import analyze_directory
+        from app.services.chunk_scorer import rank_chunks_by_relevance
+
+        self._create_fastapi_repo(tmp_path)
+
+        chunks = analyze_directory(str(tmp_path))
+        token_budget = 500
+
+        ranked = rank_chunks_by_relevance(
+            chunks=chunks,
+            jd_tech_stack=["Python", "FastAPI"],
+            token_budget=token_budget,
+        )
+
+        # 선택된 청크의 총 char_count//4가 토큰 예산 이하
+        total_est_tokens = sum(c.get("char_count", 0) // 4 for c in ranked)
+        assert total_est_tokens <= token_budget
+
+    @pytest.mark.asyncio
+    async def test_validation_on_full_result(self, sample_jd_tech_stack, valid_repo_result):
+        """전체 결과 dict → validate_code_analysis, valid=True"""
+        from unittest.mock import patch, MagicMock
+        from app.workflows.activities.code_analysis import validate_code_analysis
+
+        with patch("app.core.observability.is_langfuse_enabled", return_value=False), \
+             patch("app.workflows.activities.code_analysis.activity") as mock_activity:
+            mock_activity.heartbeat = MagicMock()
+            result = await validate_code_analysis(valid_repo_result)
+
+        assert result["valid"] is True
+        assert result["issues"] == []
+        assert result["metrics"]["commit_count"] == 50


### PR DESCRIPTION
## Summary
- AST 디렉토리 분석기 (`analyze_directory`) 14개 테스트 — 파일 탐색, 필터링, Python AST 파싱, TS fallback
- 3-Stage 프롬프트 빌더 (`build_*_prompt`) 9개 테스트 — overview/deep/synthesis 프롬프트 생성 검증
- 코드 분석 Activity (`validate_code_analysis`, `_get_file_commits`, `calculate_dynamic_token_budget`) 11개 테스트
- E2E 파이프라인 통합 4개 테스트 — 합성 레포로 directory→chunks→scoring→prompt→validation 전체 흐름 검증

## Test plan
- [x] `pytest backend/tests/test_ast_analyzer.py` — 14 passed
- [x] `pytest backend/tests/test_code_analysis_prompts.py` — 9 passed
- [x] `pytest backend/tests/test_code_analysis.py` (신규 클래스) — 11 passed
- [x] `pytest backend/tests/test_pipeline_integration.py` — 4 passed
- [x] 전체 38개 신규 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)