### PR TITLE
fix: 테스트 3개 파일 실제 구현체와 동기화

### DIFF
--- a/backend/tests/test_document_parser.py
+++ b/backend/tests/test_document_parser.py
@@ -122,44 +122,35 @@ class TestGeminiOCR:
         assert result.metadata.get("ocr") is True
 
     @pytest.mark.asyncio
-    async def test_pymupdf_used_when_sufficient(self, tmp_path, monkeypatch):
-        """pymupdf4llm 결과가 충분히 길면 그대로 사용"""
+    async def test_gemini_used_when_api_key_present(self, tmp_path, monkeypatch):
+        """GEMINI_API_KEY 설정 시 Gemini-only 파싱 사용"""
         from unittest.mock import AsyncMock
         import app.services.document_parser as dp
 
         pdf_file = tmp_path / "test.pdf"
         pdf_file.write_bytes(b"%PDF-1.4 fake pdf content")
 
-        long_text = "A" * 500  # 충분히 긴 텍스트
-        monkeypatch.setattr(dp, "_extract_with_pymupdf", AsyncMock(return_value=long_text))
+        gemini_text = "A" * 500  # Gemini가 반환하는 텍스트
 
         class MockSettings:
             GEMINI_API_KEY = "fake-key"
             PDF_PARSER_MIN_CHARS = 200
 
         monkeypatch.setattr("app.core.config.settings", MockSettings())
+        monkeypatch.setattr(dp, "_extract_with_gemini", AsyncMock(return_value=gemini_text))
 
         result = await dp._parse_pdf(str(pdf_file))
-        assert result.parser_used == "pymupdf4llm"
+        assert result.parser_used == "gemini-2.5-flash"
         assert len(result.text) == 500
+        assert result.metadata.get("ocr") is True
 
     @pytest.mark.asyncio
-    async def test_gemini_skipped_when_no_api_key(self, tmp_path, monkeypatch):
-        """GEMINI_API_KEY 미설정 시 Gemini 스킵"""
-        from unittest.mock import AsyncMock
+    async def test_gemini_raises_when_no_api_key(self, tmp_path, monkeypatch):
+        """GEMINI_API_KEY 미설정 시 ValueError 발생"""
         import app.services.document_parser as dp
 
         pdf_file = tmp_path / "test.pdf"
         pdf_file.write_bytes(b"%PDF-1.4 fake pdf content")
-
-        # pymupdf4llm 짧은 결과
-        monkeypatch.setattr(dp, "_extract_with_pymupdf", AsyncMock(return_value="short"))
-
-        # Docling도 실패
-        monkeypatch.setattr(
-            dp, "_extract_with_docling",
-            AsyncMock(side_effect=Exception("Docling failed"))
-        )
 
         class MockSettings:
             GEMINI_API_KEY = None  # 미설정
@@ -167,10 +158,8 @@ class TestGeminiOCR:
 
         monkeypatch.setattr("app.core.config.settings", MockSettings())
 
-        # 최종 결과는 짧은 pymupdf4llm 결과
-        result = await dp._parse_pdf(str(pdf_file))
-        assert result.parser_used == "pymupdf4llm"
-        assert result.metadata.get("quality") == "low"
+        with pytest.raises(ValueError, match="Gemini API key is not configured"):
+            await dp._parse_pdf(str(pdf_file))
 
 
 class TestDocumentAnalysisActivity:

--- a/backend/tests/test_linkedin_integration.py
+++ b/backend/tests/test_linkedin_integration.py
@@ -106,8 +106,10 @@ class TestLinkedInServiceNormalization:
 
         normalized = service._normalize_profile(raw_data, "https://linkedin.com/in/byun")
 
-        # null 처리 확인
-        assert normalized["experiences"] == []
+        # experience=None이지만 current_company fallback으로 1개 생성
+        assert len(normalized["experiences"]) == 1
+        assert normalized["experiences"][0]["company"] == "MoriAI"
+        # education=None → 빈 리스트
         assert normalized["education"] == []
 
         # 다른 데이터는 정상 추출

--- a/backend/tests/test_question_generation.py
+++ b/backend/tests/test_question_generation.py
@@ -413,8 +413,12 @@ class TestReviseQuestions:
         """피드백 기반 질문 수정"""
         from app.workflows.activities.question_generation import revise_questions
 
-        questions = [
+        all_questions = [
             {"question_text": "Python 경험을 설명해주세요.", "category": "technical_depth"},
+        ]
+
+        flagged_questions = [
+            {"question_text": "Python 경험을 설명해주세요.", "category": "technical_depth", "_original_idx": 0},
         ]
 
         review_feedback = {
@@ -422,7 +426,7 @@ class TestReviseQuestions:
         }
 
         mock_revised = [
-            {"question_text": "Python으로 해결한 가장 복잡한 문제는 무엇인가요?", "category": "technical_depth"},
+            {"question_text": "Python으로 해결한 가장 복잡한 문제는 무엇인가요?", "category": "technical_depth", "original_index": 0},
         ]
 
         async def mock_llm_run(prompt_config, **kwargs):
@@ -430,7 +434,7 @@ class TestReviseQuestions:
 
         with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
              patch(HEARTBEAT_PATCH):
-            result = await revise_questions(questions, review_feedback, mock_enriched_input)
+            result = await revise_questions(all_questions, flagged_questions, review_feedback, mock_enriched_input)
 
             assert isinstance(result, list)
             assert len(result) > 0
@@ -444,12 +448,16 @@ class TestReviseQuestions:
             {"question_text": "Original question", "category": "technical_depth"},
         ]
 
+        flagged_questions = [
+            {"question_text": "Original question", "category": "technical_depth", "_original_idx": 0},
+        ]
+
         async def mock_llm_run(prompt_config, **kwargs):
             return "Not a list"
 
         with patch(LLM_RUN_PATCH, side_effect=mock_llm_run), \
              patch(HEARTBEAT_PATCH):
-            result = await revise_questions(original_questions, {}, mock_enriched_input)
+            result = await revise_questions(original_questions, flagged_questions, {}, mock_enriched_input)
 
             # 원본 반환
             assert result == original_questions


### PR DESCRIPTION
## Summary
- `test_document_parser`: Gemini-only PDF 파싱 로직 반영 (pymupdf fallback 제거, API key 미설정 시 ValueError)
- `test_linkedin_integration`: current_company fallback으로 experience 1개 생성 반영
- `test_question_generation`: `revise_questions()` 시그니처 변경 (`flagged_questions` 파라미터 추가) 반영

## Test plan
- [x] 변경된 3개 테스트 파일: 41 passed, 4 skipped
- [x] 전체 회귀: 557 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)