### PR TITLE
fix: HYBRID 파이프라인 contributions 0 집계 수정 [JIT-32]

### DIFF
--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -720,11 +720,13 @@ async def _analyze_single_repo_impl(
             if static_analysis.get("overall_avg_cc", 0) > 0:
                 quality_metrics["avg_cc"] = static_analysis["overall_avg_cc"]
 
+        total_commits = driller_result["stats"]["total_commits"]
         result = {
             "repo_url": repo_url,
             "repo_name": repo_name,
             "language": primary_lang,
-            "candidate_commits": driller_result["stats"]["total_commits"],
+            "candidate_commits": total_commits,
+            "commit_count": total_commits,
             "candidate_additions": driller_result["stats"]["total_additions"],
             "avg_complexity": driller_result["stats"]["avg_complexity"],
             "monthly_contributions": driller_result.get("monthly_contributions", []),


### PR DESCRIPTION
## Summary
- HYBRID 경로 `_analyze_single_repo_impl()` 결과에 `commit_count` 키 누락
- `intel_generation.py`가 `r.get("commit_count", 0)`으로 contributions 합산 → HYBRID에서 항상 0
- Legacy는 `commit_count` + `candidate_commits` 둘 다 설정 → 정상 (363)
- HYBRID 결과에 `commit_count` 키 추가하여 Legacy와 동일하게 동작

## Root Cause
```python
# intel_generation.py:53
total_commits = sum(r.get("commit_count", 0) for r in repos)  # ← 이 키를 사용

# Legacy: commit_count ✅ + candidate_commits ✅
# HYBRID: commit_count ❌ + candidate_commits ✅ → contributions=0
```

## Test plan
- [x] 기존 테스트 557 passed, 4 skipped
- [ ] HYBRID 잡 실행 → `intel.github.contributions > 0` 확인
- [ ] Legacy/HYBRID contributions 값 비교 (±10% 이내)

Closes JIT-32

🤖 Generated with [Claude Code](https://claude.com/claude-code)