### PR TITLE
fix: result_type → output_type pydantic-ai v1.x 호환 [JIT-31]

### DIFF
--- a/backend/app/services/cached_llm.py
+++ b/backend/app/services/cached_llm.py
@@ -382,7 +382,7 @@ class CachedLLMService:
 
         ms = self._model_settings(model, override_max_tokens, temperature=temperature)
         try:
-            agent = get_llm_agent(result_type=result_type, model=model)
+            agent = get_llm_agent(output_type=result_type, model=model)
             run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
         except asyncio.CancelledError:
             logger.warning(f"LLM call cancelled for model {model}")
@@ -393,7 +393,7 @@ class CachedLLMService:
                 logger.warning(f"Primary LLM ({model}) failed: {primary_err}. Trying fallback: {fallback_model}")
                 if trace_meta:
                     self._log_fallback_event(model, fallback_model, trace_meta)
-                agent = get_llm_agent(result_type=result_type, model=fallback_model)
+                agent = get_llm_agent(output_type=result_type, model=fallback_model)
                 run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
             else:
                 raise

--- a/backend/app/services/llm_config.py
+++ b/backend/app/services/llm_config.py
@@ -196,14 +196,14 @@ def _is_native_pydantic_ai_model(model_name: str) -> bool:
 
 
 def get_llm_agent(
-    result_type: Any = None,
+    output_type: Any = None,
     system_prompt: str = "",
     model: str | None = None,
 ):
     """Pydantic AI Agent 생성
 
     Args:
-        result_type: Pydantic 모델 (구조화 출력용)
+        output_type: Pydantic 모델 (구조화 출력용, pydantic-ai v1.x)
         system_prompt: 시스템 프롬프트
         model: LLM 모델명 (기본값: settings.LLM_MODEL)
 
@@ -236,8 +236,8 @@ def get_llm_agent(
             model_instance = model_name
 
     kwargs = {"model": model_instance}
-    if result_type:
-        kwargs["result_type"] = result_type
+    if output_type:
+        kwargs["output_type"] = output_type
     if system_prompt:
         kwargs["system_prompt"] = system_prompt
 


### PR DESCRIPTION
## Summary
- pydantic-ai v1.58.0에서 `Agent` 파라미터 `result_type` → `output_type` 변경으로 모든 구조화 LLM 호출 실패 수정
- `llm_config.py`: `get_llm_agent()` 파라미터 및 `Agent()` 전달 키워드 변경
- `cached_llm.py`: `get_llm_agent()` 호출부 `output_type` 적용

## Test plan
- [x] Docker 환경 테스트 557 passed, 4 skipped
- [x] Kimi K2 Agent 생성 검증 (`output_type=TestModel`)
- [x] Claude Sonnet fallback Agent 생성 검증
- [ ] `USE_CLONE_BASED_ANALYSIS=true`로 실제 Job 실행 → Kimi K2 fallback 없이 완료 확인

Closes JIT-31

🤖 Generated with [Claude Code](https://claude.com/claude-code)