### PR TITLE
feat: 질문 카테고리별 데이터 소스 접근 제어 [JIT-53]

### DIFF
--- a/backend/app/prompts/question_generation.yaml
+++ b/backend/app/prompts/question_generation.yaml
@@ -47,6 +47,25 @@ prompts:
       ## Rule 3: Source Attribution
       Every topic MUST have clear source attribution with evidence_summary
 
+      ## Rule 4: Category-Source Alignment (CRITICAL)
+      Match topic sources to appropriate categories:
+
+      - **role_fit**: PREFER jd_match, vector_profile, resume-based topics.
+        About culture fit, motivation, career goals — NOT about code implementation details.
+        ❌ NEVER assign code/vector_code topics to role_fit.
+
+      - **technical_depth**: PREFER code, vector_code, kg_skill_depth, kg_implementation_review topics.
+        About code, architecture, problem-solving — code evidence IS appropriate here.
+
+      - **execution_ownership**: PREFER resume/linkedin project topics, kg_implementation_review.
+        About delivery results, decisions, ownership — project SCOPE matters, not code details.
+
+      - **communication**: PREFER jd_match, vector_profile, resume topics ONLY.
+        About collaboration, explanation ability — ❌ NEVER assign code-sourced topics here.
+
+      - **risk_flags**: PREFER resume/linkedin timeline gaps, kg_conflict_probe topics.
+        About concerns, gaps, inconsistencies — verify against documented evidence.
+
       # CANDIDATE PROFILE CONTEXT
       Use this candidate background to select PERSONALIZED topics grounded in their actual experience.
       Do NOT create generic questions — every topic must reference specific candidate data below.
@@ -627,6 +646,13 @@ prompts:
       # CATEGORY: ROLE_FIT (역할 적합도)
       This question assesses: culture fit, motivation, career alignment, growth potential, team dynamics.
 
+      ## DATA SOURCE CONSTRAINTS (CRITICAL)
+      - ✅ USE: Resume work experience, LinkedIn career history, JD requirements
+      - ✅ USE: Candidate's stated career goals, team experience, values
+      - ❌ DO NOT reference specific GitHub file names, function names, or code implementations
+      - ❌ DO NOT mention "GitHub에 구현하신..." or specific repository details
+      - ⚠️ You may mention the candidate's general tech stack (e.g., "Python 경험") but NOT specific code artifacts
+
       ## QUESTION DESIGN GUIDELINES
       1. **STAR 기반**: 과거 행동을 구체적으로 물어라. "하시겠습니까?"(가정) 대신 "하셨나요?"(경험)
       2. **가치관 탐색**: 단순 스킬이 아닌, 일하는 방식과 동기를 파악하라
@@ -808,6 +834,12 @@ prompts:
 
       # CATEGORY: TECHNICAL_DEPTH (기술 심층)
       This question assesses: technical skills, problem-solving, architecture design, code quality, debugging.
+
+      ## DATA SOURCE CONSTRAINTS
+      - ✅ USE: Code analysis data, GitHub implementations, tech stack, JD tech requirements
+      - ✅ USE: Specific code files, functions, and implementation patterns from evidence_context
+      - ⚠️ Resume/LinkedIn skills are supplementary — code evidence takes priority
+      - ⚠️ Only reference code that appears in evidence_context, not assumed from skills
 
       ## QUESTION DESIGN GUIDELINES
       1. **코드 근거 기반**: 후보자의 실제 코드/프로젝트에서 출발하라
@@ -995,6 +1027,12 @@ prompts:
       # CATEGORY: EXECUTION_OWNERSHIP (실행력/오너십)
       This question assesses: project delivery, decision-making, ownership, impact measurement, crisis management.
 
+      ## DATA SOURCE CONSTRAINTS
+      - ✅ USE: Resume projects, LinkedIn career progression, project scale/outcomes
+      - ✅ USE: Decision-making experiences, team leadership, crisis management stories
+      - ❌ DO NOT reference specific code files, function names, or implementation details
+      - ⚠️ You may mention project SCOPE (e.g., "대규모 서비스") but NOT code internals
+
       ## QUESTION DESIGN GUIDELINES
       1. **결과 중심**: 과정보다 결과를 먼저 물어라. "어떤 성과를 냈는가?"
       2. **의사결정 과정**: 불확실한 상황에서 어떻게 판단했는지 탐색하라
@@ -1181,6 +1219,13 @@ prompts:
       # CATEGORY: COMMUNICATION (커뮤니케이션)
       This question assesses: cross-functional communication, conflict resolution, technical explanation ability, collaboration.
 
+      ## DATA SOURCE CONSTRAINTS (CRITICAL)
+      - ✅ USE: Resume collaboration experience, LinkedIn career context, team interactions
+      - ✅ USE: Communication scenarios from work experience (presenting, explaining, resolving conflicts)
+      - ❌ DO NOT reference GitHub code, specific implementations, or code analysis data
+      - ❌ DO NOT mention "GitHub에 구현하신..." or repository details
+      - ⚠️ Focus on INTERPERSONAL situations, not technical artifacts
+
       ## QUESTION DESIGN GUIDELINES
       1. **상호작용 중심**: 혼자 일한 경험이 아닌, 다른 사람과의 소통 경험을 물어라
       2. **청중 적응력**: 기술적 내용을 비개발자에게 설명한 경험을 탐색하라
@@ -1363,6 +1408,12 @@ prompts:
 
       # CATEGORY: RISK_FLAGS (위험 신호 검증)
       This question assesses: career gaps, job hopping, skill gaps, inconsistencies, cultural misalignment.
+
+      ## DATA SOURCE CONSTRAINTS
+      - ✅ USE: Resume career timeline, LinkedIn employment history, JD requirement gaps
+      - ✅ USE: Identified inconsistencies between data sources, unexplained gaps
+      - ❌ DO NOT force code references unless the risk is specifically about code quality
+      - ⚠️ Focus on CAREER PATTERNS and GAPS, not code implementation details
 
       ## QUESTION DESIGN GUIDELINES
       1. **비판단적 톤**: "왜 자주 옮기셨나요?"(X) → "각 이직의 배경을 말씀해주시겠어요?"(O)

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -420,7 +420,8 @@ async def craft_question(
     # 카테고리별 특화 프롬프트 선택 (fallback → 범용 craft_question)
     category = topic.get("category", "technical_depth")
     category_prompt_key = f"craft_question_{category}"
-    candidate_context = build_candidate_context(analysis, enriched_input)
+    # 카테고리별 데이터 소스 필터링 — 불필요한 데이터 제외 (토큰 절감 + 품질 향상)
+    candidate_context = build_candidate_context(analysis, enriched_input, category=category)
     try:
         prompt_config = get_prompt_with_config(
             "question_generation.yaml", category_prompt_key,

--- a/backend/app/workflows/activities/question_generation_utils.py
+++ b/backend/app/workflows/activities/question_generation_utils.py
@@ -52,6 +52,47 @@ CATEGORY_DISTRIBUTION: dict[str, dict[str, dict]] = {
     },
 }
 
+# ── 카테고리별 데이터 소스 접근 제어 ──
+# 각 카테고리에서 사용 가능한 데이터 소스와 수준을 정의
+# - "full": 전체 데이터 (경력, 스킬, 프로젝트 등)
+# - "skills_only": 스킬/기술 목록만
+# - "tech_stack_only": 언어/기술 스택만 (구현 세부사항 제외)
+# - "project_scope": 프로젝트 규모/요약만 (코드 세부사항 제외)
+# - "role_only": 직무명만
+# - "none": 데이터 완전 제외
+CATEGORY_DATA_ACCESS: dict[str, dict[str, str]] = {
+    "role_fit": {
+        "resume": "full",
+        "linkedin": "full",
+        "code_analysis": "tech_stack_only",
+        "jd": "full",
+    },
+    "technical_depth": {
+        "resume": "skills_only",
+        "linkedin": "skills_only",
+        "code_analysis": "full",
+        "jd": "full",
+    },
+    "execution_ownership": {
+        "resume": "full",
+        "linkedin": "full",
+        "code_analysis": "project_scope",
+        "jd": "role_only",
+    },
+    "communication": {
+        "resume": "full",
+        "linkedin": "full",
+        "code_analysis": "none",
+        "jd": "role_only",
+    },
+    "risk_flags": {
+        "resume": "full",
+        "linkedin": "full",
+        "code_analysis": "tech_stack_only",
+        "jd": "full",
+    },
+}
+
 
 def get_distribution(experience_level: str) -> dict[str, dict]:
     """경험 레벨에 맞는 카테고리 배분 반환 (fallback: 미들)"""
@@ -84,30 +125,33 @@ def format_distribution_for_prompt(dist: dict[str, dict]) -> tuple[str, str]:
     return "\n      ".join(cat_lines), "\n      ".join(diff_lines)
 
 
-def build_candidate_context(analysis: dict, enriched_input: dict) -> str:
-    """
-    후보자 정보를 LLM 프롬프트용 요약 텍스트로 조합.
-    document_analysis, code_analysis, linkedin_profile, jd_analysis에서 핵심 정보 추출.
-    각 섹션은 graceful degradation (데이터 없으면 스킵).
-    """
-    sections = []
+# ── 카테고리별 컨텍스트 빌더 (섹션별 분리) ──
 
-    # 1. 이력서/포트폴리오 프로필
+def _build_resume_section(analysis: dict, level: str) -> str:
+    """이력서 섹션 빌드 — level에 따라 포함 범위 조절"""
     doc = analysis.get("document_analysis", {})
     profile = doc.get("profile", {})
-    if profile:
-        parts = []
-        if profile.get("name"):
-            parts.append(f"Name: {profile['name']}")
+    if not profile:
+        return ""
+
+    parts = []
+    if profile.get("name"):
+        parts.append(f"Name: {profile['name']}")
+
+    if level == "full":
         if profile.get("summary"):
             parts.append(f"Summary: {profile['summary'][:200]}")
-        skills = profile.get("skills", [])
-        if skills:
-            if isinstance(skills, dict):
-                skills = list(skills.keys())
-            elif not isinstance(skills, list):
-                skills = [str(skills)]
-            parts.append(f"Skills: {', '.join(str(s) for s in skills[:15])}")
+
+    # skills_only와 full 모두 스킬 포함
+    skills = profile.get("skills", [])
+    if skills:
+        if isinstance(skills, dict):
+            skills = list(skills.keys())
+        elif not isinstance(skills, list):
+            skills = [str(skills)]
+        parts.append(f"Skills: {', '.join(str(s) for s in skills[:15])}")
+
+    if level == "full":
         experience = profile.get("work_experience") or profile.get("experience", [])
         if experience and isinstance(experience, list):
             exp_lines = []
@@ -121,6 +165,7 @@ def build_candidate_context(analysis: dict, enriched_input: dict) -> str:
                     exp_lines.append(f"  - {exp[:100]}")
             if exp_lines:
                 parts.append("Work Experience:\n" + "\n".join(exp_lines))
+
         projects = profile.get("projects", [])
         if projects and isinstance(projects, list):
             proj_lines = []
@@ -131,20 +176,28 @@ def build_candidate_context(analysis: dict, enriched_input: dict) -> str:
                     proj_lines.append(f"  - {proj[:100]}")
             if proj_lines:
                 parts.append("Projects:\n" + "\n".join(proj_lines))
-        if parts:
-            sections.append("## Resume/Portfolio\n" + "\n".join(parts))
 
-    # 2. LinkedIn 프로필
+    if not parts:
+        return ""
+    return "## Resume/Portfolio\n" + "\n".join(parts)
+
+
+def _build_linkedin_section(enriched_input: dict, level: str) -> str:
+    """LinkedIn 섹션 빌드 — level에 따라 포함 범위 조절"""
     raw_input = enriched_input.get("raw_input", {})
     linkedin = raw_input.get("linkedin_profile") or enriched_input.get("linkedin_profile", {})
-    if linkedin and isinstance(linkedin, dict):
-        parts = []
-        name = linkedin.get("full_name") or linkedin.get("name", "")
-        headline = linkedin.get("headline", "")
-        if name:
-            parts.append(f"Name: {name}")
-        if headline:
-            parts.append(f"Headline: {headline}")
+    if not linkedin or not isinstance(linkedin, dict):
+        return ""
+
+    parts = []
+    name = linkedin.get("full_name") or linkedin.get("name", "")
+    headline = linkedin.get("headline", "")
+    if name:
+        parts.append(f"Name: {name}")
+    if headline:
+        parts.append(f"Headline: {headline}")
+
+    if level == "full":
         experiences = linkedin.get("experiences") or linkedin.get("experience", [])
         if experiences and isinstance(experiences, list):
             for exp in experiences[:3]:
@@ -153,43 +206,65 @@ def build_candidate_context(analysis: dict, enriched_input: dict) -> str:
                     company = exp.get("company_name") or exp.get("company", "")
                     if title or company:
                         parts.append(f"  - {title} @ {company}")
-        li_skills = linkedin.get("skills", [])
-        if li_skills and isinstance(li_skills, list):
-            skill_names = []
-            for s in li_skills[:10]:
-                skill_names.append(s.get("name", str(s)) if isinstance(s, dict) else str(s))
-            parts.append(f"Skills: {', '.join(skill_names)}")
-        if parts:
-            sections.append("## LinkedIn Profile\n" + "\n".join(parts))
 
-    # 3. 코드 분석
+    # skills_only와 full 모두 스킬 포함
+    li_skills = linkedin.get("skills", [])
+    if li_skills and isinstance(li_skills, list):
+        skill_names = []
+        for s in li_skills[:10]:
+            skill_names.append(s.get("name", str(s)) if isinstance(s, dict) else str(s))
+        parts.append(f"Skills: {', '.join(skill_names)}")
+
+    if not parts:
+        return ""
+    return "## LinkedIn Profile\n" + "\n".join(parts)
+
+
+def _build_code_section(analysis: dict, level: str) -> str:
+    """코드 분석 섹션 빌드 — level에 따라 포함 범위 조절"""
     code = analysis.get("code_analysis", {})
-    if code:
-        parts = []
-        langs = code.get("languages") or code.get("tech_stack", [])
-        if langs:
-            if isinstance(langs, dict):
-                parts.append(f"Languages: {', '.join(list(langs.keys())[:10])}")
-            elif isinstance(langs, list):
-                parts.append(f"Tech Stack: {', '.join(str(l) for l in langs[:10])}")
+    if not code:
+        return ""
+
+    parts = []
+
+    # tech_stack_only, project_scope, full 모두 언어/기술 포함
+    langs = code.get("languages") or code.get("tech_stack", [])
+    if langs:
+        if isinstance(langs, dict):
+            parts.append(f"Languages: {', '.join(list(langs.keys())[:10])}")
+        elif isinstance(langs, list):
+            parts.append(f"Tech Stack: {', '.join(str(lang) for lang in langs[:10])}")
+
+    if level in ("project_scope", "full"):
         repo_summary = code.get("summary") or code.get("repo_summary", "")
         if repo_summary and isinstance(repo_summary, str):
             parts.append(f"Summary: {repo_summary[:200]}")
+
+    if level == "full":
         top_candidates = code.get("top_question_candidates", [])
         if top_candidates:
             cand_lines = [f"  - {c.get('title', '')}" for c in top_candidates[:5] if isinstance(c, dict)]
             if cand_lines:
                 parts.append("Notable Implementations:\n" + "\n".join(cand_lines))
-        if parts:
-            sections.append("## Code Analysis (GitHub)\n" + "\n".join(parts))
 
-    # 4. JD 매칭 요약
+    if not parts:
+        return ""
+    return "## Code Analysis (GitHub)\n" + "\n".join(parts)
+
+
+def _build_jd_section(analysis: dict, level: str) -> str:
+    """JD 요구사항 섹션 빌드 — level에 따라 포함 범위 조절"""
     jd = analysis.get("jd_analysis", {})
-    if jd:
-        parts = []
-        title = jd.get("job_title", "")
-        if title:
-            parts.append(f"Target Role: {title}")
+    if not jd:
+        return ""
+
+    parts = []
+    title = jd.get("job_title", "")
+    if title:
+        parts.append(f"Target Role: {title}")
+
+    if level in ("full", "tech_only"):
         reqs = jd.get("requirements", [])
         if reqs:
             req_skills = []
@@ -199,8 +274,53 @@ def build_candidate_context(analysis: dict, enriched_input: dict) -> str:
                 else:
                     req_skills.append(str(r))
             parts.append(f"Key Requirements: {', '.join(req_skills)}")
-        if parts:
-            sections.append("## JD Requirements\n" + "\n".join(parts))
+
+    if not parts:
+        return ""
+    return "## JD Requirements\n" + "\n".join(parts)
+
+
+def build_candidate_context(
+    analysis: dict,
+    enriched_input: dict,
+    category: str | None = None,
+) -> str:
+    """
+    후보자 정보를 LLM 프롬프트용 요약 텍스트로 조합.
+    category가 지정되면 해당 카테고리에 적합한 데이터만 필터링.
+    category=None이면 전체 데이터 포함 (select_topics용).
+    """
+    access = CATEGORY_DATA_ACCESS.get(category) if category else None
+
+    sections = []
+
+    # 1. 이력서/포트폴리오 프로필
+    resume_level = access["resume"] if access else "full"
+    if resume_level != "none":
+        section = _build_resume_section(analysis, resume_level)
+        if section:
+            sections.append(section)
+
+    # 2. LinkedIn 프로필
+    linkedin_level = access["linkedin"] if access else "full"
+    if linkedin_level != "none":
+        section = _build_linkedin_section(enriched_input, linkedin_level)
+        if section:
+            sections.append(section)
+
+    # 3. 코드 분석
+    code_level = access["code_analysis"] if access else "full"
+    if code_level != "none":
+        section = _build_code_section(analysis, code_level)
+        if section:
+            sections.append(section)
+
+    # 4. JD 매칭 요약
+    jd_level = access["jd"] if access else "full"
+    if jd_level != "none":
+        section = _build_jd_section(analysis, jd_level)
+        if section:
+            sections.append(section)
 
     if not sections:
         return ""


### PR DESCRIPTION
## Summary

- **문제**: `build_candidate_context()`가 모든 데이터를 하나로 섞어 20개 질문 전체에 동일하게 전달 → role_fit/communication 질문에서 코드 구현 세부사항 억지 참조
- **해결**: `CATEGORY_DATA_ACCESS` 설정으로 카테고리별 데이터 소스 접근 수준 정의
- **프롬프트**: select_topics에 Rule 4 (Category-Source Alignment) + 5개 카테고리에 DATA SOURCE CONSTRAINTS 추가

### 카테고리별 데이터 접근 매트릭스

| Category | Resume | LinkedIn | Code Analysis | JD |
|----------|--------|----------|---------------|-----|
| role_fit | Full | Full | Tech stack만 | Full |
| technical_depth | Skills만 | Skills만 | Full | Full |
| execution_ownership | Full | Full | Project scope만 | Role만 |
| communication | Full | Full | **제외** | Role만 |
| risk_flags | Full | Full | Tech stack만 | Full |

### 수정 파일 (3개)

| 파일 | 변경 |
|------|------|
| `question_generation_utils.py` | `CATEGORY_DATA_ACCESS` + 섹션별 빌더 분리 + `category` 파라미터 |
| `question_generation.py` | `craft_question()`에서 category 전달 |
| `question_generation.yaml` | Rule 4 + 5개 카테고리 DATA SOURCE CONSTRAINTS |

## Test plan

- [x] 백엔드 전체 테스트: 642 passed, 0 failed
- [x] Langfuse 프롬프트 업로드: 30 uploaded, 0 errors
- [ ] E2E 검증: 새 잡 생성 → role_fit/communication에 코드 참조 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)