### PR TITLE
fix: enrich_input heartbeat wrapper + LinkedIn graceful degradation [JIT-41]

### DIFF
--- a/backend/app/services/linkedin_service.py
+++ b/backend/app/services/linkedin_service.py
@@ -28,17 +28,6 @@ RETRY_BACKOFF = 1.0  # seconds
 POLL_INTERVAL = 5.0  # seconds
 MAX_POLL_ATTEMPTS = 24  # 5s × 24 = 최대 2분 대기
 
-# LinkedIn 세부 페이지 7종 (접힌 섹션 데이터 수집용)
-DETAIL_PAGES = [
-    "details/experience/",
-    "details/skills/",
-    "details/education/",
-    "details/projects/",
-    "details/honors/",
-    "details/recommendations/",
-    "details/volunteering/",
-]
-
 
 class LinkedInService:
     """LinkedIn 프로필 데이터 수집 (Bright Data Web Scraper API)
@@ -91,48 +80,22 @@ class LinkedInService:
         raise LinkedInFetchError(f"Bright Data request failed after retries: {last_error}") from last_error
 
     async def _fetch_profile(self, linkedin_url: str) -> dict | None:
-        """Bright Data 비동기 API 호출 (메인 프로필 + 세부 페이지 병렬 수집)
+        """Bright Data 비동기 API 호출 (메인 프로필 URL)
 
-        전략: 메인 + 세부 페이지 일괄 트리거 → 실패 시 메인만 재시도 (graceful degradation)
+        Bright Data Web Scraper API는 메인 프로필 URL에서 experience, education,
+        skills, projects 등 모든 섹션을 추출함. /details/ 세부 페이지 URL은
+        dead_page로 처리되므로 메인 URL만 전송.
         """
-        base_url = linkedin_url.rstrip("/")
-
-        # 메인 프로필 + 세부 페이지 URL 구성
-        urls_all = [{"url": linkedin_url}]
-        for page in DETAIL_PAGES:
-            urls_all.append({"url": f"{base_url}/{page}"})
-        urls_main_only = [{"url": linkedin_url}]
+        urls = [{"url": linkedin_url}]
 
         async with httpx.AsyncClient(timeout=30.0) as client:
-            # Phase 1: 메인 + 세부 페이지 일괄 트리거 시도
-            snapshot_id = await self._trigger_collection(client, urls_all)
-
-            if snapshot_id:
-                logger.info(
-                    f"Bright Data collection started: {snapshot_id} "
-                    f"({len(urls_all)} URLs: main + {len(DETAIL_PAGES)} detail pages)"
-                )
-                data = await self._poll_and_fetch(client, snapshot_id, linkedin_url)
-
-                if data is not None:
-                    main_profile = data[0]
-                    detail_results = data[1:] if len(data) > 1 else []
-                    if detail_results:
-                        logger.info(f"Merging {len(detail_results)} detail page results")
-                    merged = self._merge_detail_pages(main_profile, detail_results)
-                    return self._normalize_profile(merged, linkedin_url)
-
-                # 폴링/조회 실패 → 메인만 재시도
-                logger.warning("Full collection failed, falling back to main profile only")
-
-            # Phase 2: 메인 프로필만 트리거 (fallback)
-            snapshot_id = await self._trigger_collection(client, urls_main_only)
+            snapshot_id = await self._trigger_collection(client, urls)
             if not snapshot_id:
                 raise LinkedInFetchError(
-                    f"Bright Data trigger failed for both full and main-only requests: {linkedin_url}"
+                    f"Bright Data trigger failed: {linkedin_url}"
                 )
 
-            logger.info(f"Bright Data fallback collection started: {snapshot_id} (main profile only)")
+            logger.info(f"Bright Data collection started: {snapshot_id}")
             data = await self._poll_and_fetch(client, snapshot_id, linkedin_url)
 
             if data is None:
@@ -261,143 +224,6 @@ class LinkedInService:
     def validate_url(url: str) -> bool:
         """LinkedIn 프로필 URL 유효성 검증"""
         return bool(LINKEDIN_URL_PATTERN.match(url))
-
-    @staticmethod
-    def _merge_detail_pages(main: dict, details: list[dict]) -> dict:
-        """세부 페이지 데이터를 메인 프로필에 병합
-
-        Bright Data는 세부 페이지에서 접힌 섹션의 전체 데이터를 반환.
-        메인 프로필의 해당 섹션이 불완전하면 세부 페이지 데이터로 보강.
-        """
-        if not details:
-            return main
-
-        merged = dict(main)
-
-        for detail in details:
-            if not isinstance(detail, dict):
-                continue
-
-            # 경력 병합 (title+company 기준 중복 제거)
-            detail_exp = detail.get("experience") or detail.get("experiences") or []
-            if detail_exp and isinstance(detail_exp, list):
-                existing_exp = merged.get("experience") or merged.get("experiences") or []
-                existing_keys = set()
-                for exp in existing_exp:
-                    if isinstance(exp, dict):
-                        title = (exp.get("title") or "").lower().strip()
-                        company = (exp.get("company") or exp.get("company_name") or "").lower().strip()
-                        existing_keys.add(f"{title}|{company}")
-
-                new_entries = []
-                for exp in detail_exp:
-                    if not isinstance(exp, dict):
-                        continue
-                    title = (exp.get("title") or "").lower().strip()
-                    company = (exp.get("company") or exp.get("company_name") or "").lower().strip()
-                    key = f"{title}|{company}"
-                    if key not in existing_keys:
-                        new_entries.append(exp)
-                        existing_keys.add(key)
-
-                if new_entries:
-                    merged_exp = list(existing_exp) + new_entries
-                    # experience 또는 experiences 키 유지
-                    if "experiences" in merged:
-                        merged["experiences"] = merged_exp
-                    else:
-                        merged["experience"] = merged_exp
-                    logger.info(f"Merged {len(new_entries)} new experience entries from detail pages")
-
-            # 스킬 병합 (name 기준 중복 제거)
-            detail_skills = detail.get("skills") or []
-            if detail_skills and isinstance(detail_skills, list):
-                existing_skills = merged.get("skills") or []
-                existing_skill_names = set()
-                for s in existing_skills:
-                    if isinstance(s, str):
-                        existing_skill_names.add(s.lower())
-                    elif isinstance(s, dict):
-                        existing_skill_names.add((s.get("name") or "").lower())
-
-                new_skills = []
-                for s in detail_skills:
-                    name = s if isinstance(s, str) else (s.get("name") or "" if isinstance(s, dict) else "")
-                    if name and name.lower() not in existing_skill_names:
-                        new_skills.append(s)
-                        existing_skill_names.add(name.lower())
-
-                if new_skills:
-                    merged["skills"] = list(existing_skills) + new_skills
-                    logger.info(f"Merged {len(new_skills)} new skills from detail pages")
-
-            # 학력 병합 (school 기준 중복 제거)
-            detail_edu = detail.get("education") or []
-            if detail_edu and isinstance(detail_edu, list):
-                existing_edu = merged.get("education") or []
-                existing_schools = set()
-                for edu in existing_edu:
-                    if isinstance(edu, dict):
-                        school = (edu.get("school") or edu.get("school_name") or edu.get("title") or "").lower()
-                        existing_schools.add(school)
-
-                new_edu = []
-                for edu in detail_edu:
-                    if not isinstance(edu, dict):
-                        continue
-                    school = (edu.get("school") or edu.get("school_name") or edu.get("title") or "").lower()
-                    if school and school not in existing_schools:
-                        new_edu.append(edu)
-                        existing_schools.add(school)
-
-                if new_edu:
-                    merged["education"] = list(existing_edu) + new_edu
-                    logger.info(f"Merged {len(new_edu)} new education entries from detail pages")
-
-            # 프로젝트 병합 (title 기준 중복 제거)
-            detail_projects = detail.get("projects") or []
-            if detail_projects and isinstance(detail_projects, list):
-                existing_projects = merged.get("projects") or []
-                existing_titles = {(p.get("title") or "").lower() for p in existing_projects if isinstance(p, dict)}
-                new_projects = [
-                    p for p in detail_projects
-                    if isinstance(p, dict) and (p.get("title") or "").lower() not in existing_titles
-                ]
-                if new_projects:
-                    merged["projects"] = list(existing_projects) + new_projects
-                    logger.info(f"Merged {len(new_projects)} new projects from detail pages")
-
-            # 수상 병합
-            detail_honors = detail.get("honors_and_awards") or detail.get("honors") or []
-            if detail_honors and isinstance(detail_honors, list):
-                existing_honors = merged.get("honors_and_awards") or []
-                existing_honor_titles = {(h.get("title") or "").lower() for h in existing_honors if isinstance(h, dict)}
-                new_honors = [
-                    h for h in detail_honors
-                    if isinstance(h, dict) and (h.get("title") or "").lower() not in existing_honor_titles
-                ]
-                if new_honors:
-                    merged["honors_and_awards"] = list(existing_honors) + new_honors
-
-            # 추천서 병합 (신규)
-            detail_recs = detail.get("recommendations") or []
-            if detail_recs and isinstance(detail_recs, list):
-                existing_recs = merged.get("recommendations") or []
-                merged["recommendations"] = list(existing_recs) + [
-                    r for r in detail_recs
-                    if isinstance(r, dict) and r not in existing_recs
-                ]
-
-            # 봉사활동 병합 (신규)
-            detail_volunteer = detail.get("volunteering") or detail.get("volunteer_experience") or []
-            if detail_volunteer and isinstance(detail_volunteer, list):
-                existing_vol = merged.get("volunteering") or []
-                merged["volunteering"] = list(existing_vol) + [
-                    v for v in detail_volunteer
-                    if isinstance(v, dict) and v not in existing_vol
-                ]
-
-        return merged
 
     def _normalize_profile(self, data: dict, url: str) -> dict:
         """Bright Data 응답을 내부 형식으로 정규화

--- a/backend/app/workflows/activities/input_enrichment.py
+++ b/backend/app/workflows/activities/input_enrichment.py
@@ -2,6 +2,7 @@
 backend/app/workflows/activities/input_enrichment.py
 Smart Input Extraction — 입력 교차 추출 및 보강
 """
+import asyncio
 import re
 import logging
 
@@ -11,6 +12,28 @@ from app.core.observability import observe_activity
 from app.exceptions import LinkedInFetchError
 
 logger = logging.getLogger(__name__)
+
+
+async def _with_heartbeat(coro, message: str, interval: float = 30.0):
+    """장기 실행 코루틴에 주기적 heartbeat를 보내 Temporal 타임아웃 방지.
+
+    Gemini OCR(최대 120s), LinkedIn 폴링(최대 120s) 등
+    heartbeat_timeout(120s) 근처까지 블로킹되는 호출을 안전하게 래핑.
+    """
+    async def _heartbeat_loop():
+        while True:
+            await asyncio.sleep(interval)
+            activity.heartbeat(message)
+
+    task = asyncio.create_task(_heartbeat_loop())
+    try:
+        return await coro
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 @activity.defn
@@ -39,7 +62,10 @@ async def enrich_input(input_data: dict) -> dict:
     if input_data.get("resume_path"):
         activity.heartbeat("Extracting URLs from resume...")
         try:
-            text = await extract_text(input_data["resume_path"])
+            text = await _with_heartbeat(
+                extract_text(input_data["resume_path"]),
+                "Processing resume OCR...",
+            )
             found = _extract_urls(text)
             for url in found["github"]:
                 extracted_urls["github"].add(url)
@@ -55,7 +81,10 @@ async def enrich_input(input_data: dict) -> dict:
     if input_data.get("portfolio_path"):
         activity.heartbeat("Extracting URLs from portfolio...")
         try:
-            text = await extract_text(input_data["portfolio_path"])
+            text = await _with_heartbeat(
+                extract_text(input_data["portfolio_path"]),
+                "Processing portfolio OCR...",
+            )
             found = _extract_urls(text)
             for url in found["github"]:
                 extracted_urls["github"].add(url)
@@ -68,7 +97,10 @@ async def enrich_input(input_data: dict) -> dict:
     if input_data.get("cover_letter_path"):
         activity.heartbeat("Extracting URLs from cover letter...")
         try:
-            text = await extract_text(input_data["cover_letter_path"])
+            text = await _with_heartbeat(
+                extract_text(input_data["cover_letter_path"]),
+                "Processing cover letter OCR...",
+            )
             found = _extract_urls(text)
             for url in found["github"]:
                 extracted_urls["github"].add(url)
@@ -88,7 +120,10 @@ async def enrich_input(input_data: dict) -> dict:
             try:
                 from app.services.github_service import GitHubService
                 github_svc = GitHubService()
-                profile_repos = await github_svc.get_user_repos(git_url)
+                profile_repos = await _with_heartbeat(
+                    github_svc.get_user_repos(git_url),
+                    "Fetching GitHub profile repos...",
+                )
                 for repo_url in profile_repos:
                     extracted_urls["github"].add(repo_url)
                     extraction_sources.setdefault("github_urls", []).append("git_url_profile")
@@ -114,12 +149,14 @@ async def enrich_input(input_data: dict) -> dict:
         activity.heartbeat("Fetching LinkedIn profile via Bright Data...")
         try:
             linkedin_svc = LinkedInService()
-            linkedin_profile = await linkedin_svc.get_profile(linkedin_url)
-        except LinkedInFetchError:
-            raise
-        except Exception as e:
-            logger.warning(f"Bright Data failed for {linkedin_url}: {e}")
+            linkedin_profile = await _with_heartbeat(
+                linkedin_svc.get_profile(linkedin_url),
+                "Polling LinkedIn profile...",
+            )
+        except (LinkedInFetchError, Exception) as e:
+            logger.warning(f"LinkedIn fetch failed for {linkedin_url} ({type(e).__name__}): {e}")
             linkedin_profile = None
+            document_errors.append({"source": "linkedin", "error": str(e)})
 
         # LinkedIn에서 GitHub URL 발견 시 추가
         if linkedin_profile and linkedin_profile.get("github_url"):
@@ -144,9 +181,12 @@ async def enrich_input(input_data: dict) -> dict:
             from app.services.github_service import GitHubService
             github_svc = GitHubService()
 
-            username_inference = await github_svc.infer_candidate_username(
-                github_urls=github_urls,
-                candidate_name=candidate_name,
+            username_inference = await _with_heartbeat(
+                github_svc.infer_candidate_username(
+                    github_urls=github_urls,
+                    candidate_name=candidate_name,
+                ),
+                "Validating GitHub URLs...",
             )
 
             # 개인 레포 URL만 사용

--- a/backend/app/workflows/interview_workflow.py
+++ b/backend/app/workflows/interview_workflow.py
@@ -87,7 +87,7 @@ class InterviewGenerationWorkflow:
                 enrich_input,
                 input_data,
                 start_to_close_timeout=timedelta(minutes=5),
-                heartbeat_timeout=timedelta(seconds=60),
+                heartbeat_timeout=timedelta(seconds=120),
                 retry_policy=EXTERNAL_API_RETRY,
             )
 


### PR DESCRIPTION
## Summary
- `_with_heartbeat()` 래퍼 추가: Resume/Portfolio/CoverLetter OCR, GitHub repos, LinkedIn fetch, GitHub validation 등 6개 장기 실행 호출에 30초 간격 heartbeat 전송으로 Temporal CancelledError 방지
- `LinkedInFetchError` 재발생(re-raise) 제거 → graceful degradation: LinkedIn 실패 시에도 나머지 enrichment 데이터(Resume OCR, GitHub 등) 보존
- `heartbeat_timeout` 60s → 120s: Gemini OCR(최대 120s), LinkedIn 폴링(최대 120s) 대응
- LinkedIn `DETAIL_PAGES` + `_merge_detail_pages()` 제거: Bright Data가 /details/ URL에 dead_page 반환하는 이슈 해소

## Test plan
- [x] pytest 643 passed, 4 skipped
- [x] 테스트 잡 완료 확인 (Job `37168ad6`, 90초 내 enrich_input 완료)
- [x] LinkedIn 데이터 정상 수집 확인 (이름: BYUN SANGHOON)
- [x] GitHub 9개 개인 레포 + 1개 org 레포 정상 분석
- [x] Langfuse 프롬프트 30개 동기화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)