### PR TITLE
feat: LinkedIn 세부 페이지 수집 + 레포 관련성 스코어링 + 추천서/봉사활동 서머리 [JIT-46~52]

### DIFF
--- a/backend/app/models/candidate_profile.py
+++ b/backend/app/models/candidate_profile.py
@@ -95,11 +95,15 @@ class UnifiedCandidateProfile(BaseModel):
     # 커버레터 인사이트
     cover_letter_insights: CoverLetterProfile | None = None
 
-    # LinkedIn 확장 데이터 (현재 미사용 → 활용)
+    # LinkedIn 확장 데이터
     linkedin_activity_summary: str | None = None
     linkedin_projects: list[dict] = Field(default_factory=list)
     linkedin_honors: list[dict] = Field(default_factory=list)
+    linkedin_recommendations: list[dict] = Field(default_factory=list)
+    linkedin_volunteer_experience: list[dict] = Field(default_factory=list)
     recommendations_count: int = 0
+    recommendations_summary: str | None = None      # LLM 서머리 (JIT-48)
+    volunteer_summary: str | None = None             # LLM 서머리 (JIT-48)
 
     # 탐색 포인트
     areas_to_probe: list[str] = Field(default_factory=list)

--- a/backend/app/models/input.py
+++ b/backend/app/models/input.py
@@ -92,6 +92,24 @@ class LinkedInActivity(BaseModel):
     link: str | None = None
 
 
+class LinkedInRecommendation(BaseModel):
+    """LinkedIn 추천서"""
+    from_user: str
+    text: str | None = None
+    date: str | None = None
+    relationship: str | None = None  # "managed directly", "worked together"
+
+
+class LinkedInVolunteer(BaseModel):
+    """LinkedIn 봉사활동"""
+    organization: str
+    role: str | None = None
+    cause: str | None = None
+    starts_at: str | None = None
+    ends_at: str | None = None
+    description: str | None = None
+
+
 class LinkedInProfile(BaseModel):
     """Bright Data Web Scraper API 응답에서 추출한 LinkedIn 프로필
 
@@ -126,6 +144,10 @@ class LinkedInProfile(BaseModel):
 
     # 활동 (새로 추가)
     activity: list[LinkedInActivity] = Field(default_factory=list)
+
+    # 추천서/봉사활동 (JIT-47)
+    recommendations: list[LinkedInRecommendation] = Field(default_factory=list)
+    volunteer_experience: list[LinkedInVolunteer] = Field(default_factory=list)
 
     # 연결
     followers: int | None = None

--- a/backend/app/prompts/__init__.py
+++ b/backend/app/prompts/__init__.py
@@ -331,6 +331,8 @@ def _prompt_key_to_activity_name(filename: str, key: str) -> str:
         ("v2_generation.yaml", "radar_analysis"): "radar_analysis",
         ("v2_generation.yaml", "decision_summary"): "decision_summary",
         ("v2_generation.yaml", "interviewer_tips"): "interviewer_tips",
+        ("linkedin_summary.yaml", "recommendations_summary"): "profile_builder",
+        ("linkedin_summary.yaml", "volunteer_summary"): "profile_builder",
     }
 
     mapping_key = (filename, key)

--- a/backend/app/prompts/linkedin_summary.yaml
+++ b/backend/app/prompts/linkedin_summary.yaml
@@ -1,0 +1,45 @@
+prompts:
+  recommendations_summary:
+    description: "LinkedIn 추천서 분석 및 서머리 생성"
+    template: |
+      # ROLE
+      You are an expert HR analyst. Analyze LinkedIn recommendations to extract hiring insights.
+
+      # LANGUAGE REQUIREMENT
+      Write ALL output in {{output_language}}.
+
+      # INPUT
+      Below are LinkedIn recommendations for a candidate:
+
+      {{recommendations}}
+
+      # TASK
+      Summarize in 2-3 sentences:
+      1. Recommenders' relationships (supervisor/colleague/subordinate)
+      2. Commonly mentioned strengths
+      3. Notable specific achievements
+
+      # OUTPUT FORMAT
+      Return ONLY the summary text, no JSON wrapping.
+
+  volunteer_summary:
+    description: "LinkedIn 봉사활동 분석 및 서머리 생성"
+    template: |
+      # ROLE
+      You are an expert HR analyst. Analyze volunteer experience to assess values and leadership.
+
+      # LANGUAGE REQUIREMENT
+      Write ALL output in {{output_language}}.
+
+      # INPUT
+      Below are volunteer activities for a candidate:
+
+      {{volunteer_activities}}
+
+      # TASK
+      Summarize in 1-2 sentences:
+      1. Main areas of activity and roles
+      2. Consistency and dedication level
+
+      # OUTPUT FORMAT
+      Return ONLY the summary text, no JSON wrapping.

--- a/backend/app/prompts/v2_generation.yaml
+++ b/backend/app/prompts/v2_generation.yaml
@@ -315,16 +315,20 @@ prompts:
       3. Red flags to watch for during interview — each MUST include the data source in parentheses
          Example: "GitHub 활동이 최근 6개월간 없음 (GitHub)" or "이력서 경력 갭 2023-2024 (Resume)"
 
-      # MULTI-SOURCE DATA (JIT-43)
+      # MULTI-SOURCE DATA (JIT-43/50)
       The candidate_profile may contain enriched multi-source data:
       - "unified_skills": skills with source attribution (resume, github, linkedin)
       - "linkedin_experiences": LinkedIn career history for cross-referencing with resume
       - "linkedin_honors": certifications, awards from LinkedIn
+      - "recommendations_summary": LLM-generated summary of LinkedIn recommendations
+      - "volunteer_summary": LLM-generated summary of volunteer experience
       When multi-source data is available:
       - Cross-reference resume claims with LinkedIn data for verification tips
       - Note discrepancies between resume and LinkedIn as red flags
       - Use LinkedIn honors/certifications as positive verification points
       - Tag red flags with the specific source: "(Resume)", "(GitHub)", "(LinkedIn)", "(Resume vs LinkedIn)"
+      - If recommendations_summary is available, use it to identify strengths confirmed by others
+      - If volunteer_summary is available, assess candidate's leadership and values
 
       # INPUT
       Questions:

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -125,9 +125,42 @@ class GitHubService:
         target_languages: list[str],
         min_language_ratio: float = 0.3,
     ) -> list[dict]:
-        """JD 기술스택과 매칭되는 레포 필터링"""
+        """JD 기술스택과 매칭되는 레포 필터링 (하위 호환)"""
+        return await self.select_relevant_repos(
+            github_urls=github_urls,
+            target_languages=target_languages,
+            min_language_ratio=min_language_ratio,
+        )
+
+    async def select_relevant_repos(
+        self,
+        github_urls: list[str],
+        target_languages: list[str],
+        min_language_ratio: float = 0.2,
+        jd_text: str = "",
+        jd_keywords: list[str] | None = None,
+    ) -> list[dict]:
+        """JD 기반 레포 관련성 스코어링 + 필터링 (JIT-49)
+
+        스코어링 공식:
+            score = (lang_match × 0.3) + (size_activity × 0.3) + (jd_keyword × 0.4)
+
+        Args:
+            github_urls: 레포 URL 목록
+            target_languages: JD 기술스택 언어 목록
+            min_language_ratio: 최소 언어 비율 (하위 호환)
+            jd_text: JD 전체 텍스트 (키워드 매칭용)
+            jd_keywords: JD 키워드 목록 (없으면 jd_text에서 추출)
+
+        Returns:
+            관련성 높은 순으로 정렬된 레포 목록
+        """
         target_set = {lang.lower() for lang in target_languages}
-        matched = []
+        scored_repos = []
+
+        # JD 키워드 추출 (jd_text에서)
+        if not jd_keywords and jd_text:
+            jd_keywords = self._extract_jd_keywords(jd_text)
 
         for url in github_urls:
             languages = await self.get_repo_languages(url)
@@ -138,19 +171,101 @@ class GitHubService:
             if total_bytes == 0:
                 continue
 
-            matched_bytes = sum(
-                bytes_count for lang, bytes_count in languages.items()
-                if lang.lower() in target_set
+            info = await self.get_repo_info(url)
+            if info.get("error"):
+                continue
+
+            # 최소 레포 크기 필터 (100KB 이하 제외)
+            repo_size = info.get("size", 0) or 0
+            if repo_size < 100:
+                logger.debug(f"Skipping small repo ({repo_size}KB): {url}")
+                continue
+
+            # 스코어링
+            score = self._score_repo_relevance(
+                info=info,
+                languages=languages,
+                total_bytes=total_bytes,
+                target_set=target_set,
+                jd_keywords=jd_keywords or [],
             )
-            ratio = matched_bytes / total_bytes
 
-            if ratio >= min_language_ratio:
-                info = await self.get_repo_info(url)
+            if score >= 0.2:
                 info["languages"] = languages
-                info["jd_match_ratio"] = ratio
-                matched.append(info)
+                info["jd_match_ratio"] = score
+                info["relevance_score"] = score
+                scored_repos.append(info)
 
-        return matched
+        # 관련성 높은 순 정렬
+        scored_repos.sort(key=lambda r: r.get("relevance_score", 0), reverse=True)
+
+        logger.info(
+            f"Repo selection: {len(github_urls)} candidates → "
+            f"{len(scored_repos)} relevant (target_languages={target_languages})"
+        )
+
+        return scored_repos
+
+    @staticmethod
+    def _score_repo_relevance(
+        info: dict,
+        languages: dict,
+        total_bytes: int,
+        target_set: set[str],
+        jd_keywords: list[str],
+    ) -> float:
+        """레포 관련성 점수 계산 (JIT-49)
+
+        score = (lang_match × 0.3) + (size_activity × 0.3) + (jd_keyword × 0.4)
+        """
+        # 1. 언어 매칭 점수 (0.0-1.0)
+        matched_bytes = sum(
+            bytes_count for lang, bytes_count in languages.items()
+            if lang.lower() in target_set
+        )
+        lang_match = matched_bytes / total_bytes if total_bytes > 0 else 0.0
+
+        # 2. 크기/활동 점수 (0.0-1.0)
+        repo_size = info.get("size", 0) or 0
+        size_score = min(repo_size / 5000, 1.0)
+        stars = info.get("stars", 0) or 0
+        forks = info.get("forks", 0) or 0
+        activity_score = min((stars + forks * 2) / 50, 1.0)
+        size_activity = size_score * 0.7 + activity_score * 0.3
+
+        # 3. JD 키워드 매칭 점수 (0.0-1.0)
+        jd_keyword_score = 0.0
+        if jd_keywords:
+            description = (info.get("description") or "").lower()
+            repo_name = (info.get("name") or "").lower()
+            searchable = f"{description} {repo_name}"
+
+            matched_keywords = sum(
+                1 for kw in jd_keywords
+                if kw.lower() in searchable
+            )
+            jd_keyword_score = min(matched_keywords / max(len(jd_keywords), 1), 1.0)
+
+        score = (lang_match * 0.3) + (size_activity * 0.3) + (jd_keyword_score * 0.4)
+        return round(score, 3)
+
+    @staticmethod
+    def _extract_jd_keywords(jd_text: str) -> list[str]:
+        """JD 텍스트에서 기술 키워드 추출"""
+        tech_keywords = {
+            "python", "javascript", "typescript", "java", "go", "rust", "ruby",
+            "react", "vue", "angular", "next.js", "nuxt", "svelte",
+            "node.js", "express", "fastapi", "django", "flask", "spring",
+            "tensorflow", "pytorch", "langchain", "llm", "rag",
+            "aws", "azure", "gcp", "docker", "kubernetes", "terraform",
+            "postgresql", "mysql", "mongodb", "redis", "elasticsearch",
+            "graphql", "rest", "grpc", "microservices",
+            "temporal", "kafka", "rabbitmq", "celery",
+            "ci/cd", "github actions", "jenkins",
+            "machine learning", "deep learning", "nlp", "computer vision",
+        }
+        jd_lower = jd_text.lower()
+        return [kw for kw in tech_keywords if kw in jd_lower]
 
     async def get_account_type(self, username: str) -> dict:
         """

--- a/backend/app/services/linkedin_service.py
+++ b/backend/app/services/linkedin_service.py
@@ -21,12 +21,23 @@ from app.exceptions import LinkedInFetchError
 logger = logging.getLogger(__name__)
 
 LINKEDIN_URL_PATTERN = re.compile(
-    r"^https?://(?:www\.)?linkedin\.com/in/[\w\-]+/?$"
+    r"^https?://(?:www\.)?linkedin\.com/in/[\w\-]+(?:/(?:details/[\w\-]+)?)?/?$"
 )
 MAX_RETRIES = 2
 RETRY_BACKOFF = 1.0  # seconds
 POLL_INTERVAL = 5.0  # seconds
 MAX_POLL_ATTEMPTS = 24  # 5s × 24 = 최대 2분 대기
+
+# LinkedIn 세부 페이지 7종 (접힌 섹션 데이터 수집용)
+DETAIL_PAGES = [
+    "details/experience/",
+    "details/skills/",
+    "details/education/",
+    "details/projects/",
+    "details/honors/",
+    "details/recommendations/",
+    "details/volunteering/",
+]
 
 
 class LinkedInService:
@@ -80,13 +91,26 @@ class LinkedInService:
         raise LinkedInFetchError(f"Bright Data request failed after retries: {last_error}") from last_error
 
     async def _fetch_profile(self, linkedin_url: str) -> dict | None:
-        """Bright Data 비동기 API 호출 (trigger → poll → retrieve)"""
+        """Bright Data 비동기 API 호출 (메인 프로필 + 세부 페이지 병렬 수집)
+
+        1. 메인 프로필 + 7개 세부 페이지 URL을 한 번에 트리거
+        2. 폴링 후 결과 조회
+        3. 세부 페이지 데이터를 메인 프로필에 병합
+        """
+        # 프로필 base URL 정규화 (trailing slash 포함)
+        base_url = linkedin_url.rstrip("/")
+
+        # 메인 프로필 + 세부 페이지 URL 구성
+        urls_to_fetch = [{"url": linkedin_url}]
+        for page in DETAIL_PAGES:
+            urls_to_fetch.append({"url": f"{base_url}/{page}"})
+
         async with httpx.AsyncClient(timeout=30.0) as client:
-            # 1. 수집 트리거
+            # 1. 수집 트리거 (메인 + 세부 페이지 일괄)
             trigger_resp = await client.post(
                 f"{self.BASE_URL}/trigger",
                 params={"dataset_id": self.DATASET_ID},
-                json=[{"url": linkedin_url}],
+                json=urls_to_fetch,
                 headers=self.headers,
             )
 
@@ -102,7 +126,10 @@ class LinkedInService:
             if not snapshot_id:
                 raise LinkedInFetchError(f"No snapshot_id in trigger response: {trigger_data}")
 
-            logger.info(f"Bright Data collection started: {snapshot_id}")
+            logger.info(
+                f"Bright Data collection started: {snapshot_id} "
+                f"({len(urls_to_fetch)} URLs: main + {len(DETAIL_PAGES)} detail pages)"
+            )
 
             # 2. 상태 폴링
             for poll_attempt in range(MAX_POLL_ATTEMPTS):
@@ -145,15 +172,157 @@ class LinkedInService:
                 )
 
             data = snapshot_resp.json()
-            # Bright Data는 배열로 반환
-            if isinstance(data, list) and len(data) > 0:
-                return self._normalize_profile(data[0], linkedin_url)
-            return None
+            if not isinstance(data, list) or len(data) == 0:
+                return None
+
+            # 4. 메인 프로필 + 세부 페이지 병합
+            main_profile = data[0]
+            detail_results = data[1:] if len(data) > 1 else []
+            merged = self._merge_detail_pages(main_profile, detail_results)
+
+            return self._normalize_profile(merged, linkedin_url)
 
     @staticmethod
     def validate_url(url: str) -> bool:
         """LinkedIn 프로필 URL 유효성 검증"""
         return bool(LINKEDIN_URL_PATTERN.match(url))
+
+    @staticmethod
+    def _merge_detail_pages(main: dict, details: list[dict]) -> dict:
+        """세부 페이지 데이터를 메인 프로필에 병합
+
+        Bright Data는 세부 페이지에서 접힌 섹션의 전체 데이터를 반환.
+        메인 프로필의 해당 섹션이 불완전하면 세부 페이지 데이터로 보강.
+        """
+        if not details:
+            return main
+
+        merged = dict(main)
+
+        for detail in details:
+            if not isinstance(detail, dict):
+                continue
+
+            # 경력 병합 (title+company 기준 중복 제거)
+            detail_exp = detail.get("experience") or detail.get("experiences") or []
+            if detail_exp and isinstance(detail_exp, list):
+                existing_exp = merged.get("experience") or merged.get("experiences") or []
+                existing_keys = set()
+                for exp in existing_exp:
+                    if isinstance(exp, dict):
+                        title = (exp.get("title") or "").lower().strip()
+                        company = (exp.get("company") or exp.get("company_name") or "").lower().strip()
+                        existing_keys.add(f"{title}|{company}")
+
+                new_entries = []
+                for exp in detail_exp:
+                    if not isinstance(exp, dict):
+                        continue
+                    title = (exp.get("title") or "").lower().strip()
+                    company = (exp.get("company") or exp.get("company_name") or "").lower().strip()
+                    key = f"{title}|{company}"
+                    if key not in existing_keys:
+                        new_entries.append(exp)
+                        existing_keys.add(key)
+
+                if new_entries:
+                    merged_exp = list(existing_exp) + new_entries
+                    # experience 또는 experiences 키 유지
+                    if "experiences" in merged:
+                        merged["experiences"] = merged_exp
+                    else:
+                        merged["experience"] = merged_exp
+                    logger.info(f"Merged {len(new_entries)} new experience entries from detail pages")
+
+            # 스킬 병합 (name 기준 중복 제거)
+            detail_skills = detail.get("skills") or []
+            if detail_skills and isinstance(detail_skills, list):
+                existing_skills = merged.get("skills") or []
+                existing_skill_names = set()
+                for s in existing_skills:
+                    if isinstance(s, str):
+                        existing_skill_names.add(s.lower())
+                    elif isinstance(s, dict):
+                        existing_skill_names.add((s.get("name") or "").lower())
+
+                new_skills = []
+                for s in detail_skills:
+                    name = s if isinstance(s, str) else (s.get("name") or "" if isinstance(s, dict) else "")
+                    if name and name.lower() not in existing_skill_names:
+                        new_skills.append(s)
+                        existing_skill_names.add(name.lower())
+
+                if new_skills:
+                    merged["skills"] = list(existing_skills) + new_skills
+                    logger.info(f"Merged {len(new_skills)} new skills from detail pages")
+
+            # 학력 병합 (school 기준 중복 제거)
+            detail_edu = detail.get("education") or []
+            if detail_edu and isinstance(detail_edu, list):
+                existing_edu = merged.get("education") or []
+                existing_schools = set()
+                for edu in existing_edu:
+                    if isinstance(edu, dict):
+                        school = (edu.get("school") or edu.get("school_name") or edu.get("title") or "").lower()
+                        existing_schools.add(school)
+
+                new_edu = []
+                for edu in detail_edu:
+                    if not isinstance(edu, dict):
+                        continue
+                    school = (edu.get("school") or edu.get("school_name") or edu.get("title") or "").lower()
+                    if school and school not in existing_schools:
+                        new_edu.append(edu)
+                        existing_schools.add(school)
+
+                if new_edu:
+                    merged["education"] = list(existing_edu) + new_edu
+                    logger.info(f"Merged {len(new_edu)} new education entries from detail pages")
+
+            # 프로젝트 병합 (title 기준 중복 제거)
+            detail_projects = detail.get("projects") or []
+            if detail_projects and isinstance(detail_projects, list):
+                existing_projects = merged.get("projects") or []
+                existing_titles = {(p.get("title") or "").lower() for p in existing_projects if isinstance(p, dict)}
+                new_projects = [
+                    p for p in detail_projects
+                    if isinstance(p, dict) and (p.get("title") or "").lower() not in existing_titles
+                ]
+                if new_projects:
+                    merged["projects"] = list(existing_projects) + new_projects
+                    logger.info(f"Merged {len(new_projects)} new projects from detail pages")
+
+            # 수상 병합
+            detail_honors = detail.get("honors_and_awards") or detail.get("honors") or []
+            if detail_honors and isinstance(detail_honors, list):
+                existing_honors = merged.get("honors_and_awards") or []
+                existing_honor_titles = {(h.get("title") or "").lower() for h in existing_honors if isinstance(h, dict)}
+                new_honors = [
+                    h for h in detail_honors
+                    if isinstance(h, dict) and (h.get("title") or "").lower() not in existing_honor_titles
+                ]
+                if new_honors:
+                    merged["honors_and_awards"] = list(existing_honors) + new_honors
+
+            # 추천서 병합 (신규)
+            detail_recs = detail.get("recommendations") or []
+            if detail_recs and isinstance(detail_recs, list):
+                existing_recs = merged.get("recommendations") or []
+                merged["recommendations"] = list(existing_recs) + [
+                    r for r in detail_recs
+                    if isinstance(r, dict) and r not in existing_recs
+                ]
+
+            # 봉사활동 병합 (신규)
+            detail_volunteer = detail.get("volunteering") or detail.get("volunteer_experience") or []
+            if detail_volunteer and isinstance(detail_volunteer, list):
+                existing_vol = merged.get("volunteering") or []
+                merged["volunteering"] = list(existing_vol) + [
+                    v for v in detail_volunteer
+                    if isinstance(v, dict) and v not in existing_vol
+                ]
+
+        return merged
 
     def _normalize_profile(self, data: dict, url: str) -> dict:
         """Bright Data 응답을 내부 형식으로 정규화
@@ -326,6 +495,34 @@ class LinkedInService:
             elif isinstance(lang, dict):
                 languages.append(lang.get("name") or "")
 
+        # 추천서 정규화 (JIT-47)
+        recommendations = []
+        raw_recs = data.get("recommendations") or []
+        for rec in raw_recs[:20]:
+            if not isinstance(rec, dict):
+                continue
+            recommendations.append({
+                "from_user": rec.get("from_user") or rec.get("recommender") or rec.get("name") or "Anonymous",
+                "text": rec.get("text") or rec.get("recommendation_text") or rec.get("description"),
+                "date": rec.get("date"),
+                "relationship": rec.get("relationship") or rec.get("subtitle"),
+            })
+
+        # 봉사활동 정규화 (JIT-47)
+        volunteer = []
+        raw_volunteer = data.get("volunteering") or data.get("volunteer_experience") or []
+        for vol in raw_volunteer[:10]:
+            if not isinstance(vol, dict):
+                continue
+            volunteer.append({
+                "organization": vol.get("organization") or vol.get("company") or vol.get("title") or "",
+                "role": vol.get("role") or vol.get("position") or vol.get("subtitle"),
+                "cause": vol.get("cause"),
+                "starts_at": vol.get("start_date") or vol.get("starts_at"),
+                "ends_at": vol.get("end_date") or vol.get("ends_at"),
+                "description": vol.get("description"),
+            })
+
         # 스킬 추출: Bright Data API는 skills 필드를 반환하지 않으므로
         # 원본 데이터에 skills가 있으면 사용, 없으면 텍스트에서 추출
         raw_skills = data.get("skills") or []
@@ -336,7 +533,8 @@ class LinkedInService:
         logger.info(
             f"LinkedIn normalized: {len(experiences)} experiences, "
             f"{len(education)} education, {len(raw_skills)} skills, "
-            f"{len(projects)} projects"
+            f"{len(projects)} projects, {len(recommendations)} recommendations, "
+            f"{len(volunteer)} volunteer"
         )
 
         return {
@@ -365,6 +563,10 @@ class LinkedInService:
 
             # 활동 (새로 추가)
             "activity": activity,
+
+            # 추천서/봉사활동 (JIT-46/47)
+            "recommendations": recommendations,
+            "volunteer_experience": volunteer,
 
             # 연결
             "followers": data.get("followers"),

--- a/backend/app/workflows/activities/analysis_generation.py
+++ b/backend/app/workflows/activities/analysis_generation.py
@@ -638,6 +638,17 @@ async def generate_deep_analysis(
             jd_analysis, code_analysis, document_analysis,
             lang=output_language, candidate_profile=candidate_profile,
         )
+
+    # JIT-51: match quality 순 정렬 (exact → similar → partial → none)
+    # 동일 match type 내에서는 confidence 내림차순
+    MATCH_TYPE_ORDER = {"exact": 0, "similar": 1, "partial": 2, "none": 3}
+    skill_table = sorted(
+        skill_table,
+        key=lambda row: (
+            MATCH_TYPE_ORDER.get(row.type if hasattr(row, 'type') else row.get("type", "none"), 4),
+            -(row.confidence if hasattr(row, 'confidence') else row.get("confidence", 0)),
+        ),
+    )
     activity.heartbeat()
 
     # 5. 전체 매칭 점수 계산 (Evidence-Based Weighted Composite)

--- a/backend/app/workflows/activities/code_analysis.py
+++ b/backend/app/workflows/activities/code_analysis.py
@@ -48,6 +48,7 @@ async def analyze_code(
 
     jd_tech_stack = (execution_plan or {}).get("jd_tech_stack") or input_data.get("jd_tech_stack", [])
     candidate_username = input_data.get("candidate_github_username")
+    jd_text = input_data.get("jd_text", "") or (execution_plan or {}).get("jd_text", "")
 
     # Initialize activity logger
     job_id = input_data.get("job_id")
@@ -68,10 +69,11 @@ async def analyze_code(
             "target_languages": jd_tech_stack,
         })
 
-    target_repos = await github.filter_repos_by_language(
+    target_repos = await github.select_relevant_repos(
         github_urls=github_urls,
         target_languages=jd_tech_stack,
-        min_language_ratio=0.3,
+        min_language_ratio=0.2,
+        jd_text=jd_text,
     )
 
     if not target_repos:

--- a/backend/app/workflows/activities/decision_generation.py
+++ b/backend/app/workflows/activities/decision_generation.py
@@ -98,6 +98,11 @@ async def _llm_generate_decision_summary(
             candidate_profile_data["linkedin_experiences"] = linkedin_experiences
         if candidate_profile and candidate_profile.get("data_completeness"):
             candidate_profile_data["data_completeness"] = candidate_profile["data_completeness"]
+        # JIT-50: 추천서/봉사활동 서머리
+        if candidate_profile and candidate_profile.get("recommendations_summary"):
+            candidate_profile_data["recommendations_summary"] = candidate_profile["recommendations_summary"]
+        if candidate_profile and candidate_profile.get("volunteer_summary"):
+            candidate_profile_data["volunteer_summary"] = candidate_profile["volunteer_summary"]
 
         prompt_config = get_prompt_with_config(
             "v2_generation.yaml", "decision_summary",
@@ -230,6 +235,11 @@ async def _llm_generate_interviewer_tips(
                 candidate_profile_data["linkedin_experiences"] = candidate_profile["linkedin_experiences"][:3]
             if candidate_profile.get("linkedin_honors"):
                 candidate_profile_data["linkedin_honors"] = candidate_profile["linkedin_honors"][:3]
+            # JIT-50: 추천서/봉사활동 서머리 주입
+            if candidate_profile.get("recommendations_summary"):
+                candidate_profile_data["recommendations_summary"] = candidate_profile["recommendations_summary"]
+            if candidate_profile.get("volunteer_summary"):
+                candidate_profile_data["volunteer_summary"] = candidate_profile["volunteer_summary"]
 
         prompt_config = get_prompt_with_config(
             "v2_generation.yaml", "interviewer_tips",

--- a/backend/app/workflows/activities/finalization.py
+++ b/backend/app/workflows/activities/finalization.py
@@ -265,6 +265,28 @@ def _format_linkedin_summary(profile: dict) -> str:
     if skills:
         parts.append(f"스킬: {', '.join(skills[:15])}")
 
+    # 추천서 (JIT-50)
+    recommendations = profile.get("recommendations", [])
+    if recommendations:
+        rec_lines = ["추천서:"]
+        for r in recommendations[:5]:
+            if isinstance(r, dict):
+                from_user = r.get("from_user", "익명")
+                text = (r.get("text") or "")[:200]
+                rec_lines.append(f"  - {from_user}: {text}")
+        parts.append("\n".join(rec_lines))
+
+    # 봉사활동 (JIT-50)
+    volunteer = profile.get("volunteer_experience", [])
+    if volunteer:
+        vol_lines = ["봉사활동:"]
+        for v in volunteer[:5]:
+            if isinstance(v, dict):
+                org = v.get("organization", "")
+                role = v.get("role", "")
+                vol_lines.append(f"  - {org}: {role}")
+        parts.append("\n".join(vol_lines))
+
     return "\n\n".join(parts) if parts else "LinkedIn 프로필 정보 제한적"
 
 

--- a/backend/app/workflows/activities/intel_generation.py
+++ b/backend/app/workflows/activities/intel_generation.py
@@ -200,6 +200,20 @@ async def generate_intel_brief(
             result["linkedin_projects"] = linkedin_projects[:5]
         if linkedin_honors:
             result["linkedin_honors"] = linkedin_honors[:5]
+        # 추천서/봉사활동 서머리 (JIT-50)
+        recommendations_summary = candidate_profile.get("recommendations_summary")
+        if recommendations_summary:
+            result["recommendations_summary"] = recommendations_summary
+        volunteer_summary = candidate_profile.get("volunteer_summary")
+        if volunteer_summary:
+            result["volunteer_summary"] = volunteer_summary
+        # 추천서/봉사활동 원본 데이터 (프론트 표시용)
+        recs = candidate_profile.get("linkedin_recommendations", [])
+        if recs:
+            result["linkedin_recommendations"] = recs[:10]
+        vol = candidate_profile.get("linkedin_volunteer_experience", [])
+        if vol:
+            result["linkedin_volunteer_experience"] = vol[:10]
         # Cover letter insights for Decision tab cross-reference
         cover_letter = candidate_profile.get("cover_letter_insights")
         if cover_letter:

--- a/backend/app/workflows/activities/profile_builder.py
+++ b/backend/app/workflows/activities/profile_builder.py
@@ -6,6 +6,7 @@ Profile Builder Activity — Phase 2.5
 UnifiedCandidateProfile로 통합.
 
 SkillNormalizer로 스킬 정규화 + 중복 제거 + implies 관계 추적.
+추천서/봉사활동 LLM 서머리 생성 (JIT-48).
 """
 import logging
 from datetime import datetime
@@ -13,6 +14,66 @@ from datetime import datetime
 from temporalio import activity
 
 logger = logging.getLogger(__name__)
+
+
+async def _summarize_recommendations(
+    recommendations: list[dict],
+    output_language: str = "ko",
+) -> str | None:
+    """추천서 전문을 LLM으로 서머리: 추천인 관계, 핵심 평가, 공통 테마"""
+    if not recommendations:
+        return None
+
+    rec_text = "\n".join([
+        f"- {r.get('from_user', '익명')} ({r.get('relationship', '')}): {r.get('text', '')}"
+        for r in recommendations[:10]
+    ])
+
+    try:
+        from app.prompts import get_prompt_with_config
+        from app.services.cached_llm import CachedLLMService
+
+        prompt_config = get_prompt_with_config(
+            "linkedin_summary.yaml", "recommendations_summary",
+            recommendations=rec_text,
+            output_language=output_language,
+        )
+        llm = CachedLLMService()
+        result = await llm.run_with_prompt_config(prompt_config)
+        return result.strip() if result else None
+    except Exception as e:
+        logger.warning(f"Recommendations summary failed: {e}")
+        return None
+
+
+async def _summarize_volunteer(
+    volunteer: list[dict],
+    output_language: str = "ko",
+) -> str | None:
+    """봉사활동 내역을 LLM으로 서머리: 활동 분야, 역할, 지속성"""
+    if not volunteer:
+        return None
+
+    vol_text = "\n".join([
+        f"- {v.get('organization', '')} | {v.get('role', '')} | {v.get('cause', '')} | {v.get('description', '')}"
+        for v in volunteer[:10]
+    ])
+
+    try:
+        from app.prompts import get_prompt_with_config
+        from app.services.cached_llm import CachedLLMService
+
+        prompt_config = get_prompt_with_config(
+            "linkedin_summary.yaml", "volunteer_summary",
+            volunteer_activities=vol_text,
+            output_language=output_language,
+        )
+        llm = CachedLLMService()
+        result = await llm.run_with_prompt_config(prompt_config)
+        return result.strip() if result else None
+    except Exception as e:
+        logger.warning(f"Volunteer summary failed: {e}")
+        return None
 
 
 @activity.defn
@@ -120,7 +181,27 @@ async def build_candidate_profile(
             linkedin_honors = []
         linkedin_activity = linkedin_profile.get("activity", [])
         activity_summary = _summarize_activities(linkedin_activity)
-        recommendations = linkedin_profile.get("connections", 0) or 0
+
+        # 추천서/봉사활동 (JIT-47)
+        linkedin_recommendations = linkedin_profile.get("recommendations", [])
+        if not isinstance(linkedin_recommendations, list):
+            linkedin_recommendations = []
+        linkedin_volunteer = linkedin_profile.get("volunteer_experience", [])
+        if not isinstance(linkedin_volunteer, list):
+            linkedin_volunteer = []
+        # 버그 수정: connections가 아닌 실제 recommendations 배열 길이 사용
+        recommendations_count = len(linkedin_recommendations)
+
+        # 7.5. 추천서/봉사활동 LLM 서머리 생성 (JIT-48)
+        output_language = enriched.get("raw_input", {}).get("language_config", {}).get("output_language", "ko")
+        if not isinstance(output_language, str):
+            output_language = "ko"
+        recommendations_summary = await _summarize_recommendations(
+            linkedin_recommendations, output_language,
+        )
+        volunteer_summary = await _summarize_volunteer(
+            linkedin_volunteer, output_language,
+        )
 
         # 8. 경력 연수 계산
         experience_years = profile.get("experience_years", 0) or 0
@@ -171,7 +252,11 @@ async def build_candidate_profile(
             linkedin_activity_summary=activity_summary,
             linkedin_projects=[p if isinstance(p, dict) else {"title": str(p)} for p in linkedin_projects],
             linkedin_honors=[h if isinstance(h, dict) else {"title": str(h)} for h in linkedin_honors],
-            recommendations_count=recommendations,
+            linkedin_recommendations=[r if isinstance(r, dict) else {"from_user": str(r)} for r in linkedin_recommendations],
+            linkedin_volunteer_experience=[v if isinstance(v, dict) else {"organization": str(v)} for v in linkedin_volunteer],
+            recommendations_count=recommendations_count,
+            recommendations_summary=recommendations_summary,
+            volunteer_summary=volunteer_summary,
             areas_to_probe=areas_to_probe,
             data_sources=data_sources,
             data_completeness=completeness,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -267,3 +267,152 @@ def mock_aggregated_analysis():
             "company_culture": [],
         },
     }
+
+
+# ============================================================
+# JIT-41~44: Integration Test Fixtures
+# ============================================================
+
+@pytest.fixture
+def candidate_profile_with_skills():
+    """JIT-41/42/43: UnifiedCandidateProfile (multi-source skills)"""
+    return {
+        "name": "Test User",
+        "skills": [
+            {"canonical_name": "Python", "sources": ["resume", "github"], "category": "language", "confidence": 1.0, "proficiency_signals": {}, "implied_skills": [], "aliases": [], "domain": "backend"},
+            {"canonical_name": "FastAPI", "sources": ["resume", "github", "linkedin"], "category": "framework", "confidence": 1.0, "proficiency_signals": {}, "implied_skills": [], "aliases": [], "domain": "backend"},
+            {"canonical_name": "TypeScript", "sources": ["resume"], "category": "language", "confidence": 0.9, "proficiency_signals": {}, "implied_skills": [], "aliases": [], "domain": "frontend"},
+            {"canonical_name": "PostgreSQL", "sources": ["github", "linkedin"], "category": "tool", "confidence": 0.8, "proficiency_signals": {}, "implied_skills": [], "aliases": [], "domain": "backend"},
+        ],
+        "experiences": [
+            {"company": "TechCorp", "title": "Senior Engineer", "duration": "3 years"},
+        ],
+        "linkedin_experiences": [
+            {"title": "Senior Engineer", "company": "TechCorp", "description": "Building AI systems", "starts_at": "2022-01"},
+        ],
+        "linkedin_honors": [{"title": "Top Contributor 2024", "issuer": "TechConf"}],
+        "linkedin_projects": [{"title": "AI Interview Generator"}],
+        "areas_to_probe": ["Distributed system experience gap", "No team leadership evidence"],
+        "data_completeness": 0.85,
+        "data_sources": ["resume", "github", "linkedin"],
+        "confidence_level": "high",
+        "experience_years": 5,
+        "experience_level": "시니어",
+    }
+
+
+@pytest.fixture
+def empty_candidate_profile():
+    """시나리오 4: candidate_profile 없을 때"""
+    return None
+
+
+@pytest.fixture
+def code_analysis_hybrid():
+    """JIT-44: HYBRID 파이프라인 코드 분석 결과"""
+    return {
+        "repositories": [
+            {
+                "repo_name": "test-repo",
+                "candidate_commits": 150,
+                "ast_analysis": {
+                    "functions": [{"name": "main"}, {"name": "process_data"}, {"name": "validate_input"}],
+                    "classes": [{"name": "UserService"}],
+                },
+                "hybrid_metadata": {
+                    "key_files_count": 5,
+                    "deep_analyses_count": 4,
+                    "ranked_chunks_count": 12,
+                    "model_used": "moonshot-v1-128k",
+                    "use_ast_pipeline": True,
+                    "used_clone_fallback": False,
+                },
+            },
+            {
+                "repo_name": "test-lib",
+                "candidate_commits": 80,
+                "ast_analysis": {
+                    "functions": [{"name": "helper_fn"}, {"name": "util_fn"}],
+                    "classes": [],
+                },
+                "hybrid_metadata": {
+                    "key_files_count": 3,
+                    "deep_analyses_count": 2,
+                    "ranked_chunks_count": 8,
+                    "model_used": "moonshot-v1-128k",
+                    "use_ast_pipeline": True,
+                    "used_clone_fallback": False,
+                },
+            },
+        ],
+        "tech_stack": ["Python", "FastAPI", "PostgreSQL"],
+        "combined_tech_stack": ["Python", "FastAPI", "PostgreSQL"],
+        "pipeline_type": "clone_based",
+        "ast_chunk_count": 20,
+        "analyzed_functions_count": 5,
+        "hybrid_metadata": {
+            "method": "hybrid",
+            "total_repos": 2,
+            "total_ast_chunks": 20,
+            "total_deep_analyses": 6,
+        },
+        "monthly_contributions": [10, 15, 20, 25, 30, 20, 15, 10, 5, 0, 0, 0],
+        "quality_metrics": {"test_coverage": 0.7},
+        "risk_flags": [],
+    }
+
+
+@pytest.fixture
+def code_analysis_legacy():
+    """JIT-44: LEGACY 파이프라인 (HYBRID 필드 없음)"""
+    return {
+        "repositories": [
+            {"repo_name": "old-repo", "candidate_commits": 50, "ast_analysis": {"functions": [], "classes": []}},
+        ],
+        "tech_stack": ["Python"],
+        "pipeline_type": "legacy",
+        "monthly_contributions": [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+        "quality_metrics": {},
+        "risk_flags": [],
+    }
+
+
+@pytest.fixture
+def document_analysis_with_skills():
+    """document_analysis with profile.skills (fallback 용)"""
+    return {
+        "profile": {
+            "name": "Test User",
+            "skills": ["Python", "JavaScript", "Docker"],
+            "experience_years": 5,
+            "experiences": [{"company": "OldCorp", "title": "Developer", "duration": "2 years"}],
+        },
+        "jd_match_score": 0.7,
+    }
+
+
+@pytest.fixture
+def document_analysis_empty_skills():
+    """document_analysis with empty skills"""
+    return {
+        "profile": {"name": "Test User", "skills": [], "experience_years": 0},
+        "jd_match_score": 0.3,
+    }
+
+
+@pytest.fixture
+def jd_analysis_fixture():
+    """JD 분석 결과"""
+    return {
+        "job_title": "Backend Engineer",
+        "company_name": "TechCorp",
+        "company_context": "AI 스타트업",
+        "requirements": [
+            {"skill": "Python", "category": "필수", "description": "Python 3년 이상"},
+            {"skill": "FastAPI", "category": "필수", "description": "FastAPI 경험"},
+            {"skill": "PostgreSQL", "category": "우대", "description": "DB 설계"},
+            {"skill": "Kubernetes", "category": "우대", "description": "컨테이너 오케스트레이션"},
+        ],
+        "responsibilities": ["백엔드 개발", "API 설계"],
+        "success_metrics": [],
+    }

--- a/backend/tests/test_code_analysis.py
+++ b/backend/tests/test_code_analysis.py
@@ -35,7 +35,7 @@ class TestJdMatchingRepoFilter:
             return {}
 
         async def mock_get_repo_info(url):
-            return {"url": url, "name": url.split("/")[-1]}
+            return {"url": url, "name": url.split("/")[-1], "size": 5000}
 
         with patch.object(svc, "get_repo_languages", side_effect=mock_get_repo_languages), \
              patch.object(svc, "get_repo_info", side_effect=mock_get_repo_info):
@@ -106,11 +106,11 @@ class TestCodeAnalysisActivity:
         from app.workflows.activities.code_analysis import analyze_code
         from unittest.mock import patch
 
-        async def mock_filter_repos(github_urls, target_languages, min_language_ratio):
+        async def mock_select_repos(github_urls, target_languages, min_language_ratio=0.2, jd_text="", jd_keywords=None):
             return []  # 매칭되는 레포 없음
 
         with patch("app.workflows.activities.code_analysis.activity") as mock_activity, \
-             patch("app.services.github_service.GitHubService.filter_repos_by_language", side_effect=mock_filter_repos):
+             patch("app.services.github_service.GitHubService.select_relevant_repos", side_effect=mock_select_repos):
 
             mock_activity.heartbeat = MagicMock()
 
@@ -128,9 +128,9 @@ class TestCodeAnalysisActivity:
         from app.workflows.activities.code_analysis import analyze_code
         from unittest.mock import patch
 
-        async def mock_filter_repos(github_urls, target_languages, min_language_ratio):
+        async def mock_select_repos(github_urls, target_languages, min_language_ratio=0.2, jd_text="", jd_keywords=None):
             return [
-                {"url": "https://github.com/user/repo", "name": "repo", "languages": {"Python": 80000}}
+                {"url": "https://github.com/user/repo", "name": "repo", "languages": {"Python": 80000}, "size": 5000}
             ]
 
         async def mock_pydriller(repo_url, job_id, author, since_years, file_types):
@@ -140,7 +140,7 @@ class TestCodeAnalysisActivity:
             }
 
         async def mock_ast_analyze(files, primary_language):
-            return {"functions": 5, "classes": 2}
+            return {"functions": [], "classes": [], "parser_used": "mock"}
 
         def mock_rank_files(files, jd_tech_stack, token_budget):
             return files
@@ -148,13 +148,21 @@ class TestCodeAnalysisActivity:
         async def mock_llm_analyze(ranked_files, ast_context):
             return {"notable_implementations": [{"title": "Main function", "complexity": "low"}]}
 
+        async def mock_overview(files, commit_diffs, ast_summary, jd_tech_stack, model, ranked_chunks=None):
+            return {"key_files": [], "patterns": [], "tech_stack": ["Python"]}
+
+        async def mock_synthesize(overview, deep_analyses, repo_info, jd_tech_stack, model):
+            return {"notable_implementations": [{"title": "Main function", "complexity": "low"}], "patterns": [], "tech_stack": ["Python"], "quality_score": 0.7}
+
         with patch("app.workflows.activities.code_analysis.activity") as mock_activity, \
-             patch("app.services.github_service.GitHubService.filter_repos_by_language", side_effect=mock_filter_repos), \
+             patch("app.services.github_service.GitHubService.select_relevant_repos", side_effect=mock_select_repos), \
              patch("app.services.code_analyzer.CodeAnalyzer.analyze_with_pydriller", side_effect=mock_pydriller), \
              patch("app.services.code_analyzer.CodeAnalyzer.select_top_files", return_value=[]), \
              patch("app.services.code_analyzer.CodeAnalyzer.analyze_ast", side_effect=mock_ast_analyze), \
              patch("app.services.code_analyzer.CodeAnalyzer.rank_files_for_llm", side_effect=mock_rank_files), \
-             patch("app.services.code_analyzer.CodeAnalyzer.llm_analyze_code", side_effect=mock_llm_analyze):
+             patch("app.services.code_analyzer.CodeAnalyzer.llm_analyze_code", side_effect=mock_llm_analyze), \
+             patch("app.services.code_analyzer.CodeAnalyzer.llm_overview_analysis", side_effect=mock_overview), \
+             patch("app.services.code_analyzer.CodeAnalyzer.llm_synthesize_analysis", side_effect=mock_synthesize):
 
             mock_activity.heartbeat = MagicMock()
 

--- a/frontend/src/components/tabs/IntelBriefTab.tsx
+++ b/frontend/src/components/tabs/IntelBriefTab.tsx
@@ -336,11 +336,21 @@ export const IntelBriefTab = memo(function IntelBriefTab({ intel, candidate, tec
                 {t('intel_skills')}
               </h4>
               <div className="flex flex-wrap gap-2">
-                {linkedinProfile.skills.map((skill, i) => (
-                  <span key={i} className="px-2.5 py-1 bg-indigo-50 text-indigo-700 border border-indigo-200 rounded-full text-xs font-medium">
-                    {skill}
-                  </span>
-                ))}
+                {linkedinProfile.skills.map((skill, i) => {
+                  const jdReqs = jd_summary?.requirements?.map(r => r.text?.toLowerCase()) || [];
+                  const isJdMatch = jdReqs.some(r =>
+                    r && (r.includes(skill.toLowerCase()) || skill.toLowerCase().includes(r))
+                  );
+                  return (
+                    <span key={i} className={`px-2.5 py-1 rounded-full text-xs font-medium border ${
+                      isJdMatch
+                        ? 'bg-emerald-100 text-emerald-800 border-emerald-300'
+                        : 'bg-indigo-50 text-indigo-700 border-indigo-200'
+                    }`}>
+                      {skill}
+                    </span>
+                  );
+                })}
               </div>
             </div>
           )}
@@ -414,6 +424,42 @@ export const IntelBriefTab = memo(function IntelBriefTab({ intel, candidate, tec
                   </div>
                 ))}
               </div>
+            </div>
+          )}
+
+          {/* Recommendations Summary (JIT-52) */}
+          {linkedinProfile?.recommendations_summary && (
+            <div className="bg-purple-50 rounded-lg p-4 border border-purple-200">
+              <h4 className="text-sm font-semibold text-purple-800 flex items-center gap-2 mb-2">
+                <svg className="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+                </svg>
+                {t('intel_recommendations')}
+                {linkedinProfile.recommendations && (
+                  <span className="bg-purple-200 text-purple-700 text-xs px-2 py-0.5 rounded-full">
+                    {linkedinProfile.recommendations.length}
+                  </span>
+                )}
+              </h4>
+              <p className="text-sm text-gray-700">{linkedinProfile.recommendations_summary}</p>
+            </div>
+          )}
+
+          {/* Volunteer Summary (JIT-52) */}
+          {linkedinProfile?.volunteer_summary && (
+            <div className="bg-teal-50 rounded-lg p-4 border border-teal-200">
+              <h4 className="text-sm font-semibold text-teal-800 flex items-center gap-2 mb-2">
+                <svg className="w-4 h-4 text-teal-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                </svg>
+                {t('intel_volunteer')}
+                {linkedinProfile.volunteer_experience && (
+                  <span className="bg-teal-200 text-teal-700 text-xs px-2 py-0.5 rounded-full">
+                    {linkedinProfile.volunteer_experience.length}
+                  </span>
+                )}
+              </h4>
+              <p className="text-sm text-gray-700">{linkedinProfile.volunteer_summary}</p>
             </div>
           )}
 

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -145,6 +145,8 @@ const resources = {
       intel_certifications: '자격증',
       intel_projects: '프로젝트',
       intel_honors: '수상 및 성과',
+      intel_recommendations: '추천서',
+      intel_volunteer: '봉사활동',
       intel_languages: '사용 언어',
       intel_linkedin_profile: 'LinkedIn 프로필 보기',
       // Result tabs - Deep Analysis
@@ -642,6 +644,8 @@ const resources = {
       intel_certifications: 'Certifications',
       intel_projects: 'Projects',
       intel_honors: 'Honors & Awards',
+      intel_recommendations: 'Recommendations',
+      intel_volunteer: 'Volunteer Experience',
       intel_languages: 'Languages',
       intel_linkedin_profile: 'View LinkedIn Profile',
       // Result tabs - Deep Analysis

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -389,6 +389,24 @@ export interface InterviewerGuide {
   green_flags_summary?: string[]
 }
 
+/** LinkedIn recommendation */
+export interface LinkedInRecommendation {
+  from_user: string
+  text?: string
+  date?: string
+  relationship?: string
+}
+
+/** LinkedIn volunteer experience */
+export interface LinkedInVolunteer {
+  organization: string
+  role?: string
+  cause?: string
+  starts_at?: string
+  ends_at?: string
+  description?: string
+}
+
 /** LinkedIn profile (legacy structure) */
 export interface LinkedInProfile {
   name?: string
@@ -403,6 +421,10 @@ export interface LinkedInProfile {
   profile_url?: string
   projects?: Array<{ title: string; description?: string }>
   honors_and_awards?: Array<{ title: string; issuer?: string; description?: string }>
+  recommendations?: LinkedInRecommendation[]
+  volunteer_experience?: LinkedInVolunteer[]
+  recommendations_summary?: string
+  volunteer_summary?: string
 }
 
 /** Interview script metadata */


### PR DESCRIPTION
## Summary

- **LinkedIn 데이터 품질 개선**: Bright Data에 7개 세부 페이지 URL(experience/skills/education/projects/honors/recommendations/volunteering)을 병렬 수집하여 접힌 섹션 데이터 완전 수집. 중복 제거 로직 포함
- **GitHub 레포 관련성 스코어링**: JD 기반 스코어링(lang×0.3 + size×0.3 + keyword×0.4)으로 의미 있는 레포만 선택. 단순 학습 레포 제외, JD 관련 핵심 레포 우선 분석
- **추천서/봉사활동 LLM 서머리**: LinkedInRecommendation/LinkedInVolunteer 모델 추가 + CachedLLMService 기반 서머리 생성 → intel/decision 파이프라인에 반영
- **프론트엔드 UI**: IntelBriefTab에 추천서/봉사활동 서머리 카드 + LinkedIn 스킬 JD 매칭 하이라이트
- **스킬 테이블 정렬**: match quality 순(exact→similar→partial→none) + confidence 내림차순

### 수정 파일 (18개)

| 영역 | 파일 | 변경 |
|------|------|------|
| 데이터 모델 | `models/input.py` | LinkedInRecommendation, LinkedInVolunteer 모델 추가 |
| 데이터 모델 | `models/candidate_profile.py` | 추천서/봉사활동 필드 추가 |
| LinkedIn 수집 | `services/linkedin_service.py` | 세부 페이지 수집 + 병합 + 정규화 |
| GitHub 선택 | `services/github_service.py` | 관련성 스코어링 시스템 |
| 프로필 빌드 | `activities/profile_builder.py` | 서머리 생성 + 필드 매핑 + recommendations_count 버그 수정 |
| 인텔 생성 | `activities/intel_generation.py` | 추천서/봉사활동 서머리 주입 |
| 분석 생성 | `activities/analysis_generation.py` | 스킬 테이블 정렬 |
| 코드 분석 | `activities/code_analysis.py` | select_relevant_repos() 호출 |
| 판단 생성 | `activities/decision_generation.py` | 추천서/봉사활동 데이터 활용 |
| 최종화 | `activities/finalization.py` | LinkedIn 서머리 확장 |
| 프롬프트 | `prompts/linkedin_summary.yaml` | 추천서/봉사활동 서머리 프롬프트 (신규) |
| 프롬프트 | `prompts/__init__.py` | 프롬프트 키 매핑 추가 |
| 프롬프트 | `prompts/v2_generation.yaml` | interviewer_tips 변수 추가 |
| 테스트 | `tests/conftest.py` | 테스트 픽스처 확장 |
| 테스트 | `tests/test_code_analysis.py` | HYBRID 파이프라인 mock 업데이트 |
| 프론트 타입 | `types/interview.ts` | TS 인터페이스 추가 |
| 프론트 UI | `tabs/IntelBriefTab.tsx` | 추천서/봉사활동 카드 + 스킬 하이라이트 |
| 프론트 i18n | `i18n.ts` | 번역 키 추가 (ko/en) |

## Test plan

- [x] 백엔드 전체 테스트: 642 passed, 4 skipped
- [x] TypeScript 타입 체크: 정상 통과
- [x] Langfuse 프롬프트 업로드: 30 uploaded, 0 errors
- [ ] E2E 검증: 새 잡 생성 → LinkedIn 전체 데이터 + 레포 관련성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)