### PR TITLE
fix(llm): Kimi thinking 코드 리뷰 4건 반영 (PR #383 follow-up)

### DIFF
--- a/backend/app/prompts/CLAUDE.md
+++ b/backend/app/prompts/CLAUDE.md
@@ -20,3 +20,29 @@ LLM 프롬프트 YAML 파일.
 
 - 질문 생성: 다중 소스 증거 기반 전략
 - 필수 필드는 `null 금지` + 추론 규칙 명시 (MEMORY.md 참조)
+
+## Kimi K2.5 thinking mode in Langfuse prompt config
+
+Kimi (`moonshot/*`) 프롬프트의 경우 Langfuse prompt `config`에서 thinking 모드를
+명시적으로 오버라이드할 수 있다. 유일하게 허용되는 형식:
+
+```yaml
+config:
+  thinking:
+    type: "enabled"   # 또는 "disabled"
+```
+
+그 외 모든 형식(예: `{"thinking": true}`, `{"thinking": "enabled"}`,
+`{"thinking": {"enabled": true}}`)은 **무시**되고 `llm_config.THINKING_ENABLED_PROMPTS`
+세트의 하드코딩 정책으로 fallback된다. 이 경우 `llm_config.py`가 프로세스당
+프롬프트별로 한 번만 `WARNING` 로그를 남긴다.
+
+우선순위 (`resolve_kimi_thinking`):
+1. env var `LLM_KIMI_THINKING` = `on` / `off` (글로벌 kill-switch)
+2. Langfuse `config.thinking.type` (프롬프트별 override)
+3. `THINKING_ENABLED_PROMPTS` 세트 포함 여부
+4. 기본 OFF
+
+Kimi 제약 — thinking=ON → `temperature=1.0` 강제 / OFF → `0.6` 강제. 다른 값은
+HTTP 400. Langfuse prompt config에 `temperature`가 있어도 Kimi라면 덮어써지며,
+`cached_llm._build_kimi_thinking_args`가 `INFO` 로그로 override 사실을 기록한다.

--- a/backend/app/services/cached_llm.py
+++ b/backend/app/services/cached_llm.py
@@ -350,20 +350,55 @@ class CachedLLMService:
             activity_name=activity_name,
             langfuse_config=langfuse_config,
         )
+        forced_temp = 1.0 if enabled else 0.6
+        # Kimi 제약: thinking=ON → 1.0, OFF → 0.6. 그 외 값은 HTTP 400.
+        # 기본값(0.0)은 실제 operator가 설정한 값이 아니므로 로깅 노이즈만 만듦 → 제외.
+        # 1.0/0.6 그대로면 override가 아니므로 제외.
+        if base_temperature not in (0.0, 1.0, 0.6):
+            logger.info(
+                "Kimi temperature override: %.2f → %.2f (thinking=%s, prompt=%s)",
+                base_temperature,
+                forced_temp,
+                "enabled" if enabled else "disabled",
+                prompt_name or activity_name,
+            )
         return (
             {"thinking": {"type": "enabled" if enabled else "disabled"}},
-            1.0 if enabled else 0.6,
+            forced_temp,
         )
 
     @staticmethod
-    def _make_cache_key(prompt: str, model: str, activity_name: str | None = None, job_id: str | None = None) -> str:
+    def _make_cache_key(
+        prompt: str,
+        model: str,
+        activity_name: str | None = None,
+        job_id: str | None = None,
+        temperature: float | None = None,
+        extra_body: dict | None = None,
+    ) -> str:
         """캐시 키 생성 (Activity + Job 스코프 통합)
 
         키 형식:
           글로벌:   llm_cache:{activity}:{hash}
           잡스코프: llm_cache:job:{job_id}:{activity}:{hash}
+
+        해싱 대상에 temperature / extra_body도 포함한다. 이유:
+          - Kimi thinking 토글(Langfuse operator가 config.thinking.type 변경)이나
+            env LLM_KIMI_THINKING on/off 전환 시 동일 prompt+model이라도
+            실제 출력 분포가 다름(reasoning vs non-reasoning).
+          - 이전 구현(`model:prompt`)은 이런 조건 차이를 키에 반영하지 않아
+            thinking 토글 후 TTL 만료까지 stale 결과를 서빙했다.
+
+        Separator(`|`)는 이전 포맷(`model:prompt`)의 콜론과 달라 기존 배포에서
+        생성된 orphan 키가 우연히 같은 해시로 충돌할 가능성을 없앤다.
         """
-        content = f"{model}:{prompt}"
+        content_parts = [model]
+        if temperature is not None:
+            content_parts.append(f"t={temperature}")
+        if extra_body:
+            content_parts.append(f"eb={json.dumps(extra_body, sort_keys=True)}")
+        content_parts.append(prompt)
+        content = "|".join(content_parts)
         hash_part = hashlib.sha256(content.encode()).hexdigest()
         parts = ["llm_cache"]
         if job_id:
@@ -502,7 +537,10 @@ class CachedLLMService:
         return await self._execute_with_cache(
             prompt=prompt,
             model=model,
-            cache_key=self._make_cache_key(prompt, model, activity_name),
+            cache_key=self._make_cache_key(
+                prompt, model, activity_name,
+                temperature=temperature, extra_body=extra_body,
+            ),
             trace_meta=get_current_trace_metadata(),
             result_type=result_type,
             activity_name=activity_name,
@@ -531,7 +569,10 @@ class CachedLLMService:
         return await self._execute_with_cache(
             prompt=prompt,
             model=model,
-            cache_key=self._make_cache_key(prompt, model, activity_name, job_id=job_id),
+            cache_key=self._make_cache_key(
+                prompt, model, activity_name, job_id=job_id,
+                temperature=temperature, extra_body=extra_body,
+            ),
             trace_meta={**get_current_trace_metadata(), "job_id": job_id},
             result_type=result_type,
             activity_name=activity_name,
@@ -580,7 +621,10 @@ class CachedLLMService:
         return await self._execute_with_cache(
             prompt=prompt,
             model=model,
-            cache_key=self._make_cache_key(prompt, model, prompt_name),
+            cache_key=self._make_cache_key(
+                prompt, model, prompt_name,
+                temperature=config_temperature, extra_body=extra_body,
+            ),
             trace_meta=trace_meta,
             result_type=result_type,
             activity_name=prompt_name,

--- a/backend/app/services/llm_config.py
+++ b/backend/app/services/llm_config.py
@@ -86,7 +86,14 @@ THINKING_ENABLED_PROMPTS: set[str] = {
     # 최종 결과물
     "finalization_candidate_summary",
     "finalization_interviewer_guide",
+    # 3-Stage 코드 분석 Stage 3 종합 (Stage 1 overview, Stage 2 per-file deep는 OFF 유지)
+    # 사용자 정책: "종합분석 띵킹" — 최종 synthesis 단계만 reasoning 활성화.
+    "code_synthesis_analysis",
 }
+
+# Langfuse config.thinking 형식이 잘못됐을 때 한 번만 경고하기 위한 dedup 세트.
+# 테스트에서는 매 테스트 시작 시 clear해야 한다.
+_WARNED_MALFORMED_THINKING: set[str] = set()
 
 
 def is_kimi_model(model: str | None) -> bool:
@@ -114,8 +121,20 @@ def resolve_kimi_thinking(
     # 2) Langfuse config override
     if langfuse_config:
         thinking = langfuse_config.get("thinking")
-        if isinstance(thinking, dict) and thinking.get("type") in ("enabled", "disabled"):
-            return thinking["type"] == "enabled"
+        if thinking is not None:
+            if isinstance(thinking, dict) and thinking.get("type") in ("enabled", "disabled"):
+                return thinking["type"] == "enabled"
+            # Malformed (e.g. {"thinking": True}, {"thinking": "enabled"},
+            # {"thinking": {"enabled": True}}) — 정책으로 fallthrough하되, 한 번만 경고.
+            warn_key = prompt_name or activity_name or "<unknown>"
+            if warn_key not in _WARNED_MALFORMED_THINKING:
+                _WARNED_MALFORMED_THINKING.add(warn_key)
+                logger.warning(
+                    "Langfuse config.thinking malformed for %s "
+                    "(expected {type: enabled|disabled}, got %r) — falling back to policy",
+                    warn_key,
+                    thinking,
+                )
 
     # 3) 코드 정책 집합
     key = prompt_name or activity_name

--- a/backend/tests/test_kimi_thinking.py
+++ b/backend/tests/test_kimi_thinking.py
@@ -1,6 +1,9 @@
 """Kimi K2.5 thinking mode 정책 + extra_body 배관 테스트."""
 from unittest.mock import patch
 
+import pytest
+
+from app.services import llm_config
 from app.services.cached_llm import CachedLLMService
 from app.services.llm_config import (
     THINKING_ENABLED_PROMPTS,
@@ -9,9 +12,18 @@ from app.services.llm_config import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _reset_malformed_warn_cache():
+    """각 테스트마다 malformed warn dedup 세트를 초기화."""
+    llm_config._WARNED_MALFORMED_THINKING.clear()
+    yield
+    llm_config._WARNED_MALFORMED_THINKING.clear()
+
+
 class TestThinkingPolicy:
-    def test_enabled_set_has_8_prompts(self):
-        assert len(THINKING_ENABLED_PROMPTS) == 8
+    def test_enabled_set_has_9_prompts(self):
+        # 8 + code_synthesis_analysis (3-Stage 코드 분석 Stage 3 종합)
+        assert len(THINKING_ENABLED_PROMPTS) == 9
 
     def test_synthesis_prompts_enabled(self):
         for name in (
@@ -160,3 +172,213 @@ class TestBuildKimiThinkingArgs:
         )
         assert extra == {"thinking": {"type": "enabled"}}
         assert temp == 1.0
+
+
+class TestCodeSynthesisThinking:
+    """Fix #2: code_synthesis_analysis (Stage 3 종합)가 thinking=ON."""
+
+    def test_synthesis_activity_enabled(self):
+        # activity_name 경로 (code_analyzer.llm_synthesize_analysis에서 사용)
+        assert resolve_kimi_thinking(
+            prompt_name=None,
+            activity_name="code_synthesis_analysis",
+            langfuse_config=None,
+        ) is True
+
+    def test_overview_activity_disabled(self):
+        # Stage 1 overview는 OFF 유지 (preliminary survey)
+        assert resolve_kimi_thinking(
+            prompt_name=None,
+            activity_name="code_overview_analysis",
+            langfuse_config=None,
+        ) is False
+
+    def test_deep_analysis_prefix_still_disabled(self):
+        # Stage 2 per-file deep analysis도 OFF 유지
+        assert resolve_kimi_thinking(
+            prompt_name=None,
+            activity_name="code_deep_analysis_src/foo.py",
+            langfuse_config=None,
+        ) is False
+
+    def test_synthesis_in_enabled_set(self):
+        assert "code_synthesis_analysis" in THINKING_ENABLED_PROMPTS
+
+
+class TestMalformedLangfuseThinkingConfig:
+    """Fix #4 Part B: 잘못된 Langfuse config.thinking은 정책으로 fallthrough + 1회 경고."""
+
+    def test_bool_true_falls_back_to_policy(self):
+        # enabled_set에 있는 프롬프트 → 정책으로 True
+        assert resolve_kimi_thinking(
+            prompt_name="finalization_candidate_summary",
+            activity_name=None,
+            langfuse_config={"thinking": True},
+        ) is True
+
+    def test_bool_true_unknown_prompt_falls_back_to_default_off(self):
+        assert resolve_kimi_thinking(
+            prompt_name="some_unknown_prompt",
+            activity_name=None,
+            langfuse_config={"thinking": True},
+        ) is False
+
+    def test_string_enabled_falls_back_to_policy(self):
+        # "yes"는 dict가 아니므로 malformed → 정책 fallthrough
+        assert resolve_kimi_thinking(
+            prompt_name="v2_generation_radar_analysis",
+            activity_name=None,
+            langfuse_config={"thinking": "yes"},
+        ) is True
+
+    def test_wrong_dict_shape_falls_back_to_policy(self):
+        # {"enabled": True} 형태도 malformed
+        assert resolve_kimi_thinking(
+            prompt_name="jd_analysis_analyze",
+            activity_name=None,
+            langfuse_config={"thinking": {"enabled": True}},
+        ) is False
+
+    def test_warning_logged_once_per_prompt(self, caplog):
+        import logging
+        caplog.set_level(logging.WARNING, logger="app.services.llm_config")
+        # 같은 프롬프트로 두 번 호출 → warn은 한 번만
+        for _ in range(3):
+            resolve_kimi_thinking(
+                prompt_name="some_prompt",
+                activity_name=None,
+                langfuse_config={"thinking": True},
+            )
+        warn_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "config.thinking malformed" in r.getMessage()
+        ]
+        assert len(warn_records) == 1, f"expected 1 warning, got {len(warn_records)}"
+
+    def test_warning_separate_per_prompt(self, caplog):
+        import logging
+        caplog.set_level(logging.WARNING, logger="app.services.llm_config")
+        resolve_kimi_thinking(
+            prompt_name="prompt_a", activity_name=None,
+            langfuse_config={"thinking": True},
+        )
+        resolve_kimi_thinking(
+            prompt_name="prompt_b", activity_name=None,
+            langfuse_config={"thinking": "yes"},
+        )
+        warn_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "config.thinking malformed" in r.getMessage()
+        ]
+        assert len(warn_records) == 2
+
+    def test_valid_config_does_not_warn(self, caplog):
+        import logging
+        caplog.set_level(logging.WARNING, logger="app.services.llm_config")
+        resolve_kimi_thinking(
+            prompt_name="whatever", activity_name=None,
+            langfuse_config={"thinking": {"type": "enabled"}},
+        )
+        warn_records = [
+            r for r in caplog.records
+            if "config.thinking malformed" in r.getMessage()
+        ]
+        assert len(warn_records) == 0
+
+    def test_missing_thinking_key_does_not_warn(self, caplog):
+        import logging
+        caplog.set_level(logging.WARNING, logger="app.services.llm_config")
+        resolve_kimi_thinking(
+            prompt_name="whatever", activity_name=None,
+            langfuse_config={"other_field": 42},
+        )
+        warn_records = [
+            r for r in caplog.records
+            if "config.thinking malformed" in r.getMessage()
+        ]
+        assert len(warn_records) == 0
+
+
+class TestCacheKeyThinkingAware:
+    """Fix #1: cache-key가 temperature/extra_body 변화를 반영."""
+
+    def test_different_thinking_mode_different_cache_key(self):
+        # 같은 prompt+model, thinking ON vs OFF → 다른 키
+        key_on = CachedLLMService._make_cache_key(
+            prompt="hello", model="moonshot/kimi-k2.5",
+            activity_name="synthesis",
+            temperature=1.0,
+            extra_body={"thinking": {"type": "enabled"}},
+        )
+        key_off = CachedLLMService._make_cache_key(
+            prompt="hello", model="moonshot/kimi-k2.5",
+            activity_name="synthesis",
+            temperature=0.6,
+            extra_body={"thinking": {"type": "disabled"}},
+        )
+        assert key_on != key_off
+
+    def test_same_thinking_mode_same_cache_key(self):
+        key_a = CachedLLMService._make_cache_key(
+            prompt="hello", model="moonshot/kimi-k2.5",
+            activity_name="synthesis",
+            temperature=1.0,
+            extra_body={"thinking": {"type": "enabled"}},
+        )
+        key_b = CachedLLMService._make_cache_key(
+            prompt="hello", model="moonshot/kimi-k2.5",
+            activity_name="synthesis",
+            temperature=1.0,
+            extra_body={"thinking": {"type": "enabled"}},
+        )
+        assert key_a == key_b
+
+    def test_non_kimi_stable_key_regardless_of_temperature_fluctuation(self):
+        # Non-Kimi: extra_body=None, temperature는 operator가 설정한 base
+        # → temperature가 같으면 같은 키 (안정적)
+        key_a = CachedLLMService._make_cache_key(
+            prompt="hello", model="openai:gpt-4.1-mini",
+            activity_name="analyze_jd",
+            temperature=0.0, extra_body=None,
+        )
+        key_b = CachedLLMService._make_cache_key(
+            prompt="hello", model="openai:gpt-4.1-mini",
+            activity_name="analyze_jd",
+            temperature=0.0, extra_body=None,
+        )
+        assert key_a == key_b
+
+    def test_non_kimi_extra_body_none_does_not_affect_hash(self):
+        # extra_body=None 일 때 해시는 model+prompt (+temperature) 기반이어야 한다
+        key_with = CachedLLMService._make_cache_key(
+            prompt="hi", model="openai:gpt-4.1-mini",
+            temperature=0.0, extra_body=None,
+        )
+        # 같은 인자를 명시적으로 전달해도 동일
+        key_also = CachedLLMService._make_cache_key(
+            prompt="hi", model="openai:gpt-4.1-mini",
+            temperature=0.0, extra_body=None,
+        )
+        assert key_with == key_also
+
+    def test_prefix_separator_changed_from_colon_to_pipe(self):
+        # Orphan 키 방지: 새 포맷은 `|` separator를 사용하여 이전 `model:prompt` 해시와 다름
+        import hashlib
+        model, prompt = "moonshot/kimi-k2.5", "hello"
+        old_format_hash = hashlib.sha256(f"{model}:{prompt}".encode()).hexdigest()
+        new_key = CachedLLMService._make_cache_key(
+            prompt=prompt, model=model, temperature=None, extra_body=None,
+        )
+        # 새 키는 old_format 해시를 포함하지 않아야 한다
+        assert old_format_hash not in new_key
+
+    def test_cache_key_signature_accepts_new_kwargs(self):
+        # 시그니처 regression 방지
+        key = CachedLLMService._make_cache_key(
+            prompt="p", model="m",
+            activity_name="a", job_id="j",
+            temperature=0.6, extra_body={"thinking": {"type": "disabled"}},
+        )
+        assert key.startswith("llm_cache:job:j:a:")


### PR DESCRIPTION
PR #383 (Kimi K2.5 thinking 모드 기본 OFF + 정책 기반 ON) 머지 후 코드 리뷰에서 발견된 4건의 이슈를 한 번에 처리하는 follow-up.

## Fix #1 (HIGH) — 캐시키 thinking-aware 재설계

**파일**: `backend/app/services/cached_llm.py`

`_make_cache_key`에 `temperature`, `extra_body` 인자 추가. 해시 입력에 포함하여
Langfuse `config.thinking.type` 토글 또는 env `LLM_KIMI_THINKING` on/off 전환 시
같은 prompt+model이 다른 캐시 키로 분리되도록.

- 이전 구현(`f\"{model}:{prompt}\"`)은 thinking 토글 후 TTL(24h) 만료까지 stale 결과 서빙.
- Separator를 `:` → `|`로 교체 → 이전 배포의 orphan 키와 우연 충돌 방지.
- `run`, `run_for_job`, `run_with_prompt_config` 3개 caller 전부 새 인자 패스스루.

## Fix #2 (HIGH) — `code_synthesis_analysis` 누락 보완

**파일**: `backend/app/services/llm_config.py`

3-Stage 코드 분석에서 Stage 3 (synthesis)는 사용자 정책상 reasoning ON이어야
하는데 `THINKING_ENABLED_PROMPTS` 세트에 없어 OFF로 동작 중이었음.
Stage 1 (`code_overview_analysis`), Stage 2 (`code_deep_analysis_*`)는 정책대로 OFF 유지.

## Fix #3 (MEDIUM) — Kimi 강제 temperature override 로깅

**파일**: `backend/app/services/cached_llm.py:_build_kimi_thinking_args`

Langfuse가 설정한 `base_temperature` (예: 0.3)가 Kimi 제약(thinking ON → 1.0,
OFF → 0.6) 때문에 묵시적으로 덮어써질 때 `INFO` 로그 한 줄.
0.0/1.0/0.6은 default거나 이미 일치하는 값이므로 제외 (노이즈 최소화).

## Fix #4 (MEDIUM) — 잘못된 Langfuse `config.thinking` 형식 가드

**파일**: `backend/app/prompts/CLAUDE.md`, `backend/app/services/llm_config.py`

- **문서**: 허용 형식(`{type: enabled|disabled}`)과 fallback 동작을 prompts CLAUDE.md에 명시.
- **경고**: `resolve_kimi_thinking`에서 `thinking` 키가 잘못된 형식
  (`{\"thinking\": True}`, `{\"thinking\": \"yes\"}`, `{\"thinking\": {\"enabled\": True}}` 등)
  일 때 정책으로 fallthrough하면서 프로세스당 프롬프트별 1회 `WARNING`.
  Module-level `_WARNED_MALFORMED_THINKING` set으로 dedup.

## Test plan

- [x] `tests/test_kimi_thinking.py`에 18개 신규 테스트 추가
  - `TestCodeSynthesisThinking` (4): synthesis ON, overview/deep OFF
  - `TestMalformedLangfuseThinkingConfig` (8): malformed fallthrough, warn dedup
  - `TestCacheKeyThinkingAware` (6): thinking 토글 키 분리, separator 변경
- [x] `_reset_malformed_warn_cache` autouse fixture로 테스트 간 격리
- [x] 기존 `test_enabled_set_has_8_prompts` → `_has_9_prompts`로 카운트 갱신 (set에 1개 추가)
- [x] Docker 컨테이너 테스트: **62 passed** (test_kimi_thinking.py 36 + test_observability.py 26)
- [x] `test_cache_and_quotas.py` 20 passed (캐시키 시그니처 변경 regression 없음)

## Related

- Predecessor: #383 (Kimi K2.5 thinking 모드 기본 OFF + 정책 기반 ON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)