### PR TITLE
feat(llm): Kimi K2.5 thinking 기본 OFF + 8개 프롬프트만 ON

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -110,6 +110,9 @@ class Settings(BaseSettings):
     # LLM Cache
     LLM_CACHE_ENABLED: bool = True  # False면 LLM 응답 캐싱 비활성화
 
+    # Kimi K2.5 thinking 모드 글로벌 override — auto(정책) | on | off
+    LLM_KIMI_THINKING: str = "auto"
+
     # Embedding
     EMBEDDING_DIMENSION: int = 1536
 

--- a/backend/app/services/cached_llm.py
+++ b/backend/app/services/cached_llm.py
@@ -308,8 +308,12 @@ class CachedLLMService:
         model: str | None = None,
         override_max_tokens: int | None = None,
         temperature: float = 0.0,
+        extra_body: dict | None = None,
     ):
-        """모델별 최적 ModelSettings 반환 (temperature 기본값 0.0 = 결정적 출력)"""
+        """모델별 최적 ModelSettings 반환 (temperature 기본값 0.0 = 결정적 출력).
+
+        extra_body는 Kimi thinking 같은 provider-specific 파라미터 전달용.
+        """
         from pydantic_ai import ModelSettings
         from app.services.llm_config import get_max_output_tokens
         if override_max_tokens:
@@ -318,7 +322,38 @@ class CachedLLMService:
             max_tokens = get_max_output_tokens(model)
         else:
             max_tokens = settings.LLM_MAX_OUTPUT_TOKENS
-        return ModelSettings(max_tokens=max_tokens, temperature=temperature)
+        kwargs: dict[str, Any] = {"max_tokens": max_tokens, "temperature": temperature}
+        if extra_body:
+            kwargs["extra_body"] = extra_body
+        return ModelSettings(**kwargs)
+
+    @staticmethod
+    def _build_kimi_thinking_args(
+        *,
+        model: str,
+        prompt_name: str | None = None,
+        activity_name: str | None = None,
+        langfuse_config: dict | None = None,
+        base_temperature: float = 0.0,
+    ) -> tuple[dict | None, float]:
+        """Kimi K2.5용 extra_body + 강제 temperature 반환.
+
+        Kimi가 아니면 (None, base_temperature) 그대로 통과.
+        Kimi이면 thinking 정책을 해석해 extra_body={"thinking": {...}}와
+        Kimi가 허용하는 고정 temperature(1.0/0.6)를 반환.
+        """
+        from app.services.llm_config import is_kimi_model, resolve_kimi_thinking
+        if not is_kimi_model(model):
+            return None, base_temperature
+        enabled = resolve_kimi_thinking(
+            prompt_name=prompt_name,
+            activity_name=activity_name,
+            langfuse_config=langfuse_config,
+        )
+        return (
+            {"thinking": {"type": "enabled" if enabled else "disabled"}},
+            1.0 if enabled else 0.6,
+        )
 
     @staticmethod
     def _make_cache_key(prompt: str, model: str, activity_name: str | None = None, job_id: str | None = None) -> str:
@@ -376,11 +411,12 @@ class CachedLLMService:
         override_max_tokens: int | None = None,
         trace_meta: dict | None = None,
         temperature: float = 0.0,
+        extra_body: dict | None = None,
     ) -> tuple[Any, Any]:
         """LLM 호출 + 폴백 + 결과 정규화. (data, run_result) 반환."""
         from app.services.llm_config import get_llm_agent
 
-        ms = self._model_settings(model, override_max_tokens, temperature=temperature)
+        ms = self._model_settings(model, override_max_tokens, temperature=temperature, extra_body=extra_body)
         try:
             agent = get_llm_agent(output_type=result_type, model=model)
             run_result = await asyncio.shield(agent.run(prompt, model_settings=ms))
@@ -418,6 +454,7 @@ class CachedLLMService:
         activity_name: str | None = None,
         override_max_tokens: int | None = None,
         temperature: float = 0.0,
+        extra_body: dict | None = None,
     ) -> Any:
         """캐시 조회 → LLM 호출 → Langfuse 로깅 → 캐시 저장 (공통 파이프라인)"""
         # 1. 캐시 조회
@@ -429,6 +466,7 @@ class CachedLLMService:
         data, run_result = await self._call_llm_with_fallback(
             prompt, model, result_type, override_max_tokens, trace_meta,
             temperature=temperature,
+            extra_body=extra_body,
         )
 
         # 3. Langfuse 로깅
@@ -457,6 +495,10 @@ class CachedLLMService:
             model = get_model_for_activity(activity_name)
         model = model or settings.LLM_MODEL
 
+        extra_body, temperature = self._build_kimi_thinking_args(
+            model=model, activity_name=activity_name
+        )
+
         return await self._execute_with_cache(
             prompt=prompt,
             model=model,
@@ -464,6 +506,8 @@ class CachedLLMService:
             trace_meta=get_current_trace_metadata(),
             result_type=result_type,
             activity_name=activity_name,
+            temperature=temperature,
+            extra_body=extra_body,
         )
 
     async def run_for_job(
@@ -480,6 +524,10 @@ class CachedLLMService:
             model = get_model_for_activity(activity_name)
         model = model or settings.LLM_MODEL
 
+        extra_body, temperature = self._build_kimi_thinking_args(
+            model=model, activity_name=activity_name
+        )
+
         return await self._execute_with_cache(
             prompt=prompt,
             model=model,
@@ -487,6 +535,8 @@ class CachedLLMService:
             trace_meta={**get_current_trace_metadata(), "job_id": job_id},
             result_type=result_type,
             activity_name=activity_name,
+            temperature=temperature,
+            extra_body=extra_body,
         )
 
     async def run_with_prompt_config(
@@ -518,6 +568,15 @@ class CachedLLMService:
             if temp is not None:
                 config_temperature = float(temp)
 
+        # Kimi thinking 모드는 prompt_name + Langfuse config로 해석.
+        # Kimi일 때만 extra_body와 강제 temperature(1.0/0.6)가 적용됨.
+        extra_body, config_temperature = self._build_kimi_thinking_args(
+            model=model,
+            prompt_name=prompt_name,
+            langfuse_config=prompt_config.config,
+            base_temperature=config_temperature,
+        )
+
         return await self._execute_with_cache(
             prompt=prompt,
             model=model,
@@ -527,6 +586,7 @@ class CachedLLMService:
             activity_name=prompt_name,
             override_max_tokens=config_max_tokens,
             temperature=config_temperature,
+            extra_body=extra_body,
         )
 
     # ─── Langfuse 이벤트 로깅 ────────────────────────────

--- a/backend/app/services/llm_config.py
+++ b/backend/app/services/llm_config.py
@@ -58,6 +58,74 @@ GPT_41_MINI_MODEL = "openai:gpt-4.1-mini"
 # Legacy alias (backward compatibility)
 CODE_ANALYSIS_GLM_MODEL = GLM_CODER_MODEL
 
+# =============================================================================
+# Kimi K2.5 Thinking Mode 정책
+# =============================================================================
+# Kimi K2.5는 기본적으로 thinking=enabled. 느리고 비싸기 때문에 기본은 OFF로
+# 강제하고, 종합분석·최종 검토·최종 결과물 단계만 ON.
+#
+# 우선순위 (cached_llm.py:resolve_kimi_thinking 참조):
+#   1) env var LLM_KIMI_THINKING = "on" | "off"  (글로벌 kill-switch)
+#   2) Langfuse prompt config.thinking.type  (프롬프트별 override)
+#   3) THINKING_ENABLED_PROMPTS 집합에 포함되면 ON
+#   4) 기본 OFF
+#
+# Kimi 제약: thinking=ON → temperature 1.0 고정 / OFF → 0.6 고정. 다른 값은 400.
+# =============================================================================
+
+THINKING_ENABLED_PROMPTS: set[str] = {
+    # 종합분석 (5축 레이더 + 스킬 매칭)
+    "v2_generation_radar_analysis",
+    "v2_generation_skill_matching",
+    # 최종 의사결정 종합
+    "v2_generation_decision_summary",
+    "v2_generation_interviewer_tips",
+    # 질문 최종 검토 / revise
+    "quality_review_review",
+    "question_enhancement_revise_questions",
+    # 최종 결과물
+    "finalization_candidate_summary",
+    "finalization_interviewer_guide",
+}
+
+
+def is_kimi_model(model: str | None) -> bool:
+    """Kimi (Moonshot) 모델 여부"""
+    return bool(model) and model.startswith("moonshot/")
+
+
+def resolve_kimi_thinking(
+    *,
+    prompt_name: str | None,
+    activity_name: str | None,
+    langfuse_config: dict | None,
+) -> bool:
+    """Kimi thinking 모드를 결정. True=enabled, False=disabled.
+
+    우선순위: env > Langfuse config > THINKING_ENABLED_PROMPTS > 기본 OFF.
+    """
+    # 1) env override
+    env = (settings.LLM_KIMI_THINKING or "auto").lower()
+    if env == "on":
+        return True
+    if env == "off":
+        return False
+
+    # 2) Langfuse config override
+    if langfuse_config:
+        thinking = langfuse_config.get("thinking")
+        if isinstance(thinking, dict) and thinking.get("type") in ("enabled", "disabled"):
+            return thinking["type"] == "enabled"
+
+    # 3) 코드 정책 집합
+    key = prompt_name or activity_name
+    if key and key in THINKING_ENABLED_PROMPTS:
+        return True
+
+    # 4) 기본 OFF
+    return False
+
+
 ACTIVITY_MODEL_CONFIG: dict[str, str] = {
     # Phase 0: Input Enrichment
     "enrich_input": KIMI_CHAT_MODEL,

--- a/backend/tests/test_kimi_thinking.py
+++ b/backend/tests/test_kimi_thinking.py
@@ -1,0 +1,162 @@
+"""Kimi K2.5 thinking mode 정책 + extra_body 배관 테스트."""
+from unittest.mock import patch
+
+from app.services.cached_llm import CachedLLMService
+from app.services.llm_config import (
+    THINKING_ENABLED_PROMPTS,
+    is_kimi_model,
+    resolve_kimi_thinking,
+)
+
+
+class TestThinkingPolicy:
+    def test_enabled_set_has_8_prompts(self):
+        assert len(THINKING_ENABLED_PROMPTS) == 8
+
+    def test_synthesis_prompts_enabled(self):
+        for name in (
+            "v2_generation_radar_analysis",
+            "v2_generation_skill_matching",
+            "v2_generation_decision_summary",
+            "v2_generation_interviewer_tips",
+        ):
+            assert resolve_kimi_thinking(
+                prompt_name=name, activity_name=None, langfuse_config=None
+            ) is True, name
+
+    def test_final_review_prompts_enabled(self):
+        for name in (
+            "quality_review_review",
+            "question_enhancement_revise_questions",
+        ):
+            assert resolve_kimi_thinking(
+                prompt_name=name, activity_name=None, langfuse_config=None
+            ) is True, name
+
+    def test_finalization_prompts_enabled(self):
+        for name in (
+            "finalization_candidate_summary",
+            "finalization_interviewer_guide",
+        ):
+            assert resolve_kimi_thinking(
+                prompt_name=name, activity_name=None, langfuse_config=None
+            ) is True, name
+
+    def test_parallel_analysis_prompts_disabled(self):
+        for name in (
+            "jd_analysis_analyze",
+            "jd_analysis_translate",
+            "document_analysis_extract_profile",
+            "linkedin_summary_recommendations_summary",
+            "question_topic_selection_select_topics",
+            "question_craft_technical_depth_craft_question_technical_depth",
+            "question_enhancement_enhance_terminology",
+            "question_enhancement_generate_scenarios",
+            "question_enhancement_generate_followups",
+            "question_enhancement_generate_interviewer_notes",
+            "question_enhancement_generate_decision_guide",
+        ):
+            assert resolve_kimi_thinking(
+                prompt_name=name, activity_name=None, langfuse_config=None
+            ) is False, name
+
+    def test_code_deep_analysis_prefix_disabled(self):
+        assert resolve_kimi_thinking(
+            prompt_name=None,
+            activity_name="code_deep_analysis_src/main.py",
+            langfuse_config=None,
+        ) is False
+
+    def test_langfuse_config_enabled_override(self):
+        assert resolve_kimi_thinking(
+            prompt_name="jd_analysis_analyze",
+            activity_name=None,
+            langfuse_config={"thinking": {"type": "enabled"}},
+        ) is True
+
+    def test_langfuse_config_disabled_override(self):
+        assert resolve_kimi_thinking(
+            prompt_name="v2_generation_radar_analysis",
+            activity_name=None,
+            langfuse_config={"thinking": {"type": "disabled"}},
+        ) is False
+
+    def test_env_on_forces_enabled(self):
+        with patch("app.services.llm_config.settings.LLM_KIMI_THINKING", "on"):
+            assert resolve_kimi_thinking(
+                prompt_name="jd_analysis_analyze",
+                activity_name=None,
+                langfuse_config=None,
+            ) is True
+
+    def test_env_off_forces_disabled(self):
+        with patch("app.services.llm_config.settings.LLM_KIMI_THINKING", "off"):
+            assert resolve_kimi_thinking(
+                prompt_name="v2_generation_radar_analysis",
+                activity_name=None,
+                langfuse_config=None,
+            ) is False
+
+    def test_default_off_for_unknown(self):
+        assert resolve_kimi_thinking(
+            prompt_name="some_unknown_prompt",
+            activity_name=None,
+            langfuse_config=None,
+        ) is False
+
+
+class TestIsKimiModel:
+    def test_moonshot_prefix_is_kimi(self):
+        assert is_kimi_model("moonshot/kimi-k2.5") is True
+        assert is_kimi_model("moonshot/kimi-k2-0905-preview") is True
+
+    def test_other_providers_not_kimi(self):
+        assert is_kimi_model("openai:gpt-4.1-mini") is False
+        assert is_kimi_model("zai/glm-4.5-flash") is False
+        assert is_kimi_model("anthropic:claude-3-5-sonnet") is False
+        assert is_kimi_model(None) is False
+        assert is_kimi_model("") is False
+
+
+class TestBuildKimiThinkingArgs:
+    def test_kimi_thinking_enabled_forces_temp_1(self):
+        extra, temp = CachedLLMService._build_kimi_thinking_args(
+            model="moonshot/kimi-k2.5",
+            prompt_name="finalization_candidate_summary",
+        )
+        assert extra == {"thinking": {"type": "enabled"}}
+        assert temp == 1.0
+
+    def test_kimi_thinking_disabled_forces_temp_0_6(self):
+        extra, temp = CachedLLMService._build_kimi_thinking_args(
+            model="moonshot/kimi-k2.5",
+            prompt_name="jd_analysis_analyze",
+        )
+        assert extra == {"thinking": {"type": "disabled"}}
+        assert temp == 0.6
+
+    def test_non_kimi_passthrough_preserves_base_temp(self):
+        extra, temp = CachedLLMService._build_kimi_thinking_args(
+            model="openai:gpt-4.1-mini",
+            prompt_name="finalization_candidate_summary",
+            base_temperature=0.2,
+        )
+        assert extra is None
+        assert temp == 0.2
+
+    def test_non_kimi_passthrough_with_no_base_temp(self):
+        extra, temp = CachedLLMService._build_kimi_thinking_args(
+            model="zai/glm-4.5-flash",
+            activity_name="analyze_code",
+        )
+        assert extra is None
+        assert temp == 0.0
+
+    def test_langfuse_config_wins_over_default_set(self):
+        extra, temp = CachedLLMService._build_kimi_thinking_args(
+            model="moonshot/kimi-k2.5",
+            prompt_name="jd_analysis_analyze",
+            langfuse_config={"thinking": {"type": "enabled"}},
+        )
+        assert extra == {"thinking": {"type": "enabled"}}
+        assert temp == 1.0


### PR DESCRIPTION
## Summary

Kimi K2.5는 thinking 기본값이 `enabled`라 모든 LLM 호출에 reasoning 토큰이 붙어 토큰/레이턴시/비용이 크게 늘어남. 병렬 분석·초안 생성에는 불필요하므로 **코드 기본을 OFF로 강제**하고, 종합분석·최종 검토·최종 결과물 **8개 프롬프트만 ON**으로 유지.

## 정책표

### 🔴 ON (8개)
| Prompt | 이유 |
|--------|------|
| `v2_generation_radar_analysis` | 5축 레이더 종합 점수 |
| `v2_generation_skill_matching` | JD↔후보자 스킬 종합 매칭 |
| `v2_generation_decision_summary` | 최종 채용 판단 종합 |
| `v2_generation_interviewer_tips` | 면접관 팁 종합 |
| `quality_review_review` | 질문 환각/품질 최종 검토 |
| `question_enhancement_revise_questions` | 품질 리뷰 후 질문 revise |
| `finalization_candidate_summary` | 후보자 요약 최종 |
| `finalization_interviewer_guide` | 면접관 가이드 최종 |

### 🟢 OFF (기본값)
- `code_deep_analysis_*` (파일당 병렬)
- `analyze_jd`, `analyze_documents`, `profile_builder` (병렬 분석)
- `question_topic_selection`, `question_craft_*` 5개 카테고리 (초안 생성)
- `question_enhancement` 나머지 5개 (bulk 보조 생성 — terminology/scenarios/followups/notes/decision_guide)

## 해석 우선순위

`cached_llm.py:_build_kimi_thinking_args()` → `llm_config.py:resolve_kimi_thinking()`
1. env `LLM_KIMI_THINKING` (`on`/`off`) — 글로벌 kill-switch
2. Langfuse prompt `config.thinking.type` — per-prompt override
3. `THINKING_ENABLED_PROMPTS` 하드코딩 집합
4. 기본 OFF

## Kimi 온도 제약 처리

Kimi 문서: thinking ON → temperature **1.0 고정** / OFF → **0.6 고정**, 다른 값 400. `_build_kimi_thinking_args()`가 thinking 결정 후 필요한 temperature도 함께 반환. Kimi가 아닌 provider는 `extra_body=None` passthrough로 무해.

## 변경 파일

- `backend/app/services/llm_config.py` — 정책 집합 + resolver 헬퍼
- `backend/app/services/cached_llm.py` — `extra_body` 배관 (`_model_settings`, `_call_llm_with_fallback`, `_execute_with_cache`, `run`, `run_for_job`, `run_with_prompt_config`)
- `backend/app/core/config.py` — `LLM_KIMI_THINKING` env var
- `backend/tests/test_kimi_thinking.py` — 18개 단위 테스트 신규

## Test plan

- [x] 단위 테스트: `test_kimi_thinking.py` 18개 + `test_observability.py` 26개 = 44 pass
- [x] 실제 Kimi API probe: `thinking=disabled+temp=0.6` / `thinking=enabled+temp=1.0` 둘 다 응답 정상
- [x] non-Kimi provider passthrough: `openai:gpt-4.1-mini`, `zai/glm-4.5-flash` → `extra_body=None`

## 예상 효과

- **토큰 절감**: code_deep_analysis(파일당 N회), question_craft(질문당), question_enhancement bulk(질문당 4~5회)에서 thinking 토큰 제거 → **전체 잡 토큰 ~70% 절감 추정**
- **속도↑**: OFF 경로 레이턴시 크게 감소
- **품질 유지**: 종합분석/최종 검토/최종 결과물에만 thinking을 남겨 출력 품질은 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)