### PR TITLE
fix(observability): Langfuse SDK v4 API 마이그레이션

### DIFF
--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -1,10 +1,18 @@
 """
 backend/app/core/observability.py
-Langfuse LLM observability — LiteLLM callback + @observe 데코레이터 방식
+Langfuse LLM observability — Langfuse Python SDK v4 (OpenTelemetry-based)
 
-Structlog 통합:
-- langfuse_trace_context()가 structlog 컨텍스트도 함께 바인딩
-- 로그와 트레이스가 동일한 job_id/phase/activity 컨텍스트 공유
+v4 API mapping (from legacy v3):
+- client.start_span(...)          → client.start_as_current_observation(..., as_type="span")
+- span.update_trace(session_id=…) → OTel span attrs (session.id / user.id / langfuse.trace.tags)
+                                     set on the current span; Langfuse OTel exporter promotes
+                                     them to trace-level fields so Sessions/User/Tag UIs populate.
+- langfuse_context.update_*       → client.update_current_span (only valid inside an active span)
+- client.create_score(trace_id=…) → unchanged
+
+Structlog integration:
+- langfuse_trace_context() also binds structlog context so logs and traces
+  share the same job_id / phase / activity metadata.
 """
 import os
 from contextlib import contextmanager
@@ -12,6 +20,16 @@ from contextvars import ContextVar
 from typing import Any
 
 from app.core.config import settings
+
+
+# OTel attribute keys used by the Langfuse v4 exporter to surface trace-level
+# fields (Sessions tab, User filter, Tag filter). Defined in
+# langfuse._client.attributes.LangfuseOtelSpanAttributes. Hard-coding here so
+# we don't depend on a private module path.
+_OTEL_ATTR_SESSION_ID = "session.id"
+_OTEL_ATTR_USER_ID = "user.id"
+_OTEL_ATTR_TAGS = "langfuse.trace.tags"
+
 
 # Lazy import to avoid circular dependency
 def _get_logger():
@@ -22,12 +40,12 @@ def _get_logger():
         import logging
         return logging.getLogger(__name__)
 
+
 logger = _get_logger()
 
 _initialized = False
 _langfuse_client = None
 
-# Context variables for trace metadata
 _current_job_id: ContextVar[str | None] = ContextVar("current_job_id", default=None)
 _current_phase: ContextVar[str | None] = ContextVar("current_phase", default=None)
 _current_activity: ContextVar[str | None] = ContextVar("current_activity", default=None)
@@ -68,18 +86,15 @@ def setup_langfuse() -> bool:
     try:
         import litellm
 
-        # Langfuse 3.x 호환을 위해 langfuse_otel (OpenTelemetry 기반) 사용
-        # 참고: https://docs.litellm.ai/docs/observability/langfuse_otel_integration
+        # v4는 OpenTelemetry 기반 → LiteLLM은 langfuse_otel 콜백 사용
+        # https://docs.litellm.ai/docs/observability/langfuse_otel_integration
         litellm.callbacks = ["langfuse_otel"]
 
-        # LiteLLM reads these env vars automatically, but set explicitly
         os.environ.setdefault("LANGFUSE_PUBLIC_KEY", settings.LANGFUSE_PUBLIC_KEY)
         os.environ.setdefault("LANGFUSE_SECRET_KEY", settings.LANGFUSE_SECRET_KEY)
         os.environ.setdefault("LANGFUSE_HOST", settings.LANGFUSE_HOST)
-        # langfuse_otel은 LANGFUSE_OTEL_HOST 환경 변수 사용
         os.environ.setdefault("LANGFUSE_OTEL_HOST", settings.LANGFUSE_HOST)
 
-        # Initialize Langfuse client for @observe decorator
         get_langfuse_client()
 
         _initialized = True
@@ -90,28 +105,100 @@ def setup_langfuse() -> bool:
         return False
 
 
+# =============================================================================
+# Internal helpers for v4 API
+# =============================================================================
+
+def _trace_context_for_job(client, job_id: str | None) -> dict | None:
+    """job_id 기반 안정적인 trace_id를 생성해 trace_context dict로 반환.
+
+    job_id가 None이면 None을 반환해 기본 trace 사용.
+    """
+    if not job_id or client is None:
+        return None
+    try:
+        trace_id = client.create_trace_id(seed=job_id)
+        return {"trace_id": trace_id}
+    except Exception:
+        return None
+
+
+def _span_metadata(
+    job_id: str | None = None,
+    phase: str | None = None,
+    activity: str | None = None,
+    extra: dict | None = None,
+) -> dict:
+    """observation(span)에 붙일 메타데이터 조립."""
+    meta: dict[str, Any] = {}
+    if job_id:
+        meta["job_id"] = job_id
+    if phase:
+        meta["phase"] = phase
+    if activity:
+        meta["activity"] = activity
+    if extra:
+        meta.update(extra)
+    return meta
+
+
+def _set_trace_level_attrs(
+    session_id: str | None = None,
+    user_id: str | None = None,
+    tags: list[str] | None = None,
+) -> None:
+    """현재 OTel span에 trace-level 속성을 세팅 (Sessions/User/Tag UI용).
+
+    v4.2.x에는 `client.update_current_trace` / `propagate_attributes`가 없어,
+    Langfuse OTel exporter가 읽는 span attribute를 직접 설정한다.
+    Active span이 없으면 no-op.
+    """
+    if not (session_id or user_id or tags):
+        return
+    try:
+        from opentelemetry import trace as _otel_trace
+        current = _otel_trace.get_current_span()
+        if current is None or not current.is_recording():
+            return
+        if session_id:
+            current.set_attribute(_OTEL_ATTR_SESSION_ID, session_id)
+        if user_id:
+            current.set_attribute(_OTEL_ATTR_USER_ID, user_id)
+        if tags:
+            # Langfuse expects tags as a list of strings
+            current.set_attribute(_OTEL_ATTR_TAGS, list(tags))
+    except Exception as e:
+        logger.debug(f"set trace-level attrs skipped: {e}")
+
+
+def _update_current_span_safe(client, **kwargs) -> None:
+    """update_current_span을 안전 호출 (없거나 실패 시 무시).
+
+    주의: 호출 시점에 active span이 없으면 Langfuse가 경고 로그를 찍고 no-op.
+    observe_activity 데코레이터 안에서 호출될 때만 실효가 있다.
+    """
+    if client is None:
+        return
+    updater = getattr(client, "update_current_span", None)
+    if updater is None:
+        return
+    try:
+        updater(**kwargs)
+    except Exception as e:
+        logger.debug(f"update_current_span skipped: {e}")
+
+
 @contextmanager
 def langfuse_trace_context(
     job_id: str | None = None,
     phase: str | None = None,
     activity: str | None = None,
 ):
-    """Langfuse 추적 컨텍스트 설정 + Structlog 컨텍스트 바인딩
-
-    Langfuse와 Structlog 모두에 동일한 컨텍스트를 설정하여
-    로그와 트레이스가 일관된 메타데이터를 공유합니다.
-
-    Usage:
-        with langfuse_trace_context(job_id="123", phase="question_generation"):
-            await llm.run(prompt)
-            logger.info("Processing")  # job_id, phase 자동 포함
-    """
-    # Save previous values
+    """Langfuse 추적 컨텍스트 설정 + Structlog 컨텍스트 바인딩"""
     prev_job_id = _current_job_id.get()
     prev_phase = _current_phase.get()
     prev_activity = _current_activity.get()
 
-    # Set new values
     if job_id:
         _current_job_id.set(job_id)
     if phase:
@@ -119,42 +206,32 @@ def langfuse_trace_context(
     if activity:
         _current_activity.set(activity)
 
-    # Structlog 컨텍스트도 함께 바인딩
     try:
         from app.core.logging import bind_job_context
         bind_job_context(job_id=job_id, phase=phase, activity=activity)
     except ImportError:
-        pass  # logging 모듈 미사용 환경
+        pass
 
     try:
-        # Update langfuse context if available
         if is_langfuse_enabled():
-            try:
-                # Langfuse v3.x: import from langfuse directly
-                try:
-                    from langfuse import langfuse_context
-                except ImportError:
-                    # Fallback for older versions
-                    from langfuse.decorators import langfuse_context
-                langfuse_context.update_current_trace(
-                    session_id=job_id,
-                    metadata={
-                        "job_id": job_id,
-                        "phase": phase,
-                        "activity": activity,
-                    },
-                    tags=[f"phase:{phase}", f"activity:{activity}"] if phase else None,
-                )
-            except Exception as e:
-                logger.debug(f"langfuse_context update skipped: {e}")
+            client = get_langfuse_client()
+            _update_current_span_safe(
+                client,
+                metadata=_span_metadata(job_id=job_id, phase=phase, activity=activity),
+            )
+            # trace-level 필드: 현재 span이 있으면 Sessions/User/Tag 필드도 갱신
+            tags: list[str] = []
+            if phase:
+                tags.append(f"phase:{phase}")
+            if activity:
+                tags.append(f"activity:{activity}")
+            _set_trace_level_attrs(session_id=job_id, tags=tags or None)
         yield
     finally:
-        # Restore previous values
         _current_job_id.set(prev_job_id)
         _current_phase.set(prev_phase)
         _current_activity.set(prev_activity)
 
-        # Structlog 컨텍스트도 복원
         try:
             from app.core.logging import bind_job_context
             bind_job_context(
@@ -197,8 +274,10 @@ def create_trace_for_job(
 ) -> str | None:
     """Job용 Langfuse Trace 생성 (세션 레벨)
 
-    Returns:
-        trace_id if successful, None otherwise
+    결정론적 trace_id(seed=job_id)로 루트 span을 만들고 session/user/tags를
+    설정한 뒤 즉시 종료한다. 루트 span duration=0은 의도적인 placeholder —
+    실제 작업 구간은 각 activity의 observe_activity 래퍼가 자체 span으로 기록하며,
+    모두 같은 trace_id로 귀속된다.
     """
     if not is_langfuse_enabled():
         return None
@@ -208,31 +287,26 @@ def create_trace_for_job(
         if not client:
             return None
 
-        # Langfuse v3.x: Use start_span which automatically creates a trace
-        # The span.trace_id contains the generated trace ID
-        span = client.start_span(
+        trace_context = _trace_context_for_job(client, job_id)
+        with client.start_as_current_observation(
+            trace_context=trace_context,
             name=f"interview-generation-{job_id}",
+            as_type="span",
             input={
                 "job_id": job_id,
                 "workflow": "InterviewGenerationWorkflow",
                 **(metadata or {}),
             },
-        )
-
-        # Update trace metadata
-        span.update_trace(
-            name=f"interview-generation-{job_id}",
-            session_id=job_id,
-            user_id=user_id,
-            tags=["workflow", "interview-generation"],
-            metadata={
-                "job_id": job_id,
-                "workflow": "InterviewGenerationWorkflow",
-            },
-        )
-
-        trace_id = span.trace_id
-        span.end()  # End immediately, just to register the trace
+            metadata=_span_metadata(
+                job_id=job_id, extra={"workflow": "InterviewGenerationWorkflow"}
+            ),
+        ) as span:
+            _set_trace_level_attrs(
+                session_id=job_id,
+                user_id=user_id,
+                tags=["workflow", "interview-generation"],
+            )
+            trace_id = span.trace_id
 
         logger.debug(f"Created Langfuse trace for job {job_id}: {trace_id}")
         return trace_id
@@ -247,11 +321,7 @@ def create_span_for_phase(
     trace_id: str | None = None,
     metadata: dict | None = None,
 ):
-    """Phase용 Langfuse Span 생성
-
-    Returns:
-        span object if successful, None otherwise
-    """
+    """Phase용 Langfuse Span 생성"""
     if not is_langfuse_enabled():
         return None
 
@@ -260,19 +330,20 @@ def create_span_for_phase(
         if not client:
             return None
 
-        # Langfuse v3.x: Use start_span (trace_id is not a parameter)
-        # If trace_id is needed, it should be managed externally
-        span = client.start_span(
+        trace_context = (
+            {"trace_id": trace_id} if trace_id else _trace_context_for_job(client, job_id)
+        )
+        span = client.start_observation(
+            trace_context=trace_context,
             name=f"phase-{phase}",
+            as_type="span",
             input={
                 "job_id": job_id,
                 "phase": phase,
                 **(metadata or {}),
             },
+            metadata=_span_metadata(job_id=job_id, phase=phase),
         )
-
-        # Set session_id via update_trace
-        span.update_trace(session_id=job_id)
 
         logger.debug(f"Created Langfuse span for phase {phase}")
         return span
@@ -282,17 +353,18 @@ def create_span_for_phase(
 
 
 def end_span(span, status: str = "success", metadata: dict | None = None):
-    """Span 종료"""
+    """Span 종료 (v4: update로 metadata 기록 후 end)"""
     if span is None:
         return
 
     try:
-        span.end(
+        span.update(
             metadata={
                 "status": status,
                 **(metadata or {}),
             }
         )
+        span.end()
     except Exception as e:
         logger.debug(f"Failed to end span: {e}")
 
@@ -302,31 +374,22 @@ def log_event(
     metadata: dict | None = None,
     level: str = "DEFAULT",
 ):
-    """Langfuse 이벤트 로깅
-
-    Args:
-        name: 이벤트 이름
-        metadata: 추가 메타데이터
-        level: 로그 레벨 (DEFAULT, DEBUG, WARNING, ERROR)
-    """
+    """Langfuse 이벤트 로깅 — 현재 span의 metadata에 이벤트 정보 병합"""
     if not is_langfuse_enabled():
         return
 
     try:
-        # Langfuse v3.x: import from langfuse directly
-        try:
-            from langfuse import langfuse_context
-        except ImportError:
-            from langfuse.decorators import langfuse_context
-        langfuse_context.update_current_observation(
+        client = get_langfuse_client()
+        _update_current_span_safe(
+            client,
             metadata={
                 "event": name,
                 "level": level,
                 **(metadata or {}),
-            }
+            },
         )
     except Exception:
-        pass  # 이벤트 로깅 실패는 무시
+        pass
 
 
 def score_trace(
@@ -335,21 +398,13 @@ def score_trace(
     value: float,
     comment: str | None = None,
 ):
-    """Trace에 점수 추가 (품질 평가용)
-
-    Args:
-        trace_id: Langfuse trace ID
-        name: 점수 이름 (e.g., "quality", "relevance")
-        value: 점수 값 (0.0 ~ 1.0)
-        comment: 코멘트
-    """
+    """Trace에 점수 추가 (품질 평가용)"""
     if not is_langfuse_enabled() or not trace_id:
         return
 
     try:
         client = get_langfuse_client()
         if client:
-            # Langfuse v3.x: Use create_score
             client.create_score(
                 trace_id=trace_id,
                 name=name,
@@ -364,27 +419,15 @@ def score_trace(
 # Phase 4: Agent Graph Visualization (Custom Observation Types)
 # =============================================================================
 
-def create_agent_observation(
-    trace_id: str,
+def _create_typed_observation(
+    as_type: str,
+    trace_id: str | None,
     name: str,
-    input_data: dict | None = None,
-    output_data: dict | None = None,
-    metadata: dict | None = None,
-    parent_observation_id: str | None = None,
+    input_data: dict | None,
+    output_data: dict | None,
+    metadata: dict | None,
 ):
-    """Agent 타입 Observation 생성 (Agent Graph 시각화용).
-
-    Args:
-        trace_id: 연결할 Trace ID (v3에서는 무시됨)
-        name: Agent 이름
-        input_data: 입력 데이터
-        output_data: 출력 데이터
-        metadata: 추가 메타데이터
-        parent_observation_id: 부모 Observation ID (계층 구조)
-
-    Returns:
-        생성된 Observation 또는 None
-    """
+    """agent/tool/retrieval 공통 observation 생성 헬퍼."""
     if not is_langfuse_enabled():
         return None
 
@@ -393,23 +436,44 @@ def create_agent_observation(
         if not client:
             return None
 
-        # Langfuse v3.x: Use start_span (without trace_id parameter)
-        observation = client.start_span(
+        trace_context = {"trace_id": trace_id} if trace_id else None
+        observation = client.start_observation(
+            trace_context=trace_context,
             name=name,
+            as_type=as_type,
             input=input_data,
+            output=output_data,
             metadata={
-                "observation_type": "agent",
-                "trace_id_hint": trace_id,  # Store for reference
+                "observation_type": as_type,
                 **(metadata or {}),
             },
         )
-        if output_data:
-            observation.update(output=output_data)
-        logger.debug(f"Created agent observation: {name}")
         return observation
     except Exception as e:
-        logger.warning(f"Failed to create agent observation: {e}")
+        logger.warning(f"Failed to create {as_type} observation: {e}")
         return None
+
+
+def create_agent_observation(
+    trace_id: str,
+    name: str,
+    input_data: dict | None = None,
+    output_data: dict | None = None,
+    metadata: dict | None = None,
+    parent_observation_id: str | None = None,  # kept for signature compatibility
+):
+    """Agent 타입 Observation 생성"""
+    obs = _create_typed_observation(
+        as_type="agent",
+        trace_id=trace_id,
+        name=name,
+        input_data=input_data,
+        output_data=output_data,
+        metadata=metadata,
+    )
+    if obs:
+        logger.debug(f"Created agent observation: {name}")
+    return obs
 
 
 def create_tool_observation(
@@ -420,44 +484,18 @@ def create_tool_observation(
     metadata: dict | None = None,
     parent_observation_id: str | None = None,
 ):
-    """Tool 타입 Observation 생성 (Agent Graph 시각화용).
-
-    Args:
-        trace_id: 연결할 Trace ID (v3에서는 무시됨)
-        name: Tool 이름
-        input_data: 입력 데이터
-        output_data: 출력 데이터
-        metadata: 추가 메타데이터
-        parent_observation_id: 부모 Observation ID
-
-    Returns:
-        생성된 Observation 또는 None
-    """
-    if not is_langfuse_enabled():
-        return None
-
-    try:
-        client = get_langfuse_client()
-        if not client:
-            return None
-
-        # Langfuse v3.x: Use start_span (without trace_id parameter)
-        observation = client.start_span(
-            name=name,
-            input=input_data,
-            metadata={
-                "observation_type": "tool",
-                "trace_id_hint": trace_id,  # Store for reference
-                **(metadata or {}),
-            },
-        )
-        if output_data:
-            observation.update(output=output_data)
+    """Tool 타입 Observation 생성"""
+    obs = _create_typed_observation(
+        as_type="tool",
+        trace_id=trace_id,
+        name=name,
+        input_data=input_data,
+        output_data=output_data,
+        metadata=metadata,
+    )
+    if obs:
         logger.debug(f"Created tool observation: {name}")
-        return observation
-    except Exception as e:
-        logger.warning(f"Failed to create tool observation: {e}")
-        return None
+    return obs
 
 
 def create_retrieval_observation(
@@ -468,105 +506,63 @@ def create_retrieval_observation(
     metadata: dict | None = None,
     parent_observation_id: str | None = None,
 ):
-    """Retrieval 타입 Observation 생성 (RAG Agent Graph 시각화용).
-
-    Args:
-        trace_id: 연결할 Trace ID (v3에서는 무시됨)
-        name: Retrieval 이름
-        query: 검색 쿼리
-        documents: 검색된 문서 목록
-        metadata: 추가 메타데이터
-        parent_observation_id: 부모 Observation ID
-
-    Returns:
-        생성된 Observation 또는 None
-    """
-    if not is_langfuse_enabled():
-        return None
-
-    try:
-        client = get_langfuse_client()
-        if not client:
-            return None
-
-        # Langfuse v3.x: Use start_span (without trace_id parameter)
-        observation = client.start_span(
-            name=name,
-            input={"query": query} if query else None,
-            metadata={
-                "observation_type": "retrieval",
-                "document_count": len(documents) if documents else 0,
-                "trace_id_hint": trace_id,  # Store for reference
-                **(metadata or {}),
-            },
-        )
-        if documents:
-            observation.update(output={"documents": documents})
+    """Retrieval 타입 Observation 생성 (RAG)"""
+    obs = _create_typed_observation(
+        as_type="retriever",
+        trace_id=trace_id,
+        name=name,
+        input_data={"query": query} if query else None,
+        output_data={"documents": documents} if documents else None,
+        metadata={
+            "document_count": len(documents) if documents else 0,
+            **(metadata or {}),
+        },
+    )
+    if obs:
         logger.debug(f"Created retrieval observation: {name}")
-        return observation
-    except Exception as e:
-        logger.warning(f"Failed to create retrieval observation: {e}")
-        return None
+    return obs
 
 
 def end_observation(observation, output_data: dict | None = None, status: str = "success"):
-    """Observation 종료 (Agent Graph 노드 완료 마킹).
-
-    Args:
-        observation: 종료할 Observation 객체
-        output_data: 출력 데이터
-        status: 완료 상태 (success/error)
-    """
+    """Observation 종료 (v4: update로 output/metadata 기록 후 end)"""
     if observation is None:
         return
 
     try:
-        observation.end(
-            output=output_data,
-            metadata={"status": status},
-        )
+        update_kwargs: dict[str, Any] = {"metadata": {"status": status}}
+        if output_data is not None:
+            update_kwargs["output"] = output_data
+        observation.update(**update_kwargs)
+        observation.end()
     except Exception as e:
         logger.debug(f"Failed to end observation: {e}")
 
 
 # =============================================================================
-# Phase 1: @observe 데코레이터 래퍼
+# Phase 1: observe_activity 데코레이터
 # =============================================================================
 
 def _extract_job_id(args: tuple, kwargs: dict) -> str | None:
     """Activity 인자에서 job_id 추출"""
-    # Check positional args
     for arg in args:
         if isinstance(arg, dict):
             if "job_id" in arg:
                 return arg.get("job_id")
-            # enriched_input 또는 input_data 내부 검사
             if "raw_input" in arg and isinstance(arg["raw_input"], dict):
                 return arg["raw_input"].get("job_id")
-    # Check kwargs
     for v in kwargs.values():
         if isinstance(v, dict):
             if "job_id" in v:
                 return v.get("job_id")
-    # Check direct job_id kwarg
     return kwargs.get("job_id")
 
 
 def _safe_serialize(obj: Any, max_length: int = 5000) -> dict | str | list | None:
-    """결과를 Langfuse-safe 포맷으로 직렬화
-
-    Args:
-        obj: 직렬화할 객체
-        max_length: 최대 문자열 길이
-
-    Returns:
-        직렬화된 결과 (dict, str, list, or None)
-    """
+    """결과를 Langfuse-safe 포맷으로 직렬화"""
     try:
         if obj is None:
             return None
         if isinstance(obj, dict):
-            # 딕셔너리: 최대 20개 키, 각 값 500자 제한
             return {
                 str(k)[:100]: (
                     _safe_serialize(v, max_length=500) if isinstance(v, (dict, list))
@@ -575,24 +571,22 @@ def _safe_serialize(obj: Any, max_length: int = 5000) -> dict | str | list | Non
                 for k, v in list(obj.items())[:20]
             }
         if isinstance(obj, list):
-            # 리스트: 최대 10개 항목
             return [
                 _safe_serialize(item, max_length=500) if isinstance(item, (dict, list))
                 else str(item)[:500] if item is not None else None
                 for item in obj[:10]
             ]
-        # 기타 타입: 문자열로 변환
         return str(obj)[:max_length]
     except Exception as e:
         return {"type": str(type(obj)), "preview": "serialization_failed", "error": str(e)[:100]}
 
 
 def observe_activity(name: str, phase: str = "unknown"):
-    """Activity용 Langfuse span 래퍼 데코레이터
+    """Activity용 Langfuse span 래퍼 데코레이터 (Langfuse v4 API)
 
-    Temporal Activity에 Langfuse 추적을 추가합니다.
-    동적 @observe 대신 직접 span을 생성하여 output을 명시적으로 기록합니다.
-    @activity.defn 데코레이터 아래에 위치해야 합니다.
+    start_as_current_observation을 사용해 span을 OTel context의 current span으로
+    올려, activity 내부의 LLM generation, 중첩 observe_activity, update_current_span
+    호출이 모두 이 span의 자식으로 올바르게 귀속되도록 한다.
 
     Usage:
         @activity.defn
@@ -605,51 +599,55 @@ def observe_activity(name: str, phase: str = "unknown"):
     def decorator(func):
         @wraps(func)
         async def wrapper(*args, **kwargs):
+            if not is_langfuse_enabled():
+                return await func(*args, **kwargs)
+
             job_id = _extract_job_id(args, kwargs)
+            client = get_langfuse_client()
+            if client is None:
+                return await func(*args, **kwargs)
 
-            if is_langfuse_enabled():
-                span = None
+            trace_context = _trace_context_for_job(client, job_id)
+            try:
+                async_cm = client.start_as_current_observation(
+                    trace_context=trace_context,
+                    name=name,
+                    as_type="span",
+                    input={
+                        "args_count": len(args),
+                        "kwargs_keys": list(kwargs.keys()),
+                        "job_id": job_id,
+                    },
+                    metadata=_span_metadata(job_id=job_id, phase=phase, activity=name),
+                )
+            except Exception as e:
+                logger.debug(f"Failed to start Langfuse span for {name}: {e}")
+                return await func(*args, **kwargs)
+
+            with async_cm as span:
+                _set_trace_level_attrs(
+                    session_id=job_id,
+                    tags=[f"phase:{phase}", f"activity:{name}"],
+                )
                 try:
-                    client = get_langfuse_client()
-                    if client:
-                        # 1. Span 시작 (동적 @observe 대신 직접 생성)
-                        span = client.start_span(
-                            name=name,
-                            input={
-                                "args_count": len(args),
-                                "kwargs_keys": list(kwargs.keys()),
-                                "job_id": job_id,
-                            },
-                        )
-                        # Trace 메타데이터 업데이트
-                        span.update_trace(
-                            session_id=job_id,
-                            tags=[f"phase:{phase}", f"activity:{name}"],
-                        )
-
-                    # 2. Activity 실행
                     with langfuse_trace_context(job_id=job_id, phase=phase, activity=name):
                         result = await func(*args, **kwargs)
-
-                    # 3. Output 명시적 기록 (update 후 end)
-                    if span:
+                    try:
                         span.update(
                             output=_safe_serialize(result),
                             metadata={"status": "success", "activity": name, "phase": phase},
                         )
-                        span.end()
-
+                    except Exception:
+                        pass
                     return result
                 except Exception as e:
-                    # 에러 시에도 span 종료
-                    if span:
+                    try:
                         span.update(
                             output={"error": str(e)[:500]},
                             metadata={"status": "error", "activity": name, "phase": phase},
                         )
-                        span.end()
+                    except Exception:
+                        pass
                     raise
-            else:
-                return await func(*args, **kwargs)
         return wrapper
     return decorator


### PR DESCRIPTION
## Summary

Langfuse SDK v3 → v4.2 (OpenTelemetry 기반) 업그레이드 후 `AttributeError: 'Langfuse' object has no attribute 'start_span'` 때문에 **전체 Temporal activity (33개)가 실패**하던 문제를 해결합니다. 프로덕션에서 `de675337-8697-479e-8e8c-609aaf722ba1` 등 잡이 `enriching` 단계에서 멈췄던 장애의 루트 원인.

## 주요 변경

- `client.start_span(...)` → `client.start_as_current_observation(...)` 컨텍스트 매니저 (OTel current span 승격 → 중첩 LLM generation이 올바르게 parent됨)
- v3 `span.update_trace(session_id/user_id/tags)` 대체: OTel span attr (`session.id`, `user.id`, `langfuse.trace.tags`) 직접 세팅 → **Langfuse Sessions/User/Tag 필터 UI 정상 유지**
- `create_trace_id(seed=job_id)`로 결정론적 trace_id 생성, 동일 job의 모든 span이 같은 trace에 자동 귀속
- `langfuse_context.*` v3 심볼 완전 제거
- `_safe_serialize`, `_extract_job_id`, 공개 API 18개 시그니처 유지 → **23개 호출부 수정 불필요**

## Test plan

- [x] `test_observability.py` 26/26 pass
- [x] `test_evaluation.py` 34/34 pass
- [x] backend 전체 테스트 648 pass (5 preexisting failures — Mistral SDK/activity count assertion, 본 PR 무관)
- [x] E2E smoke: happy / error 전파 / 중첩 decorator / job_id 없음 / flush — 5/5 pass
- [x] 독립 코드리뷰 2라운드 (크리티컬 2건 → 수정 후 PASS)
- [x] 프로덕션 워커 재기동 후 멈춰있던 실제 잡 `de675337`의 `persist_result` attempt 11 성공 (84ms) → 자동 종료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)