### PR TITLE
fix(github): PyGithub 2.9.x get_languages() url 키 leak 방어

### DIFF
--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -62,7 +62,10 @@ class GitHubService:
         try:
             g = self._get_github()
             repo = g.get_repo(path)
-            return dict(repo.get_languages())
+            # PyGithub 2.9.x leak: get_languages() may include a stray 'url' key (str).
+            # Filter to int-only to protect downstream sum/max/min/iteration.
+            raw = dict(repo.get_languages())
+            return {k: v for k, v in raw.items() if isinstance(v, int)}
         except Exception as e:
             logger.warning(f"Failed to get languages for {url}: {e}")
             return {}

--- a/backend/tests/test_github_service.py
+++ b/backend/tests/test_github_service.py
@@ -1,0 +1,61 @@
+"""
+backend/tests/test_github_service.py
+GitHubService 단위 테스트
+
+테스트 항목:
+- get_repo_languages: PyGithub 2.9.x url 키 leak 방어 (sanitizer)
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.services.github_service import GitHubService
+
+
+class TestGetRepoLanguagesSanitizer:
+    """get_repo_languages: PyGithub 2.9.x url 키 leak 방어"""
+
+    @pytest.mark.asyncio
+    async def test_drops_non_int_values_from_pygithub_leak(self):
+        """PyGithub 2.9.x가 반환 dict에 추가하는 'url' (str) 키를 필터링"""
+        svc = GitHubService()
+
+        # PyGithub 2.9.x 실제 버그 재현: int 언어 바이트와 str 'url' 혼재
+        polluted = {
+            "JavaScript": 37951,
+            "HTML": 845,
+            "url": "https://api.github.com/repos/owner/repo/languages",
+        }
+        mock_repo = MagicMock()
+        mock_repo.get_languages.return_value = polluted
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value = mock_repo
+
+        with patch.object(svc, "_get_github", return_value=mock_gh):
+            result = await svc.get_repo_languages(
+                "https://github.com/owner/repo"
+            )
+
+        # str 'url' 키는 제거되어야 함
+        assert "url" not in result
+        assert result == {"JavaScript": 37951, "HTML": 845}
+
+        # 다운스트림 sum(values())가 TypeError 없이 동작함을 확인
+        assert sum(result.values()) == 38796
+
+    @pytest.mark.asyncio
+    async def test_clean_dict_unchanged(self):
+        """leak이 없는 정상 응답은 그대로 반환"""
+        svc = GitHubService()
+
+        clean = {"Python": 100000, "Shell": 500}
+        mock_repo = MagicMock()
+        mock_repo.get_languages.return_value = clean
+        mock_gh = MagicMock()
+        mock_gh.get_repo.return_value = mock_repo
+
+        with patch.object(svc, "_get_github", return_value=mock_gh):
+            result = await svc.get_repo_languages(
+                "https://github.com/owner/repo"
+            )
+
+        assert result == clean


### PR DESCRIPTION
## Summary

PyGithub 2.9.1의 `Repository.get_languages()`가 응답 dict에 `'url'` 키(str 값)를 섞어서 반환하는 production 버그를 소스에서 단일 위생화(sanitize)로 방어합니다.

### Root cause

PyGithub 2.9.x는 `get_languages()`를 내부적으로 API 응답 dict를 그대로 사용하면서 `url` 필드를 leak시킵니다. 실제 production 응답 예:

```python
{'JavaScript': 37951, 'HTML': 845,
 'url': 'https://api.github.com/repos/.../languages'}
```

### 영향

- **터진 현상**: `backend/app/services/github_service.py:175` `sum(languages.values())` → `TypeError: unsupported operand type(s) for +: 'int' and 'str'`
- **영향받은 잡**: `620723b4-341f-4859-a273-8291d7081f5f` (analyze_code Temporal activity)
- **잠재 위험 (latent)**:
  - `backend/app/services/code_analysis.py:776` `max(languages, key=languages.get)` → `'<' not supported between 'int' and 'str'`
  - `planning.py:55` `.keys()` 순회
  - KG 추출 파이프라인

### Fix

`get_repo_languages`에서 **소스 단일 지점** 필터링:

```python
raw = dict(repo.get_languages())
return {k: v for k, v in raw.items() if isinstance(v, int)}
```

다운스트림 consumer에는 손대지 않아 변경을 surgical하게 유지합니다.

### 검증

- `rg "get_languages\(\)" backend/` → 이 메서드 외 직접 호출 없음 확인
- 신규 테스트 `tests/test_github_service.py::TestGetRepoLanguagesSanitizer` 2개 추가
  - `test_drops_non_int_values_from_pygithub_leak`: leak 시나리오 필터 동작
  - `test_clean_dict_unchanged`: 정상 응답은 그대로 통과

## Test plan

- [x] `pytest tests/ -k github_service` → 2 passed
- [x] `pytest tests/test_code_analysis.py` → 25 passed (regression 없음)
- [ ] 다음 production 잡에서 analyze_code activity 정상 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)