### PR TITLE
feat: Stage 4.5 confidence threshold + Cross-Repo 검증 + 파이프라인 메트릭 확장 [JIT-37]

### DIFF
--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -187,6 +187,43 @@ async def analyze_code(
                 "notable_implementations": analysis.get("notable_implementations", []),
             })
 
+    # ================================================================
+    # JIT-37: Cross-Repo 검증 — 모든 레포 분석 완료 후
+    # ================================================================
+    if use_clone_based and len(repositories) >= 2:
+        activity.heartbeat("Cross-repo author verification...")
+        try:
+            from app.services.github_service import GitHubService
+            results_by_repo = {}
+            for repo in repositories:
+                ir = repo.get("_identity_result")
+                if ir is not None:
+                    results_by_repo[repo["repo_name"]] = ir
+
+            if len(results_by_repo) >= 2:
+                cross_result = GitHubService.verify_cross_repo(results_by_repo)
+                # 검증 결과를 각 repo의 candidate_identification에 반영
+                for repo in repositories:
+                    ci = repo.get("candidate_identification", {})
+                    ci["cross_repo_verified"] = cross_result.cross_repo_verified
+                    if cross_result.best_match:
+                        ci["cross_repo_best_author"] = cross_result.best_match.name
+                        ci["cross_repo_confidence"] = cross_result.best_match.confidence
+                        ci["cross_repo_repos_matched"] = cross_result.best_match.repos_matched
+                    repo["candidate_identification"] = ci
+
+                logger.info(
+                    f"Cross-repo verification: verified={cross_result.cross_repo_verified}, "
+                    f"best={cross_result.best_match.name if cross_result.best_match else None}, "
+                    f"repos_matched={len(results_by_repo)}"
+                )
+        except Exception as e:
+            logger.warning(f"Cross-repo verification failed (non-fatal): {e}")
+
+    # JIT-37: _identity_result 내부 필드 제거 (외부 결과에 포함시키지 않음)
+    for repo in repositories:
+        repo.pop("_identity_result", None)
+
     # Aggregate
     all_notables = []
     for repo in repositories:
@@ -292,7 +329,7 @@ def _jd_to_file_types(jd_tech_stack: list[str]) -> list[str]:
 
 
 def _log_pipeline_metrics(result: dict, use_clone_based: bool) -> None:
-    """JIT-25: A/B 비교용 파이프라인 메트릭 로깅"""
+    """JIT-25/37: A/B 비교용 파이프라인 메트릭 로깅"""
     repos = result.get("repositories", [])
     pipeline_label = "HYBRID" if use_clone_based else "LEGACY"
 
@@ -311,6 +348,27 @@ def _log_pipeline_metrics(result: dict, use_clone_based: bool) -> None:
             hybrid_chunks += meta.get("ranked_chunks_count", 0)
             hybrid_deep += meta.get("deep_analyses_count", 0)
 
+    # JIT-37: author 식별 메트릭
+    from collections import Counter
+    methods = []
+    confidences = []
+    cross_repo_count = 0
+    for repo in repos:
+        ci = repo.get("candidate_identification", {})
+        method = ci.get("method", "none")
+        if "/" in method:
+            method = method.split("/")[-1]  # "git_author_validation/name_exact" → "name_exact"
+        methods.append(method)
+        score = ci.get("confidence_score")
+        if score is not None:
+            confidences.append(score)
+        if ci.get("cross_repo_verified"):
+            cross_repo_count += 1
+
+    method_counter = Counter(methods)
+    author_match_method = method_counter.most_common(1)[0][0] if method_counter else "none"
+    author_avg_confidence = round(sum(confidences) / len(confidences), 2) if confidences else 0.0
+
     logger.info(
         f"[A/B] pipeline={pipeline_label} "
         f"repos={len(repos)} "
@@ -319,7 +377,10 @@ def _log_pipeline_metrics(result: dict, use_clone_based: bool) -> None:
         f"tech={tech_count} "
         f"question_candidates={question_candidates} "
         f"hybrid_chunks={hybrid_chunks} "
-        f"hybrid_deep={hybrid_deep}"
+        f"hybrid_deep={hybrid_deep} "
+        f"author_method={author_match_method} "
+        f"author_avg_confidence={author_avg_confidence} "
+        f"cross_repo_match={cross_repo_count}"
     )
 
 
@@ -470,12 +531,14 @@ async def _analyze_single_repo_impl(
                 logger.warning(f"Git log fallback failed for {repo_name}: {e}")
 
         # ================================================================
-        # Stage 4.5: GitHub username → git author 검증 (JIT-35)
+        # Stage 4.5: GitHub username → git author 검증 (JIT-35/37)
         # 7단계 휴리스틱 + AuthorIdentityResult 배열 반환.
-        # top_committer_fallback 삭제, confidence 0.0~1.0 수치 반환.
+        # JIT-37: confidence < 0.5 → author 필터 비적용 (전체 커밋 수집)
         # ================================================================
         # JIT-36: 다중 author 목록 (PyDriller에 list[str]로 전달)
         candidate_author_names: list[str] = []
+        # JIT-37: cross-repo 검증용 identity_result 보존
+        repo_identity_result = None
 
         if candidate_username and clone_dir:
             try:
@@ -487,39 +550,59 @@ async def _analyze_single_repo_impl(
                         identity_result = GitHubService.resolve_author_by_identity(
                             candidate_username, git_authors, repo_name=repo_name,
                         )
+                        repo_identity_result = identity_result  # JIT-37: cross-repo용 보존
+
                         if identity_result.best_match:
                             best = identity_result.best_match
-                            original = candidate_username
-                            candidate_username = best.name
-                            confidence = (
-                                "high" if best.confidence >= 0.9
-                                else "medium" if best.confidence >= 0.6
-                                else "low"
-                            )
-                            # JIT-36: identity-linked 매칭에서 모든 author name 수집
-                            candidate_author_names = list(dict.fromkeys(
-                                m.name for m in identity_result.matches
-                                if m.method != "commit_pattern_analysis"
-                            ))
-                            candidate_identification = {
-                                "method": f"git_author_validation/{best.method}",
-                                "confidence": confidence,
-                                "confidence_score": best.confidence,
-                                "original_username": original,
-                                "resolved_username": candidate_username,
-                                "matched_author": best.name,
-                                "matched_email": best.email,
-                                "matched_commits": best.commits,
-                                "match_candidates": len(identity_result.matches),
-                                "author_names": candidate_author_names,
-                            }
-                            logger.info(
-                                f"Git author resolved: {original} → "
-                                f"{candidate_username} for {repo_name} "
-                                f"(method={best.method}, "
-                                f"confidence={best.confidence}, "
-                                f"all_authors={candidate_author_names})"
-                            )
+
+                            # JIT-37: confidence < 0.5 → author 필터 비적용
+                            if best.confidence < 0.5:
+                                logger.warning(
+                                    f"Low confidence ({best.confidence}) for "
+                                    f"{candidate_username} in {repo_name} — "
+                                    f"skipping author filter (full commit collection)"
+                                )
+                                candidate_username = None
+                                candidate_identification = {
+                                    "method": f"git_author_validation/{best.method}",
+                                    "confidence": "low",
+                                    "confidence_score": best.confidence,
+                                    "original_username": candidate_username,
+                                    "resolved_username": None,
+                                    "skipped_low_confidence": True,
+                                }
+                            else:
+                                original = candidate_username
+                                candidate_username = best.name
+                                confidence = (
+                                    "high" if best.confidence >= 0.9
+                                    else "medium" if best.confidence >= 0.6
+                                    else "low"
+                                )
+                                # JIT-36: identity-linked 매칭에서 모든 author name 수집
+                                candidate_author_names = list(dict.fromkeys(
+                                    m.name for m in identity_result.matches
+                                    if m.method != "commit_pattern_analysis"
+                                ))
+                                candidate_identification = {
+                                    "method": f"git_author_validation/{best.method}",
+                                    "confidence": confidence,
+                                    "confidence_score": best.confidence,
+                                    "original_username": original,
+                                    "resolved_username": candidate_username,
+                                    "matched_author": best.name,
+                                    "matched_email": best.email,
+                                    "matched_commits": best.commits,
+                                    "match_candidates": len(identity_result.matches),
+                                    "author_names": candidate_author_names,
+                                }
+                                logger.info(
+                                    f"Git author resolved: {original} → "
+                                    f"{candidate_username} for {repo_name} "
+                                    f"(method={best.method}, "
+                                    f"confidence={best.confidence}, "
+                                    f"all_authors={candidate_author_names})"
+                                )
             except Exception as e:
                 logger.warning(f"Git author validation failed for {repo_name}: {e}")
 
@@ -808,6 +891,8 @@ async def _analyze_single_repo_impl(
             "static_analysis": static_analysis,
             # 후보자 식별 메타데이터
             "candidate_identification": candidate_identification,
+            # JIT-37: cross-repo 검증용 identity_result (내부 전용, 최종 결과에서 제거)
+            "_identity_result": repo_identity_result,
             # HYBRID 분석 메타데이터
             "hybrid_metadata": {
                 "key_files_count": len(key_files),

--- a/backend/tests/test_stage_45_integration.py
+++ b/backend/tests/test_stage_45_integration.py
@@ -1,0 +1,343 @@
+"""Stage 4.5 교체 + Cross-Repo 검증 통합 테스트 (JIT-37).
+
+테스트 시나리오:
+1. 높은 confidence: name_exact 매칭(1.0) → author 필터 적용
+2. 낮은 confidence: 0.4 미만 → author 필터 비적용, 전체 커밋 수집
+3. Cross-Repo 매칭: 3개 레포 중 2개에서 동일 author → confidence 부스트
+4. Fork 레포 방어: fork 레포에서 잘못된 author → confidence 낮아 필터 스킵
+5. 메트릭 로깅: author_avg_confidence, author_method, cross_repo_match 기록
+"""
+
+import pytest
+from collections import Counter
+
+from app.models.author_identity import AuthorIdentityResult, AuthorMatch
+from app.services.github_service import GitHubService
+from app.workflows.activities.code_analysis import _log_pipeline_metrics
+
+
+# ──────────────────────────────────────────────
+# 1. 높은 confidence → author 필터 적용
+# ──────────────────────────────────────────────
+
+class TestHighConfidenceFilter:
+    """confidence >= 0.5 → author 필터 적용."""
+
+    def test_name_exact_applies_filter(self):
+        """name_exact(1.0) → best_match 반환, 필터 적용 가능."""
+        authors = [
+            {"name": "sabyun", "email": "s@g.com", "commits": 50},
+            {"name": "other", "email": "o@g.com", "commits": 10},
+        ]
+        result = GitHubService.resolve_author_by_identity("sabyun", authors)
+        assert result.best_match is not None
+        assert result.best_match.confidence >= 0.5
+        assert result.best_match.name == "sabyun"
+
+    def test_noreply_applies_filter(self):
+        """noreply_email(0.95) → best_match 반환, 필터 적용 가능."""
+        authors = [
+            {"name": "DevUser", "email": "12345+sabyun@users.noreply.github.com", "commits": 40},
+        ]
+        result = GitHubService.resolve_author_by_identity("sabyun", authors)
+        assert result.best_match is not None
+        assert result.best_match.confidence >= 0.5
+
+    def test_email_prefix_applies_filter(self):
+        """email_prefix(0.9) → 필터 적용 가능."""
+        authors = [
+            {"name": "John Doe", "email": "sabyun@company.com", "commits": 25},
+        ]
+        result = GitHubService.resolve_author_by_identity("sabyun", authors)
+        assert result.best_match is not None
+        assert result.best_match.confidence >= 0.5
+
+
+# ──────────────────────────────────────────────
+# 2. 낮은 confidence → author 필터 비적용
+# ──────────────────────────────────────────────
+
+class TestLowConfidenceSkip:
+    """confidence < 0.5 → author 필터 비적용 (전체 커밋 수집)."""
+
+    def test_commit_pattern_only_below_threshold(self):
+        """commit_pattern_analysis(0.5)만 매칭 → best_match=None (identity 필터 제외)."""
+        authors = [
+            {"name": "major-contributor", "email": "mc@gmail.com", "commits": 80},
+            {"name": "minor1", "email": "m1@gmail.com", "commits": 10},
+            {"name": "minor2", "email": "m2@gmail.com", "commits": 10},
+        ]
+        result = GitHubService.resolve_author_by_identity("unknown-user", authors)
+        # commit_pattern_analysis는 best_match 후보에서 제외됨
+        assert result.best_match is None
+
+    def test_no_match_returns_none(self):
+        """매칭 없음 → best_match=None, 필터 비적용."""
+        authors = [
+            {"name": "completely-different", "email": "cd@gmail.com", "commits": 5},
+        ]
+        result = GitHubService.resolve_author_by_identity("sabyun", authors)
+        assert result.best_match is None
+
+    def test_confidence_threshold_simulation(self):
+        """confidence < 0.5인 AuthorMatch로 threshold 동작 검증."""
+        # 실제 코드 로직 시뮬레이션:
+        # if best.confidence < 0.5 → candidate_username = None
+        low_match = AuthorMatch(
+            name="weak-match", email="w@g.com", commits=5,
+            confidence=0.4, method="name_substring",
+        )
+        # 실제 코드에서 이 조건으로 분기
+        assert low_match.confidence < 0.5
+        # → candidate_username = None, author 필터 비적용
+
+        high_match = AuthorMatch(
+            name="strong-match", email="s@g.com", commits=50,
+            confidence=0.9, method="name_exact",
+        )
+        assert high_match.confidence >= 0.5
+        # → candidate_username = best.name, author 필터 적용
+
+
+# ──────────────────────────────────────────────
+# 3. Cross-Repo 매칭
+# ──────────────────────────────────────────────
+
+class TestCrossRepoIntegration:
+    """Cross-Repo 검증 통합 동작."""
+
+    def test_two_repo_match_boosts_confidence(self):
+        """2개 레포에서 동일 author → confidence 부스트."""
+        repo_a = GitHubService.resolve_author_by_identity(
+            "sabyun",
+            [{"name": "sabyun", "email": "s@g.com", "commits": 30}],
+            repo_name="repo-a",
+        )
+        repo_b = GitHubService.resolve_author_by_identity(
+            "sabyun",
+            [{"name": "sabyun", "email": "s@g.com", "commits": 20}],
+            repo_name="repo-b",
+        )
+
+        merged = GitHubService.verify_cross_repo({
+            "repo-a": repo_a,
+            "repo-b": repo_b,
+        })
+
+        assert merged.cross_repo_verified is True
+        assert merged.best_match is not None
+        assert merged.best_match.confidence == 1.0  # 1.0 * 1.3 → cap 1.0
+        assert merged.best_match.commits == 50
+        assert len(merged.best_match.repos_matched) == 2
+
+    def test_cross_repo_updates_identification(self):
+        """cross-repo 결과가 candidate_identification dict에 반영되는 형식."""
+        # 실제 analyze_code() 내부 로직 시뮬레이션
+        repo_a_result = GitHubService.resolve_author_by_identity(
+            "sabyun",
+            [{"name": "sabyun", "email": "s@g.com", "commits": 30}],
+            repo_name="repo-a",
+        )
+
+        cross_result = GitHubService.verify_cross_repo({
+            "repo-a": repo_a_result,
+        })
+
+        # 단일 레포만 있으면 cross_repo_verified=False
+        ci = {}
+        ci["cross_repo_verified"] = cross_result.cross_repo_verified
+        if cross_result.best_match:
+            ci["cross_repo_best_author"] = cross_result.best_match.name
+            ci["cross_repo_confidence"] = cross_result.best_match.confidence
+
+        assert "cross_repo_verified" in ci
+        assert ci["cross_repo_verified"] is False
+
+    def test_three_repos_two_match(self):
+        """3개 레포 중 2개 매칭, 1개 미매칭 → verified=True."""
+        repo_a = GitHubService.resolve_author_by_identity(
+            "sabyun",
+            [{"name": "sabyun", "email": "s@g.com", "commits": 30}],
+            repo_name="repo-a",
+        )
+        repo_b = GitHubService.resolve_author_by_identity(
+            "sabyun",
+            [{"name": "sabyun", "email": "s@company.com", "commits": 20}],
+            repo_name="repo-b",
+        )
+        repo_c = GitHubService.resolve_author_by_identity(
+            "sabyun",
+            [{"name": "unrelated", "email": "u@gmail.com", "commits": 100}],
+            repo_name="repo-c",
+        )
+
+        merged = GitHubService.verify_cross_repo({
+            "repo-a": repo_a,
+            "repo-b": repo_b,
+            "repo-c": repo_c,
+        })
+
+        assert merged.cross_repo_verified is True
+        assert merged.best_match.name == "sabyun"
+
+
+# ──────────────────────────────────────────────
+# 4. Fork 레포 방어
+# ──────────────────────────────────────────────
+
+class TestForkRepoDefense:
+    """Fork 레포에서 잘못된 author 매칭 방어."""
+
+    def test_fork_repo_no_identity_match(self):
+        """Fork 레포 — Ubuntu/root/bot만 있으면 매칭 없음 → 필터 비적용."""
+        fork_authors = [
+            {"name": "Ubuntu", "email": "ubuntu@ip.internal", "commits": 500},
+            {"name": "root", "email": "root@localhost", "commits": 100},
+            {"name": "dependabot[bot]", "email": "bot@github.com", "commits": 50},
+        ]
+        result = GitHubService.resolve_author_by_identity("real-candidate", fork_authors)
+        # identity 매칭 없음 → best_match=None → 전체 커밋 수집
+        assert result.best_match is None
+
+    def test_fork_commit_pattern_excluded_from_best(self):
+        """Fork 레포 — commit_pattern_analysis만 매칭 → best_match에서 제외."""
+        authors = [
+            {"name": "fork-owner", "email": "fo@gmail.com", "commits": 200},
+            {"name": "minor", "email": "m@gmail.com", "commits": 5},
+        ]
+        result = GitHubService.resolve_author_by_identity("actual-user", authors)
+        # fork-owner가 commit_pattern_analysis로 매칭될 수 있지만 best_match에서 제외
+        if result.best_match:
+            assert result.best_match.method != "commit_pattern_analysis"
+
+
+# ──────────────────────────────────────────────
+# 5. 메트릭 로깅
+# ──────────────────────────────────────────────
+
+class TestPipelineMetrics:
+    """_log_pipeline_metrics의 author 식별 메트릭."""
+
+    def test_metrics_with_author_data(self):
+        """author 식별 메트릭이 로깅에 포함되는지 확인."""
+        result = {
+            "repositories": [
+                {
+                    "repo_name": "repo-a",
+                    "analysis": {"tech_stack": ["Python"], "patterns": []},
+                    "notable_implementations": [],
+                    "candidate_identification": {
+                        "method": "git_author_validation/name_exact",
+                        "confidence_score": 1.0,
+                        "cross_repo_verified": True,
+                    },
+                    "hybrid_metadata": {"ranked_chunks_count": 5, "deep_analyses_count": 3},
+                },
+                {
+                    "repo_name": "repo-b",
+                    "analysis": {"tech_stack": ["Python"], "patterns": []},
+                    "notable_implementations": [],
+                    "candidate_identification": {
+                        "method": "git_author_validation/noreply_email",
+                        "confidence_score": 0.95,
+                        "cross_repo_verified": True,
+                    },
+                    "hybrid_metadata": {"ranked_chunks_count": 3, "deep_analyses_count": 2},
+                },
+            ],
+            "combined_tech_stack": ["Python"],
+            "total_patterns": 0,
+            "total_notable_implementations": 0,
+            "top_question_candidates": [],
+        }
+
+        # 메트릭 추출 로직 재현 (실제 함수 내부 로직)
+        repos = result["repositories"]
+        methods = []
+        confidences = []
+        cross_repo_count = 0
+        for repo in repos:
+            ci = repo.get("candidate_identification", {})
+            method = ci.get("method", "none")
+            if "/" in method:
+                method = method.split("/")[-1]
+            methods.append(method)
+            score = ci.get("confidence_score")
+            if score is not None:
+                confidences.append(score)
+            if ci.get("cross_repo_verified"):
+                cross_repo_count += 1
+
+        method_counter = Counter(methods)
+        author_match_method = method_counter.most_common(1)[0][0]
+        author_avg_confidence = round(sum(confidences) / len(confidences), 2)
+
+        assert author_match_method in ["name_exact", "noreply_email"]
+        assert 0.97 <= author_avg_confidence <= 0.98  # (1.0 + 0.95) / 2 ≈ 0.975
+        assert cross_repo_count == 2
+
+    def test_metrics_no_author_data(self):
+        """author 식별 없는 레포 — 기본값 처리."""
+        result = {
+            "repositories": [
+                {
+                    "repo_name": "repo-a",
+                    "analysis": {"tech_stack": [], "patterns": []},
+                    "notable_implementations": [],
+                    "candidate_identification": {
+                        "method": "none",
+                        "confidence": "low",
+                    },
+                    "hybrid_metadata": {},
+                },
+            ],
+            "combined_tech_stack": [],
+            "total_patterns": 0,
+            "total_notable_implementations": 0,
+            "top_question_candidates": [],
+        }
+
+        repos = result["repositories"]
+        methods = []
+        confidences = []
+        for repo in repos:
+            ci = repo.get("candidate_identification", {})
+            method = ci.get("method", "none")
+            if "/" in method:
+                method = method.split("/")[-1]
+            methods.append(method)
+            score = ci.get("confidence_score")
+            if score is not None:
+                confidences.append(score)
+
+        method_counter = Counter(methods)
+        author_match_method = method_counter.most_common(1)[0][0]
+        author_avg_confidence = round(sum(confidences) / len(confidences), 2) if confidences else 0.0
+
+        assert author_match_method == "none"
+        assert author_avg_confidence == 0.0
+
+    def test_log_pipeline_metrics_runs_without_error(self):
+        """_log_pipeline_metrics 함수가 에러 없이 실행되는지 확인."""
+        result = {
+            "repositories": [
+                {
+                    "repo_name": "repo-a",
+                    "analysis": {"tech_stack": ["Python"], "patterns": ["singleton"]},
+                    "notable_implementations": [{"desc": "test"}],
+                    "candidate_identification": {
+                        "method": "git_author_validation/name_exact",
+                        "confidence_score": 1.0,
+                        "cross_repo_verified": False,
+                    },
+                    "hybrid_metadata": {"ranked_chunks_count": 5, "deep_analyses_count": 3},
+                },
+            ],
+            "combined_tech_stack": ["Python"],
+            "total_patterns": 1,
+            "total_notable_implementations": 1,
+            "top_question_candidates": [{"desc": "test"}],
+        }
+        # 에러 없이 실행되면 통과
+        _log_pipeline_metrics(result, use_clone_based=True)
+        _log_pipeline_metrics(result, use_clone_based=False)


### PR DESCRIPTION
## Summary
- **confidence < 0.5 threshold**: `best_match.confidence < 0.5`이면 해당 레포에서 author 필터를 적용하지 않고 전체 커밋 수집
- **Cross-Repo 검증**: 모든 레포 분석 완료 후 `verify_cross_repo()` 호출, 2+ 레포에서 동일 author 매칭 시 confidence 부스트, 결과를 `candidate_identification`에 반영
- **파이프라인 메트릭 확장**: `_log_pipeline_metrics()`에 `author_method`, `author_avg_confidence`, `cross_repo_match` 메트릭 추가
- 기존 Legacy 파이프라인 영향 없음

## Files Changed
- `backend/app/workflows/activities/code_analysis.py` — Stage 4.5 threshold + Cross-Repo + 메트릭
- `backend/tests/test_stage_45_integration.py` — 14개 통합 테스트

## Test Result
- 49 passed (기존 35 + 신규 14), 0 failed

## Linear
- https://linear.app/jittda/issue/JIT-37

🤖 Generated with [Claude Code](https://claude.com/claude-code)