### PR TITLE
docs: Langfuse-First 프롬프트 업로드 필수 규칙 추가

### DIFF
--- a/docs/claude-refs/dev-rules.md
+++ b/docs/claude-refs/dev-rules.md
@@ -32,6 +32,13 @@ frontend/e2e/                      → Playwright E2E 테스트
 - 한 파일에 한 컴포넌트 (SRP)
 - 새 파일 생성 시 기존 파일과 책임 중복 금지
 
+## Langfuse-First 프롬프트 규칙
+
+🔴 **YAML 프롬프트 수정 시 Langfuse 업로드 필수**:
+1. `backend/app/prompts/*.yaml` 수정 후 반드시 Langfuse에 업로드
+2. `docker compose exec backend python scripts/upload_prompts_to_langfuse.py --production`
+3. Langfuse가 runtime에서 우선 적용되므로, YAML만 수정하고 업로드하지 않으면 변경이 반영되지 않음
+
 ## Utility Scripts
 
 | 스크립트 | 사용법 |


### PR DESCRIPTION
## Summary
- `dev-rules.md`에 Langfuse-First 프롬프트 규칙 섹션 추가
- YAML 프롬프트 수정 시 Langfuse 업로드 필수임을 명시
- 업로드하지 않으면 런타임에 반영되지 않는 이유 설명

## Test plan
- [x] 문서 변경만으로 코드 영향 없음

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)