### PR TITLE
fix: LinkedIn graceful degradation + evidence 필터링 + truncation 개선 [JIT-55~57]

### DIFF
--- a/backend/app/services/linkedin_service.py
+++ b/backend/app/services/linkedin_service.py
@@ -93,45 +93,100 @@ class LinkedInService:
     async def _fetch_profile(self, linkedin_url: str) -> dict | None:
         """Bright Data 비동기 API 호출 (메인 프로필 + 세부 페이지 병렬 수집)
 
-        1. 메인 프로필 + 7개 세부 페이지 URL을 한 번에 트리거
-        2. 폴링 후 결과 조회
-        3. 세부 페이지 데이터를 메인 프로필에 병합
+        전략: 메인 + 세부 페이지 일괄 트리거 → 실패 시 메인만 재시도 (graceful degradation)
         """
-        # 프로필 base URL 정규화 (trailing slash 포함)
         base_url = linkedin_url.rstrip("/")
 
         # 메인 프로필 + 세부 페이지 URL 구성
-        urls_to_fetch = [{"url": linkedin_url}]
+        urls_all = [{"url": linkedin_url}]
         for page in DETAIL_PAGES:
-            urls_to_fetch.append({"url": f"{base_url}/{page}"})
+            urls_all.append({"url": f"{base_url}/{page}"})
+        urls_main_only = [{"url": linkedin_url}]
 
         async with httpx.AsyncClient(timeout=30.0) as client:
-            # 1. 수집 트리거 (메인 + 세부 페이지 일괄)
+            # Phase 1: 메인 + 세부 페이지 일괄 트리거 시도
+            snapshot_id = await self._trigger_collection(client, urls_all)
+
+            if snapshot_id:
+                logger.info(
+                    f"Bright Data collection started: {snapshot_id} "
+                    f"({len(urls_all)} URLs: main + {len(DETAIL_PAGES)} detail pages)"
+                )
+                data = await self._poll_and_fetch(client, snapshot_id, linkedin_url)
+
+                if data is not None:
+                    main_profile = data[0]
+                    detail_results = data[1:] if len(data) > 1 else []
+                    if detail_results:
+                        logger.info(f"Merging {len(detail_results)} detail page results")
+                    merged = self._merge_detail_pages(main_profile, detail_results)
+                    return self._normalize_profile(merged, linkedin_url)
+
+                # 폴링/조회 실패 → 메인만 재시도
+                logger.warning("Full collection failed, falling back to main profile only")
+
+            # Phase 2: 메인 프로필만 트리거 (fallback)
+            snapshot_id = await self._trigger_collection(client, urls_main_only)
+            if not snapshot_id:
+                raise LinkedInFetchError(
+                    f"Bright Data trigger failed for both full and main-only requests: {linkedin_url}"
+                )
+
+            logger.info(f"Bright Data fallback collection started: {snapshot_id} (main profile only)")
+            data = await self._poll_and_fetch(client, snapshot_id, linkedin_url)
+
+            if data is None:
+                return None
+
+            return self._normalize_profile(data[0], linkedin_url)
+
+    async def _trigger_collection(
+        self, client: httpx.AsyncClient, urls: list[dict]
+    ) -> str | None:
+        """Bright Data 수집 트리거. 성공 시 snapshot_id, 실패 시 None 반환."""
+        try:
             trigger_resp = await client.post(
                 f"{self.BASE_URL}/trigger",
                 params={"dataset_id": self.DATASET_ID},
-                json=urls_to_fetch,
+                json=urls,
                 headers=self.headers,
+            )
+
+            logger.info(
+                f"Bright Data trigger response: status={trigger_resp.status_code}, "
+                f"urls={len(urls)}, body={trigger_resp.text[:500]}"
             )
 
             if trigger_resp.status_code == 429:
                 raise httpx.HTTPError("Rate limited by Bright Data")
+
             if trigger_resp.status_code not in (200, 201, 202):
-                raise LinkedInFetchError(
-                    f"Bright Data trigger error {trigger_resp.status_code}: {trigger_resp.text}"
+                logger.error(
+                    f"Bright Data trigger error: status={trigger_resp.status_code}, "
+                    f"body={trigger_resp.text[:1000]}, urls={[u['url'] for u in urls]}"
                 )
+                return None
 
             trigger_data = trigger_resp.json()
             snapshot_id = trigger_data.get("snapshot_id")
             if not snapshot_id:
-                raise LinkedInFetchError(f"No snapshot_id in trigger response: {trigger_data}")
+                logger.error(f"No snapshot_id in trigger response: {trigger_data}")
+                return None
 
-            logger.info(
-                f"Bright Data collection started: {snapshot_id} "
-                f"({len(urls_to_fetch)} URLs: main + {len(DETAIL_PAGES)} detail pages)"
-            )
+            return snapshot_id
 
-            # 2. 상태 폴링
+        except httpx.HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Bright Data trigger exception: {e}", exc_info=True)
+            return None
+
+    async def _poll_and_fetch(
+        self, client: httpx.AsyncClient, snapshot_id: str, linkedin_url: str
+    ) -> list[dict] | None:
+        """상태 폴링 + 결과 조회. 실패 시 None 반환 (예외 발생 안 함)."""
+        try:
+            # 상태 폴링
             for poll_attempt in range(MAX_POLL_ATTEMPTS):
                 await asyncio.sleep(POLL_INTERVAL)
 
@@ -141,7 +196,10 @@ class LinkedInService:
                 )
 
                 if progress_resp.status_code != 200:
-                    logger.warning(f"Progress check failed: {progress_resp.status_code}")
+                    logger.warning(
+                        f"Progress check failed: status={progress_resp.status_code}, "
+                        f"body={progress_resp.text[:500]}"
+                    )
                     continue
 
                 progress_data = progress_resp.json()
@@ -151,36 +209,53 @@ class LinkedInService:
                     logger.info(f"Bright Data collection ready: {snapshot_id}")
                     break
                 elif status == "failed":
-                    raise LinkedInFetchError(f"Bright Data collection failed: {progress_data}")
+                    logger.error(
+                        f"Bright Data collection failed: snapshot={snapshot_id}, "
+                        f"response={progress_data}"
+                    )
+                    return None
                 # running 상태면 계속 폴링
             else:
-                raise LinkedInFetchError(f"Bright Data timeout after {MAX_POLL_ATTEMPTS * POLL_INTERVAL}s")
+                logger.error(
+                    f"Bright Data timeout after {MAX_POLL_ATTEMPTS * POLL_INTERVAL}s: "
+                    f"snapshot={snapshot_id}"
+                )
+                return None
 
-            # 3. 결과 조회
+            # 결과 조회
             snapshot_resp = await client.get(
                 f"{self.BASE_URL}/snapshot/{snapshot_id}",
                 params={"format": "json"},
                 headers=self.headers,
             )
 
+            logger.info(
+                f"Bright Data snapshot response: status={snapshot_resp.status_code}, "
+                f"snapshot={snapshot_id}"
+            )
+
             if snapshot_resp.status_code == 404:
                 logger.warning(f"LinkedIn profile not found: {linkedin_url}")
                 return None
             if snapshot_resp.status_code != 200:
-                raise LinkedInFetchError(
-                    f"Bright Data snapshot error {snapshot_resp.status_code}: {snapshot_resp.text}"
+                logger.error(
+                    f"Bright Data snapshot error: status={snapshot_resp.status_code}, "
+                    f"body={snapshot_resp.text[:1000]}"
                 )
+                return None
 
             data = snapshot_resp.json()
             if not isinstance(data, list) or len(data) == 0:
+                logger.warning(f"Empty snapshot data for {linkedin_url}: {type(data)}")
                 return None
 
-            # 4. 메인 프로필 + 세부 페이지 병합
-            main_profile = data[0]
-            detail_results = data[1:] if len(data) > 1 else []
-            merged = self._merge_detail_pages(main_profile, detail_results)
+            return data
 
-            return self._normalize_profile(merged, linkedin_url)
+        except httpx.HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Poll/fetch exception: {e}", exc_info=True)
+            return None
 
     @staticmethod
     def validate_url(url: str) -> bool:

--- a/backend/app/workflows/activities/finalization.py
+++ b/backend/app/workflows/activities/finalization.py
@@ -200,6 +200,76 @@ async def _download_and_store_avatar(avatar_url: str, job_id: str) -> str | None
         return None
 
 
+def _compact_code_analysis(code_analysis: dict) -> dict:
+    """LLM summary 입력용 code_analysis 지능적 압축
+
+    관련성 높은 레포 우선 포함, 불필요한 상세 데이터 제거.
+    - repositories: 관련성 높은 순 정렬 → 요약 필드만 유지
+    - target_repos, hybrid_metadata 등 메타만 유지
+    """
+    if not code_analysis:
+        return {}
+
+    compact = {}
+    # 필수 메타 필드 복사
+    for key in (
+        "combined_tech_stack", "tech_stack", "jd_tech_stack",
+        "total_patterns", "total_notable_implementations",
+        "monthly_contributions", "pipeline_type",
+        "candidate_username", "kg_entity_count",
+    ):
+        if key in code_analysis:
+            compact[key] = code_analysis[key]
+
+    # top_question_candidates (상위 10개만)
+    candidates = code_analysis.get("top_question_candidates", [])
+    compact["top_question_candidates"] = candidates[:10]
+
+    # repositories: 관련성 높은 순 정렬 + 요약 필드만 유지
+    repos = code_analysis.get("repositories", [])
+    # target_repos에서 관련성 스코어 추출
+    target_repos = code_analysis.get("target_repos", [])
+    relevance_map = {}
+    for tr in target_repos:
+        name = tr.get("name", "")
+        relevance_map[name] = tr.get("relevance_score", 0)
+
+    # 관련성 순 정렬
+    sorted_repos = sorted(
+        repos,
+        key=lambda r: relevance_map.get(r.get("repo_name", ""), 0),
+        reverse=True,
+    )
+
+    compact_repos = []
+    for repo in sorted_repos:
+        compact_repo = {
+            "repo_name": repo.get("repo_name"),
+            "repo_url": repo.get("repo_url"),
+            "language": repo.get("language"),
+            "commit_count": repo.get("commit_count") or repo.get("candidate_commits"),
+            "relevance_score": relevance_map.get(repo.get("repo_name", ""), 0),
+        }
+        # HYBRID 분석 요약 포함 (상세 코드 제외)
+        if repo.get("hybrid_metadata"):
+            meta = repo["hybrid_metadata"]
+            compact_repo["analysis_summary"] = meta.get("analysis_summary", "")
+            compact_repo["deep_analyses_count"] = meta.get("deep_analyses_count", 0)
+        # 레거시 분석 요약
+        analysis = repo.get("analysis", {})
+        if analysis and isinstance(analysis, dict):
+            patterns = analysis.get("patterns", [])
+            compact_repo["patterns_count"] = len(patterns)
+            compact_repo["patterns"] = [
+                p.get("name", str(p)) if isinstance(p, dict) else str(p)
+                for p in patterns[:5]
+            ]
+        compact_repos.append(compact_repo)
+
+    compact["repositories"] = compact_repos
+    return compact
+
+
 def _format_linkedin_summary(profile: dict) -> str:
     """LinkedIn 프로필을 프롬프트용 요약 텍스트로 변환"""
     if not profile:
@@ -367,10 +437,11 @@ async def finalize_output(
     linkedin_summary = _format_linkedin_summary(linkedin_profile)
 
     from app.prompts import get_prompt_with_config
-    # 분석 데이터 직렬화 + 절단 (LLM 컨텍스트 제한)
-    MAX_ANALYSIS_CHARS = 2000
+    # 분석 데이터 직렬화 (지능적 압축 후 절단)
+    MAX_ANALYSIS_CHARS = 5000
     doc_json = json.dumps(analysis.get("document_analysis", {}), default=str)
-    code_json = json.dumps(analysis.get("code_analysis", {}), default=str)
+    code_compact = _compact_code_analysis(analysis.get("code_analysis", {}))
+    code_json = json.dumps(code_compact, default=str)
     doc_truncated = len(doc_json) > MAX_ANALYSIS_CHARS
     code_truncated = len(code_json) > MAX_ANALYSIS_CHARS
     if doc_truncated:

--- a/backend/app/workflows/activities/question_generation.py
+++ b/backend/app/workflows/activities/question_generation.py
@@ -399,15 +399,30 @@ async def craft_question(
         except Exception as e:
             logger.debug(f"KG evidence fetch failed for {topic.get('topic')}: {e}")
 
-    # pgvector 시맨틱 검색으로 추가 컨텍스트 수집
+    # 카테고리별 데이터 소스 접근 제어 (evidence_context 코드 검색 포함)
+    from app.workflows.activities.question_generation_utils import CATEGORY_DATA_ACCESS
+    category = topic.get("category", "technical_depth")
+    code_access_level = CATEGORY_DATA_ACCESS.get(category, {}).get("code_analysis", "full")
+
+    # pgvector 시맨틱 검색으로 추가 컨텍스트 수집 (카테고리별 제어)
     if job_id:
         try:
             from app.services.vector_store import get_vector_store
             vs = get_vector_store(job_id)
             topic_text = topic.get("topic", "")
             if topic_text:
-                vector_results = await vs.search_profile(topic_text, limit=3)
-                code_results = await vs.search_code(topic_text, limit=2)
+                # 프로필 검색: 모든 카테고리에서 실행 (코드 접근 제한 카테고리는 limit 축소)
+                profile_limit = 3 if code_access_level in ("full", "project_scope") else 2
+                vector_results = await vs.search_profile(topic_text, limit=profile_limit)
+
+                # 코드 검색: 카테고리별 code_analysis 레벨에 따라 제어
+                code_results = []
+                if code_access_level == "full":
+                    code_results = await vs.search_code(topic_text, limit=2)
+                elif code_access_level == "project_scope":
+                    code_results = await vs.search_code(topic_text, limit=1)
+                # tech_stack_only, none → 코드 벡터 검색 스킵
+
                 relevant = [r for r in (vector_results + code_results) if r["similarity"] >= 0.5]
                 if relevant:
                     evidence_context += "\n\nSemantic matches (vector search):\n"
@@ -418,7 +433,6 @@ async def craft_question(
 
     from app.prompts import get_prompt_with_config
     # 카테고리별 특화 프롬프트 선택 (fallback → 범용 craft_question)
-    category = topic.get("category", "technical_depth")
     category_prompt_key = f"craft_question_{category}"
     # 카테고리별 데이터 소스 필터링 — 불필요한 데이터 제외 (토큰 절감 + 품질 향상)
     candidate_context = build_candidate_context(analysis, enriched_input, category=category)

--- a/backend/app/workflows/activities/question_generation_utils.py
+++ b/backend/app/workflows/activities/question_generation_utils.py
@@ -250,7 +250,9 @@ def _build_code_section(analysis: dict, level: str) -> str:
 
     if not parts:
         return ""
-    return "## Code Analysis (GitHub)\n" + "\n".join(parts)
+    # tech_stack_only 수준에서는 코드 분석이 아닌 기술 스택 제목 사용 (LLM이 코드 참조 질문 생성 방지)
+    heading = "## Technical Skills\n" if level == "tech_stack_only" else "## Code Analysis (GitHub)\n"
+    return heading + "\n".join(parts)
 
 
 def _build_jd_section(analysis: dict, level: str) -> str:


### PR DESCRIPTION
## Summary
- **JIT-55**: LinkedIn BrightData 수집 실패 시 graceful degradation (메인+세부 → 메인만 fallback) + API 응답 상세 로깅. ⚠️ 실제 수집 실패 근본 원인은 미확인 — 추가 디버깅 필요
- **JIT-56**: `evidence_context` 벡터 코드 검색을 `CATEGORY_DATA_ACCESS` 기반으로 카테고리별 제어. communication/risk_flags에서 코드 검색 스킵
- **JIT-57**: `MAX_ANALYSIS_CHARS` 2000→5000 상향 + `_compact_code_analysis()` 관련성 기반 레포 정렬/압축

## Test plan
- [x] pytest 642 passed, 4 skipped (기존 테스트 전체 통과)
- [ ] LinkedIn 단독 수집 테스트 (BrightData 실제 호출 — 추가 디버깅 필요)
- [ ] 통합 테스트 잡 실행 후 결과 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)