### PR TITLE
feat: Zero-Contribution 레포 필터링 + 기여도 검증 로직 [JIT-39]

### DIFF
--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -792,6 +792,69 @@ class GitHubService:
             cross_repo_verified=cross_verified,
         )
 
+    @staticmethod
+    def validate_repo_contributions(
+        repo_result: dict,
+    ) -> dict:
+        """
+        레포 기여도 정합성 검증 (JIT-39)
+
+        1. contributions vs 실제 커밋 수 일치 확인
+        2. 불일치 시 실제 커밋 수로 보정
+        3. zero-contribution 여부 판별
+
+        Args:
+            repo_result: analyze_single_repo 결과 dict
+
+        Returns:
+            {
+                "is_zero_contribution": bool,
+                "original_contributions": int,
+                "validated_contributions": int,
+                "correction_applied": bool,
+                "correction_reason": str | None,
+                "repo_name": str,
+            }
+        """
+        repo_name = repo_result.get("repo_name", "unknown")
+        commit_count = repo_result.get("candidate_commits", 0)
+        # monthly_contributions 합산 = 실제 커밋 SHA 기반 수치
+        monthly = repo_result.get("monthly_contributions", [])
+        actual_commit_sum = sum(monthly) if monthly else commit_count
+
+        correction_applied = False
+        correction_reason = None
+
+        # 정합성 검증: contributions와 실제 커밋 수 비교
+        if commit_count != actual_commit_sum and actual_commit_sum > 0:
+            correction_applied = True
+            correction_reason = (
+                f"contributions mismatch: reported={commit_count}, "
+                f"actual_sha_count={actual_commit_sum}"
+            )
+            logger.warning(
+                f"[JIT-39] {repo_name}: {correction_reason} — "
+                f"correcting to {actual_commit_sum}"
+            )
+
+        validated = actual_commit_sum if correction_applied else commit_count
+        is_zero = validated == 0
+
+        if is_zero:
+            logger.info(
+                f"[JIT-39] repo {repo_name} excluded: "
+                f"zero contributions after author filtering"
+            )
+
+        return {
+            "is_zero_contribution": is_zero,
+            "original_contributions": commit_count,
+            "validated_contributions": validated,
+            "correction_applied": correction_applied,
+            "correction_reason": correction_reason,
+            "repo_name": repo_name,
+        }
+
     async def match_candidate_from_git_log(
         self,
         clone_dir: str,

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -224,6 +224,59 @@ async def analyze_code(
     for repo in repositories:
         repo.pop("_identity_result", None)
 
+    # ================================================================
+    # JIT-39: Zero-Contribution 레포 필터링 + 기여도 정합성 검증
+    # ================================================================
+    from app.services.github_service import GitHubService as _GHSvc
+
+    repo_contribution_breakdown: list[dict] = []
+    filtered_repositories: list[dict] = []
+    zero_excluded_count = 0
+
+    for repo in repositories:
+        validation = _GHSvc.validate_repo_contributions(repo)
+        repo_contribution_breakdown.append(validation)
+
+        if validation["is_zero_contribution"]:
+            zero_excluded_count += 1
+            logger.info(
+                f"[JIT-39] Excluding {validation['repo_name']}: "
+                f"zero contributions after author filtering"
+            )
+            continue
+
+        # 기여도 보정 적용
+        if validation["correction_applied"]:
+            repo["candidate_commits"] = validation["validated_contributions"]
+            repo["commit_count"] = validation["validated_contributions"]
+
+        filtered_repositories.append(repo)
+
+    # 전체 레포 Zero인 경우 → 원본 유지 + 경고
+    if not filtered_repositories and repositories:
+        logger.warning(
+            "[JIT-39] All repos have zero contributions — "
+            "keeping original results as fallback"
+        )
+        filtered_repositories = repositories
+
+    if zero_excluded_count > 0:
+        logger.info(
+            f"[JIT-39] Filtered {zero_excluded_count} zero-contribution repos "
+            f"({len(filtered_repositories)} remaining)"
+        )
+
+    repositories = filtered_repositories
+
+    # Langfuse span에 repo_contribution_breakdown 기록
+    try:
+        from langfuse.decorators import langfuse_context
+        langfuse_context.update_current_observation(
+            metadata={"repo_contribution_breakdown": repo_contribution_breakdown}
+        )
+    except Exception:
+        pass  # Langfuse 비활성 환경에서 무시
+
     # Aggregate
     all_notables = []
     for repo in repositories:
@@ -258,6 +311,9 @@ async def analyze_code(
         "monthly_contributions": aggregated_monthly,
         # JIT-25: 파이프라인 메타데이터
         "pipeline_type": "clone_based" if use_clone_based else "legacy",
+        # JIT-39: Zero-contribution 필터링 메타데이터
+        "zero_contribution_excluded": zero_excluded_count,
+        "repo_contribution_breakdown": repo_contribution_breakdown,
     }
 
     # JIT-25: A/B 비교 메트릭 로깅
@@ -369,6 +425,13 @@ def _log_pipeline_metrics(result: dict, use_clone_based: bool) -> None:
     author_match_method = method_counter.most_common(1)[0][0] if method_counter else "none"
     author_avg_confidence = round(sum(confidences) / len(confidences), 2) if confidences else 0.0
 
+    # JIT-39: Zero-contribution 메트릭
+    zero_excluded = result.get("zero_contribution_excluded", 0)
+    corrections = sum(
+        1 for b in result.get("repo_contribution_breakdown", [])
+        if b.get("correction_applied")
+    )
+
     logger.info(
         f"[A/B] pipeline={pipeline_label} "
         f"repos={len(repos)} "
@@ -380,7 +443,9 @@ def _log_pipeline_metrics(result: dict, use_clone_based: bool) -> None:
         f"hybrid_deep={hybrid_deep} "
         f"author_method={author_match_method} "
         f"author_avg_confidence={author_avg_confidence} "
-        f"cross_repo_match={cross_repo_count}"
+        f"cross_repo_match={cross_repo_count} "
+        f"zero_excluded={zero_excluded} "
+        f"contribution_corrections={corrections}"
     )
 
 

--- a/backend/tests/test_zero_contribution_filter.py
+++ b/backend/tests/test_zero_contribution_filter.py
@@ -1,0 +1,198 @@
+"""Zero-Contribution 레포 필터링 + 기여도 검증 유닛 테스트 (JIT-39).
+
+테스트 시나리오:
+1. 정상 레포: 커밋 10개 → contributions=10, 결과에 포함
+2. Zero 레포: author 매칭 후 커밋 0개 → 결과에서 제외 + 로그 기록
+3. 정합성 불일치: contributions=5이지만 SHA 3개 → 경고 + 3으로 보정
+4. 전체 레포 Zero: 모든 레포 기여도 0 → 원본 유지 fallback
+5. Langfuse 검증: breakdown에 repo_contribution_breakdown 메타데이터 존재
+"""
+
+import pytest
+
+from app.services.github_service import GitHubService
+
+
+# ──────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────
+
+@pytest.fixture
+def normal_repo() -> dict:
+    """정상 기여 레포 (커밋 10개)."""
+    return {
+        "repo_name": "my-project",
+        "repo_url": "https://github.com/user/my-project",
+        "candidate_commits": 10,
+        "commit_count": 10,
+        "monthly_contributions": [2, 1, 3, 0, 1, 0, 0, 1, 0, 2, 0, 0],
+        "analysis": {"tech_stack": ["Python"], "patterns": []},
+        "notable_implementations": [],
+    }
+
+
+@pytest.fixture
+def zero_repo() -> dict:
+    """Zero-contribution 레포 (author 매칭 후 커밋 0개)."""
+    return {
+        "repo_name": "forked-repo",
+        "repo_url": "https://github.com/org/forked-repo",
+        "candidate_commits": 0,
+        "commit_count": 0,
+        "monthly_contributions": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "analysis": {"tech_stack": ["JavaScript"], "patterns": []},
+        "notable_implementations": [],
+    }
+
+
+@pytest.fixture
+def mismatched_repo() -> dict:
+    """정합성 불일치 레포 (contributions=5, 실제 SHA=3)."""
+    return {
+        "repo_name": "partial-repo",
+        "repo_url": "https://github.com/user/partial-repo",
+        "candidate_commits": 5,
+        "commit_count": 5,
+        "monthly_contributions": [1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+        "analysis": {"tech_stack": ["TypeScript"], "patterns": []},
+        "notable_implementations": [],
+    }
+
+
+# ──────────────────────────────────────────────
+# Test: validate_repo_contributions
+# ──────────────────────────────────────────────
+
+class TestValidateRepoContributions:
+    """GitHubService.validate_repo_contributions() 유닛 테스트."""
+
+    def test_normal_repo_valid(self, normal_repo):
+        """시나리오 1: 정상 레포 — contributions=10, 결과에 포함."""
+        result = GitHubService.validate_repo_contributions(normal_repo)
+
+        assert result["is_zero_contribution"] is False
+        assert result["original_contributions"] == 10
+        assert result["validated_contributions"] == 10
+        assert result["correction_applied"] is False
+        assert result["correction_reason"] is None
+        assert result["repo_name"] == "my-project"
+
+    def test_zero_contribution_detected(self, zero_repo):
+        """시나리오 2: Zero 레포 — 커밋 0개 → is_zero_contribution=True."""
+        result = GitHubService.validate_repo_contributions(zero_repo)
+
+        assert result["is_zero_contribution"] is True
+        assert result["original_contributions"] == 0
+        assert result["validated_contributions"] == 0
+        assert result["repo_name"] == "forked-repo"
+
+    def test_contribution_mismatch_corrected(self, mismatched_repo):
+        """시나리오 3: 정합성 불일치 — contributions=5, SHA=3 → 3으로 보정."""
+        result = GitHubService.validate_repo_contributions(mismatched_repo)
+
+        assert result["is_zero_contribution"] is False
+        assert result["original_contributions"] == 5
+        assert result["validated_contributions"] == 3
+        assert result["correction_applied"] is True
+        assert "mismatch" in result["correction_reason"]
+        assert "reported=5" in result["correction_reason"]
+        assert "actual_sha_count=3" in result["correction_reason"]
+
+    def test_empty_monthly_fallback(self):
+        """monthly_contributions 없을 때 candidate_commits fallback."""
+        repo = {
+            "repo_name": "no-monthly",
+            "candidate_commits": 7,
+            "monthly_contributions": [],
+        }
+        result = GitHubService.validate_repo_contributions(repo)
+
+        # monthly 빈 리스트 → sum=0 → candidate_commits(7) 사용
+        assert result["validated_contributions"] == 7
+        assert result["is_zero_contribution"] is False
+
+    def test_no_monthly_key(self):
+        """monthly_contributions 키 자체가 없을 때."""
+        repo = {
+            "repo_name": "no-key",
+            "candidate_commits": 5,
+        }
+        result = GitHubService.validate_repo_contributions(repo)
+
+        assert result["validated_contributions"] == 5
+        assert result["is_zero_contribution"] is False
+
+
+# ──────────────────────────────────────────────
+# Test: Zero-contribution 필터링 통합 로직
+# ──────────────────────────────────────────────
+
+class TestZeroContributionFiltering:
+    """code_analysis.py의 필터링 로직을 시뮬레이션하는 통합 테스트."""
+
+    def test_mixed_repos_filtering(self, normal_repo, zero_repo, mismatched_repo):
+        """정상 + Zero + 불일치 혼합 → Zero만 제외."""
+        repositories = [normal_repo, zero_repo, mismatched_repo]
+
+        filtered = []
+        breakdown = []
+        zero_count = 0
+
+        for repo in repositories:
+            v = GitHubService.validate_repo_contributions(repo)
+            breakdown.append(v)
+            if v["is_zero_contribution"]:
+                zero_count += 1
+                continue
+            if v["correction_applied"]:
+                repo["candidate_commits"] = v["validated_contributions"]
+                repo["commit_count"] = v["validated_contributions"]
+            filtered.append(repo)
+
+        assert len(filtered) == 2
+        assert zero_count == 1
+        assert filtered[0]["repo_name"] == "my-project"
+        assert filtered[1]["repo_name"] == "partial-repo"
+        # 보정 확인
+        assert filtered[1]["candidate_commits"] == 3
+
+    def test_all_zero_fallback(self, zero_repo):
+        """시나리오 4: 전체 레포 Zero → 원본 유지 fallback."""
+        zero_repo2 = {**zero_repo, "repo_name": "another-zero"}
+        repositories = [zero_repo, zero_repo2]
+
+        filtered = []
+        for repo in repositories:
+            v = GitHubService.validate_repo_contributions(repo)
+            if not v["is_zero_contribution"]:
+                filtered.append(repo)
+
+        # 전체 Zero → fallback
+        if not filtered and repositories:
+            filtered = repositories
+
+        assert len(filtered) == 2
+        assert filtered[0]["repo_name"] == "forked-repo"
+
+    def test_breakdown_has_all_repos(self, normal_repo, zero_repo):
+        """시나리오 5: breakdown에 모든 레포(포함/제외 모두)의 검증 결과 존재."""
+        repositories = [normal_repo, zero_repo]
+
+        breakdown = []
+        for repo in repositories:
+            v = GitHubService.validate_repo_contributions(repo)
+            breakdown.append(v)
+
+        assert len(breakdown) == 2
+        assert breakdown[0]["repo_name"] == "my-project"
+        assert breakdown[0]["is_zero_contribution"] is False
+        assert breakdown[1]["repo_name"] == "forked-repo"
+        assert breakdown[1]["is_zero_contribution"] is True
+
+        # Langfuse metadata 구조 검증
+        for entry in breakdown:
+            assert "is_zero_contribution" in entry
+            assert "original_contributions" in entry
+            assert "validated_contributions" in entry
+            assert "correction_applied" in entry
+            assert "repo_name" in entry


### PR DESCRIPTION
## Summary
- author 매칭 후 커밋 0개인 fork 레포를 자동 필터링하여 HYBRID 파이프라인 기여도 정확성 개선
- contributions vs 실제 커밋 SHA 정합성 검증 + 불일치 시 자동 보정
- Langfuse span에 `repo_contribution_breakdown` 메타데이터 기록

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `backend/app/services/github_service.py` | `validate_repo_contributions()` 헬퍼 추가 |
| `backend/app/workflows/activities/code_analysis.py` | JIT-39 필터링 로직 + Langfuse 기록 + 메트릭 확장 |
| `backend/tests/test_zero_contribution_filter.py` | 8개 유닛 테스트 (신규) |

## 테스트 결과
- `614 passed, 4 skipped` (기존 테스트 영향 없음)
- JIT-39 전용 테스트 8개 전체 통과

## Linear
https://linear.app/jittda/issue/JIT-39

🤖 Generated with [Claude Code](https://claude.com/claude-code)